### PR TITLE
Fix transfer blueprint redirect in login

### DIFF
--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -26,7 +26,7 @@ def login():
             return redirect(url_for('auth.login'))
 
         login_user(user)
-        return redirect(url_for('transfers.view_transfers'))
+        return redirect(url_for('transfer.view_transfers'))
 
     from run import app
 


### PR DESCRIPTION
## Summary
- fix the URL endpoint used in the login redirect so that it references
  the correct `transfer` blueprint

## Testing
- `python -m py_compile app/routes/auth_routes.py`
- *(attempted functional test, but Flask wasn't installed)*


------
https://chatgpt.com/codex/tasks/task_e_685ad6b542848324b4590b875c0f72b4