### PR TITLE
Add signup password confirmation

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -23,6 +23,7 @@ from wtforms.validators import (
     Length,
     NumberRange,
     Optional,
+    EqualTo,
 )
 from wtforms.widgets import CheckboxInput, ListWidget
 
@@ -37,6 +38,10 @@ class LoginForm(FlaskForm):
 class SignupForm(FlaskForm):
     email = StringField('Email', validators=[DataRequired(), Email()])
     password = PasswordField('Password', validators=[DataRequired()])
+    confirm_password = PasswordField(
+        'Confirm Password',
+        validators=[DataRequired(), EqualTo('password', message='Passwords must match')]
+    )
     submit = SubmitField('Sign Up')
 
 

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -87,6 +87,9 @@ def users():
 def signup():
     form = SignupForm()
     if form.validate_on_submit():
+        if form.password.data != form.confirm_password.data:
+            flash('Passwords must match.', 'danger')
+            return redirect(url_for('auth.signup'))
         # Check if email already exists
         existing_user = User.query.filter_by(email=form.email.data).first()
         if existing_user:

--- a/app/templates/auth/signup.html
+++ b/app/templates/auth/signup.html
@@ -14,6 +14,10 @@
                 <label for="password">Password</label>
                 <input type="password" class="form-control" id="password" name="password" required>
             </div>
+            <div class="form-group">
+                <label for="confirm_password">Confirm Password</label>
+                <input type="password" class="form-control" id="confirm_password" name="confirm_password" required>
+            </div>
             <button type="submit" class="btn btn-success">Register</button>
         </form>
     </div>

--- a/tests/test_user_flows.py
+++ b/tests/test_user_flows.py
@@ -4,10 +4,16 @@ from app import db
 from app.models import User, Location
 
 
-def signup(client, email, password):
+def signup(client, email, password, confirm_password=None):
+    if confirm_password is None:
+        confirm_password = password
     return client.post(
         '/auth/signup',
-        data={'email': email, 'password': password},
+        data={
+            'email': email,
+            'password': password,
+            'confirm_password': confirm_password,
+        },
         follow_redirects=True,
     )
 


### PR DESCRIPTION
## Summary
- add `confirm_password` with `EqualTo` validator to `SignupForm`
- display confirmation field on signup page
- check password confirmation in signup route
- update tests for new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1b867e7c8324871d01060469338f