### PR TITLE
Handle missing ADMIN_PASS in admin creation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,8 +30,16 @@ def create_admin_user():
 
         # Create an admin user
         admin_email = os.getenv('ADMIN_EMAIL')
-        admin_password = generate_password_hash(os.getenv('ADMIN_PASS'))
-        admin_user = User(email=admin_email, password=admin_password, is_admin=True, active=True)
+        raw_password = os.getenv('ADMIN_PASS')
+        if raw_password is None:
+            raise RuntimeError('ADMIN_PASS environment variable not set')
+        admin_password = generate_password_hash(raw_password)
+        admin_user = User(
+            email=admin_email,
+            password=admin_password,
+            is_admin=True,
+            active=True,
+        )
 
         db.session.add(admin_user)
         db.session.commit()


### PR DESCRIPTION
## Summary
- raise a clear error if `ADMIN_PASS` is missing when creating the initial admin user

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b0bfb9bc88324b7bdcf70e0133331