### PR TITLE
Use GST from environment

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -65,6 +65,10 @@ def create_app(args: list):
     Bootstrap(app)
     socketio = SocketIO(app)
 
+    @app.context_processor
+    def inject_gst():
+        return dict(GST=GST)
+
     with app.app_context():
         from app.routes import auth_routes
         from app.routes.routes import main, location, item, transfer, customer, invoice, product, report

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -651,7 +651,7 @@ def view_invoice(invoice_id):
         gst=gst_total,
         pst=pst_total,
         total=total,
-        GST='104805510'  # Replace with your real GST number
+        GST=GST
     )
 
 @invoice.route('/get_customer_tax_status/<int:customer_id>')


### PR DESCRIPTION
## Summary
- provide GST to templates using a context processor
- replace hard-coded GST in `view_invoice` route with the configured value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1b83b278832489fd822adba6b806