### PR TITLE
Implement purchase orders and invoice receiving

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -90,7 +90,7 @@ def create_app(args: list):
 
     with app.app_context():
         from app.routes import auth_routes
-        from app.routes.routes import main, location, item, transfer, customer, invoice, product, report
+        from app.routes.routes import main, location, item, transfer, customer, invoice, product, report, purchase
         from app.routes.auth_routes import auth, admin
         from app.models import User
 
@@ -103,6 +103,7 @@ def create_app(args: list):
         app.register_blueprint(customer)
         app.register_blueprint(invoice)
         app.register_blueprint(product)
+        app.register_blueprint(purchase)
         app.register_blueprint(report)
 
         db.create_all()

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,6 +56,9 @@
                 <a class="nav-link" href="{{ url_for('product.view_products') }}">Products</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('purchase.view_purchase_orders') }}">Purchase Orders</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('customer.view_customers') }}">Customers</a>
             </li>
             <li class="nav-item">

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Create Purchase Order</h2>
+    <form method="POST">
+        {{ form.hidden_tag() }}
+        <div class="form-group">
+            {{ form.vendor.label(class="form-label") }}
+            {{ form.vendor(class="form-control") }}
+        </div>
+        <div class="form-group">
+            {{ form.order_date.label(class="form-label") }}
+            {{ form.order_date(class="form-control") }}
+        </div>
+        <div class="form-group">
+            {{ form.expected_date.label(class="form-label") }}
+            {{ form.expected_date(class="form-control") }}
+        </div>
+        <div class="form-group">
+            {{ form.delivery_charge.label(class="form-label") }}
+            {{ form.delivery_charge(class="form-control") }}
+        </div>
+        <h4>Items</h4>
+        {% for item in form.items %}
+        <div class="form-row">
+            <div class="col">{{ item.product(class="form-control") }}</div>
+            <div class="col">{{ item.quantity(class="form-control") }}</div>
+        </div>
+        {% endfor %}
+        <button type="submit" class="btn btn-primary mt-3">Submit</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Receive Invoice for PO {{ po.id }}</h2>
+    <form method="POST">
+        {{ form.hidden_tag() }}
+        <div class="form-group">
+            {{ form.received_date.label(class="form-label") }}
+            {{ form.received_date(class="form-control") }}
+        </div>
+        <div class="form-group">
+            {{ form.gst.label(class="form-label") }}
+            {{ form.gst(class="form-control") }}
+        </div>
+        <div class="form-group">
+            {{ form.pst.label(class="form-label") }}
+            {{ form.pst(class="form-control") }}
+        </div>
+        <div class="form-group">
+            {{ form.delivery_charge.label(class="form-label") }}
+            {{ form.delivery_charge(class="form-control") }}
+        </div>
+        <h4>Items</h4>
+        {% for item in form.items %}
+        <div class="form-row">
+            <div class="col">{{ item.product(class="form-control") }}</div>
+            <div class="col">{{ item.quantity(class="form-control") }}</div>
+            <div class="col">{{ item.cost(class="form-control") }}</div>
+        </div>
+        {% endfor %}
+        <button type="submit" class="btn btn-primary mt-3">Submit</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Purchase Orders</h2>
+    <a href="{{ url_for('purchase.create_purchase_order') }}" class="btn btn-primary mb-3">Create Purchase Order</a>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Vendor</th>
+                <th>Order Date</th>
+                <th>Expected Date</th>
+                <th>Delivery</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for order in orders %}
+            <tr>
+                <td>{{ order.id }}</td>
+                <td>{{ order.vendor.first_name }} {{ order.vendor.last_name }}</td>
+                <td>{{ order.order_date }}</td>
+                <td>{{ order.expected_date }}</td>
+                <td>{{ order.delivery_charge }}</td>
+                <td>
+                    <a href="{{ url_for('purchase.receive_invoice', po_id=order.id) }}" class="btn btn-sm btn-success">Receive</a>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/tests/test_purchase_flow.py
+++ b/tests/test_purchase_flow.py
@@ -1,0 +1,52 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import User, Customer, Product, PurchaseOrder, PurchaseOrderItem
+from tests.test_user_flows import login
+
+
+def setup_purchase(app):
+    with app.app_context():
+        user = User(email='buyer@example.com', password=generate_password_hash('pass'), active=True)
+        vendor = Customer(first_name='Vend', last_name='Or')
+        product = Product(name='Part', price=5.0, cost=1.0)
+        db.session.add_all([user, vendor, product])
+        db.session.commit()
+        return user.email, vendor.id, product.id
+
+
+def test_purchase_and_receive(client, app):
+    email, vendor_id, product_id = setup_purchase(app)
+    with client:
+        login(client, email, 'pass')
+        resp = client.post('/purchase_orders/create', data={
+            'vendor': vendor_id,
+            'order_date': '2023-01-01',
+            'expected_date': '2023-01-05',
+            'delivery_charge': 2,
+            'items-0-product': product_id,
+            'items-0-quantity': 3
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    with app.app_context():
+        po = PurchaseOrder.query.first()
+        assert po is not None
+        po_id = po.id
+
+    with client:
+        login(client, email, 'pass')
+        resp = client.post(f'/purchase_orders/{po_id}/receive', data={
+            'received_date': '2023-01-04',
+            'gst': 0.25,
+            'pst': 0.35,
+            'delivery_charge': 2,
+            'items-0-product': product_id,
+            'items-0-quantity': 3,
+            'items-0-cost': 2.5
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    with app.app_context():
+        product = db.session.get(Product, product_id)
+        assert product.quantity == 3
+        assert product.cost == 2.5


### PR DESCRIPTION
## Summary
- add new models for purchase orders and receiving invoices
- update forms with PurchaseOrderForm and ReceiveInvoiceForm
- create purchase order and invoice receiving routes
- add purchase order navigation link and templates
- test purchase order and invoice receiving workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3230e71c8324af9932275098816f