### PR TITLE
Fix redirect in activate user route

### DIFF
--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -50,7 +50,7 @@ def activate_user(user_id):
     user.is_active = True
     db.session.commit()
     flash('User account activated.', 'success')
-    return redirect(url_for('admin_dashboard'))  # Redirect to an admin page
+    return redirect(url_for('admin.users'))  # Redirect to the admin user list
 
 
 @admin.route('/controlpanel/users', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- ensure admin user activation redirects to user list instead of non-existent dashboard

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_685ad6c0f86883248cdfedcf789a13ca