### PR TITLE
Add user profile and password management

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -82,6 +82,25 @@ class UserForm(FlaskForm):
     pass
 
 
+class ChangePasswordForm(FlaskForm):
+    current_password = PasswordField('Current Password', validators=[DataRequired()])
+    new_password = PasswordField('New Password', validators=[DataRequired()])
+    confirm_password = PasswordField(
+        'Confirm Password',
+        validators=[DataRequired(), EqualTo('new_password', message='Passwords must match')]
+    )
+    submit = SubmitField('Change Password')
+
+
+class SetPasswordForm(FlaskForm):
+    new_password = PasswordField('New Password', validators=[DataRequired()])
+    confirm_password = PasswordField(
+        'Confirm Password',
+        validators=[DataRequired(), EqualTo('new_password', message='Passwords must match')]
+    )
+    submit = SubmitField('Set Password')
+
+
 class ImportItemsForm(FlaskForm):
     file = FileField('Item File', validators=[FileRequired()])
     submit = SubmitField('Import')

--- a/app/models.py
+++ b/app/models.py
@@ -18,6 +18,7 @@ class User(UserMixin, db.Model):
     password = db.Column(db.String(80), nullable=False)
     is_admin = db.Column(db.Boolean, default=False, nullable=False)
     transfers = db.relationship('Transfer', backref='creator', lazy=True)
+    invoices = db.relationship('Invoice', backref='creator', lazy=True)
     active = db.Column(db.Boolean, default=False, nullable=False)
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -81,6 +81,9 @@
             </li>
             {% endif %}
             <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('auth.profile') }}">Profile</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
             </li>
             {% endif %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>User Profile - {{ user.email }}</h2>
+<form method="post">
+    {{ form.hidden_tag() }}
+    {% if form.current_password %}
+    <div class="form-group">
+        {{ form.current_password.label(class_='form-label') }}
+        {{ form.current_password(class_='form-control') }}
+    </div>
+    {% endif %}
+    <div class="form-group">
+        {{ form.new_password.label(class_='form-label') }}
+        {{ form.new_password(class_='form-control') }}
+    </div>
+    <div class="form-group">
+        {{ form.confirm_password.label(class_='form-label') }}
+        {{ form.confirm_password(class_='form-control') }}
+    </div>
+    <button type="submit" class="btn btn-primary">{{ form.submit.label.text }}</button>
+</form>
+<hr>
+<h3>Transfers</h3>
+<ul>
+    {% for t in transfers %}
+    <li><a href="{{ url_for('transfer.view_transfer', transfer_id=t.id) }}">{{ t.id }}</a></li>
+    {% else %}
+    <li>No transfers found.</li>
+    {% endfor %}
+</ul>
+<h3>Invoices</h3>
+<ul>
+    {% for inv in invoices %}
+    <li><a href="{{ url_for('invoice.view_invoice', invoice_id=inv.id) }}">{{ inv.id }}</a></li>
+    {% else %}
+    <li>No invoices found.</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -1,0 +1,67 @@
+from werkzeug.security import generate_password_hash, check_password_hash
+import os
+
+from app import db
+from app.models import User, Location, Transfer, Customer, Product, Invoice
+from tests.test_user_flows import login
+
+
+def create_user(app, email='user@example.com'):
+    with app.app_context():
+        user = User(email=email, password=generate_password_hash('oldpass'), active=True)
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def test_user_can_change_password(client, app):
+    create_user(app, 'profile@example.com')
+    with client:
+        login(client, 'profile@example.com', 'oldpass')
+        resp = client.post('/auth/profile', data={
+            'current_password': 'oldpass',
+            'new_password': 'newpass',
+            'confirm_password': 'newpass'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    with app.app_context():
+        user = User.query.filter_by(email='profile@example.com').first()
+        assert check_password_hash(user.password, 'newpass')
+
+
+def test_admin_view_and_change_user_password(client, app):
+    user_id = create_user(app, 'target@example.com')
+    with app.app_context():
+        loc = Location(name='L')
+        db.session.add(loc)
+        db.session.commit()
+        transfer = Transfer(from_location_id=loc.id, to_location_id=loc.id, user_id=user_id)
+        cust = Customer(first_name='A', last_name='B')
+        prod = Product(name='P', price=1.0, cost=0.5)
+        db.session.add_all([transfer, cust, prod])
+        db.session.commit()
+        inv = Invoice(id='INVX', user_id=user_id, customer_id=cust.id)
+        db.session.add(inv)
+        db.session.commit()
+        transfer_id = transfer.id
+
+    admin_email = os.getenv('ADMIN_EMAIL', 'admin@example.com')
+    admin_pass = os.getenv('ADMIN_PASS', 'adminpass')
+    with client:
+        login(client, admin_email, admin_pass)
+        resp = client.get(f'/user_profile/{user_id}', follow_redirects=True)
+        assert resp.status_code == 200
+        assert b'INVX' in resp.data
+        assert str(transfer_id).encode() in resp.data
+
+        resp = client.post(f'/user_profile/{user_id}', data={
+            'new_password': 'changed',
+            'confirm_password': 'changed'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    with app.app_context():
+        updated = db.session.get(User, user_id)
+        assert check_password_hash(updated.password, 'changed')
+


### PR DESCRIPTION
## Summary
- allow users and admins to manage passwords
- show user transfers and invoices on a profile page
- expose profile route to admins for other users
- add tests for password management flows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2999781c8324a6ecdbe0620df5a2