### PR TITLE
Add login test for auth blueprint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.1
 SQLAlchemy==2.0.27
 Werkzeug==2.3.0
 WTForms==3.1.2
+pytest==7.4.0

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,50 @@
+import os
+import pytest
+from flask import url_for
+from werkzeug.security import generate_password_hash
+
+from app import create_app, db
+from app.models import User
+
+
+@pytest.fixture
+def app(tmp_path):
+    os.environ.setdefault('SECRET_KEY', 'testsecret')
+    os.environ.setdefault('ADMIN_EMAIL', 'admin@example.com')
+    os.environ.setdefault('ADMIN_PASS', 'adminpass')
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    app, _ = create_app(['--demo'])
+    os.chdir(cwd)
+
+    app.config.update({'TESTING': True, 'WTF_CSRF_ENABLED': False})
+
+    with app.app_context():
+        yield app
+        db.session.remove()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_login_redirect(client, app):
+    with app.app_context():
+        user = User(
+            email='test@example.com',
+            password=generate_password_hash('password'),
+            active=True
+        )
+        db.session.add(user)
+        db.session.commit()
+        expected = url_for('transfer.view_transfers')
+
+    response = client.post('/auth/login', data={
+        'email': 'test@example.com',
+        'password': 'password'
+    })
+
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith(expected)


### PR DESCRIPTION
## Summary
- add pytest dependency
- add login redirect test using Flask test client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685afc050a288324833aa720e3412e9c