### PR TITLE
Add admin activity log viewer

### DIFF
--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -14,7 +14,7 @@ from app.forms import (
     SetPasswordForm,
 )
 
-from app.models import User, db, Transfer, Invoice
+from app.models import User, db, Transfer, Invoice, ActivityLog
 from app.activity_logger import log_activity
 from app.backup_utils import create_backup, restore_backup
 
@@ -243,3 +243,12 @@ def download_backup(filename):
     backups_dir = current_app.config['BACKUP_FOLDER']
     log_activity(f'Downloaded backup {filename}')
     return send_from_directory(backups_dir, filename, as_attachment=True)
+
+
+@admin.route('/controlpanel/activity', methods=['GET'])
+@login_required
+def activity_logs():
+    if not current_user.is_admin:
+        abort(403)
+    logs = ActivityLog.query.order_by(ActivityLog.timestamp.desc()).all()
+    return render_template('admin/activity_logs.html', logs=logs)

--- a/app/templates/admin/activity_logs.html
+++ b/app/templates/admin/activity_logs.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Activity Logs</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Timestamp</th>
+                <th>User</th>
+                <th>Activity</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for log in logs %}
+            <tr>
+                <td>{{ log.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                <td>{{ log.user.email if log.user else 'System' }}</td>
+                <td>{{ log.activity }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -79,6 +79,9 @@
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('admin.backups') }}">Backups</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('admin.activity_logs') }}">Activity Logs</a>
+            </li>
             {% endif %}
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('auth.profile') }}">Profile</a>

--- a/tests/test_activity_logs.py
+++ b/tests/test_activity_logs.py
@@ -1,0 +1,45 @@
+import os
+from flask import url_for
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import User, ActivityLog
+from tests.test_user_flows import login
+
+
+def create_log(app):
+    with app.app_context():
+        user = User(email='log@example.com', password=generate_password_hash('pass'), active=True)
+        db.session.add(user)
+        db.session.commit()
+        log = ActivityLog(user_id=user.id, activity='Did something')
+        db.session.add(log)
+        db.session.commit()
+        return log.activity
+
+
+def test_admin_can_view_activity_logs(client, app):
+    text = create_log(app)
+    with app.app_context():
+        with app.test_request_context():
+            expected = url_for('admin.activity_logs')
+
+    admin_email = os.getenv('ADMIN_EMAIL', 'admin@example.com')
+    admin_pass = os.getenv('ADMIN_PASS', 'adminpass')
+    with client:
+        login(client, admin_email, admin_pass)
+        resp = client.get(expected, follow_redirects=True)
+        assert resp.status_code == 200
+        assert text.encode() in resp.data
+
+
+def test_non_admin_forbidden_from_activity_logs(client, app):
+    with app.app_context():
+        user = User(email='normal@example.com', password=generate_password_hash('pass'), active=True)
+        db.session.add(user)
+        db.session.commit()
+
+    with client:
+        login(client, 'normal@example.com', 'pass')
+        resp = client.get('/controlpanel/activity')
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- add Activity Logs link in the navbar for admins
- create template to render logged activities
- implement new `/controlpanel/activity` admin route
- test the new admin page and access restrictions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2db8e138832498805a5657b04098