### PR TITLE
Implement activity logging

### DIFF
--- a/app/activity_logger.py
+++ b/app/activity_logger.py
@@ -1,0 +1,11 @@
+from flask_login import current_user
+from app.models import ActivityLog, db
+
+
+def log_activity(activity, user_id=None):
+    if user_id is None:
+        if current_user and not current_user.is_anonymous:
+            user_id = current_user.id
+    log = ActivityLog(user_id=user_id, activity=activity)
+    db.session.add(log)
+    db.session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -113,3 +113,12 @@ class InvoiceProduct(db.Model):
     # New tax override fields
     override_gst = db.Column(db.Boolean, nullable=True)  # True = apply GST, False = exempt, None = fallback to customer
     override_pst = db.Column(db.Boolean, nullable=True)  # True = apply PST, False = exempt, None = fallback to customer
+
+
+class ActivityLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    activity = db.Column(db.String(255), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    user = relationship('User', backref='activity_logs')


### PR DESCRIPTION
## Summary
- add database model for activity logs and logging helper
- log various actions in auth and main routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b294c6e248324b31fa2ac25efd1f9