### PR TITLE
Add item units of measure

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -55,14 +55,28 @@ class LocationForm(FlaskForm):
         self.products.choices = [(p.id, p.name) for p in Product.query.all()]
 
 
+class ItemUnitForm(FlaskForm):
+    name = StringField('Unit Name', validators=[DataRequired()])
+    factor = DecimalField('Factor', validators=[InputRequired()])
+    receiving_default = BooleanField('Receiving Default')
+    transfer_default = BooleanField('Transfer Default')
+
+
 class ItemForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired()])
+    base_unit = SelectField(
+        'Base Unit',
+        choices=[('ounce', 'Ounce'), ('gram', 'Gram'), ('each', 'Each'), ('millilitre', 'Millilitre')],
+        validators=[DataRequired()]
+    )
+    units = FieldList(FormField(ItemUnitForm), min_entries=1)
     submit = SubmitField('Submit')
 
 
 class TransferItemForm(FlaskForm):
     item = SelectField('Item', coerce=int)
-    quantity = IntegerField('Quantity')
+    unit = SelectField('Unit', coerce=int, validators=[Optional()], validate_choice=False)
+    quantity = DecimalField('Quantity', validators=[InputRequired()])
 
 
 class TransferForm(FlaskForm):
@@ -81,6 +95,7 @@ class TransferForm(FlaskForm):
         # This is just an example and might need adjustment
         for item_form in self.items:
             item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
+            item_form.unit.choices = []
 
 
 class UserForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -50,9 +50,26 @@ class Location(db.Model):
 class Item(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), unique=True, nullable=False)
+    base_unit = db.Column(db.String(20), nullable=False)
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     transfers = db.relationship('Transfer', secondary=transfer_items, backref=db.backref('items', lazy='dynamic'))
     recipe_items = relationship("ProductRecipeItem", back_populates="item", cascade="all, delete-orphan")
+    units = relationship("ItemUnit", back_populates="item", cascade="all, delete-orphan")
+
+
+class ItemUnit(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
+    name = db.Column(db.String(50), nullable=False)
+    factor = db.Column(db.Float, nullable=False)
+    receiving_default = db.Column(db.Boolean, default=False, nullable=False, server_default='0')
+    transfer_default = db.Column(db.Boolean, default=False, nullable=False, server_default='0')
+
+    item = relationship('Item', back_populates='units')
+
+    __table_args__ = (
+        db.UniqueConstraint('item_id', 'name', name='_item_unit_name_uc'),
+    )
 
 
 class Transfer(db.Model):
@@ -73,7 +90,7 @@ class TransferItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     transfer_id = db.Column(db.Integer, db.ForeignKey('transfer.id'), nullable=False)
     item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
-    quantity = db.Column(db.Integer, nullable=False)
+    quantity = db.Column(db.Float, nullable=False)
     item = relationship('Item', backref='transfer_items', lazy=True)
 
 class Customer(db.Model):

--- a/app/templates/items/add_item.html
+++ b/app/templates/items/add_item.html
@@ -9,6 +9,19 @@
             {{ form.name.label }}
             {{ form.name(class="form-control") }}
         </div>
+        <div class="form-group">
+            {{ form.base_unit.label }}
+            {{ form.base_unit(class="form-control") }}
+        </div>
+        <h4>Units</h4>
+        {% for unit in form.units %}
+        <div class="form-row mb-2">
+            <div class="col">{{ unit.name(class="form-control", placeholder="Name") }}</div>
+            <div class="col">{{ unit.factor(class="form-control", placeholder="Factor") }}</div>
+            <div class="col-auto">{{ unit.receiving_default() }} {{ unit.receiving_default.label }}</div>
+            <div class="col-auto">{{ unit.transfer_default() }} {{ unit.transfer_default.label }}</div>
+        </div>
+        {% endfor %}
         {{ form.submit(class="btn btn-primary") }}
     </form>
 </div>

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -8,12 +8,20 @@
         <div class="form-group">
             {{ form.name.label(class="form-label") }}
             {{ form.name(class="form-control", value=item.name) }}
-            {% if form.name.errors %}
-                {% for error in form.name.errors %}
-                    <div class="alert alert-danger">{{ error }}</div>
-                {% endfor %}
-            {% endif %}
         </div>
+        <div class="form-group">
+            {{ form.base_unit.label(class="form-label") }}
+            {{ form.base_unit(class="form-control", value=item.base_unit) }}
+        </div>
+        <h4>Units</h4>
+        {% for unit in form.units %}
+        <div class="form-row mb-2">
+            <div class="col">{{ unit.name(class="form-control") }}</div>
+            <div class="col">{{ unit.factor(class="form-control") }}</div>
+            <div class="col-auto">{{ unit.receiving_default() }} {{ unit.receiving_default.label }}</div>
+            <div class="col-auto">{{ unit.transfer_default() }} {{ unit.transfer_default.label }}</div>
+        </div>
+        {% endfor %}
         {{ form.submit(class="btn btn-success") }}
     </form>
 </div>

--- a/app/templates/transfers/add_transfer.html
+++ b/app/templates/transfers/add_transfer.html
@@ -73,20 +73,27 @@
     });
 
     function addItemToList(item) {
-        var listItem = document.createElement('div');
-        listItem.classList.add('item-container', 'd-flex', 'justify-content-between', 'align-items-center', 'mb-2');
-        listItem.innerHTML = `
-            <div style="padding-left: 15px; font-weight: bold;">${item.name}</div>
-            <div class="d-flex align-items-center">
-                <input type="hidden" name="items-${itemIndex}-item" value="${item.id}">
-                <input type="number" class="form-control quantity" name="items-${itemIndex}-quantity" placeholder="Qty" style="max-width: 120px;">
-                <button type="button" class="btn btn-danger delete-item ml-2">Delete</button>
-            </div>
-        `;
-        document.getElementById('item-list').appendChild(listItem);
-        document.getElementById('suggestions').innerHTML = '';
-        document.getElementById('item-name').value = '';
-        itemIndex++;
+        fetch(`/items/${item.id}/units`).then(r => r.json()).then(units => {
+            var options = '';
+            units.forEach(u => {
+                options += `<option value="${u.id}">${u.name}</option>`;
+            });
+            var listItem = document.createElement('div');
+            listItem.classList.add('item-container', 'd-flex', 'justify-content-between', 'align-items-center', 'mb-2');
+            listItem.innerHTML = `
+                <div style="padding-left: 15px; font-weight: bold;">${item.name}</div>
+                <div class="d-flex align-items-center">
+                    <input type="hidden" name="items-${itemIndex}-item" value="${item.id}">
+                    <select name="items-${itemIndex}-unit" class="form-control mr-2" style="max-width: 120px;">${options}</select>
+                    <input type="number" step="any" class="form-control quantity" name="items-${itemIndex}-quantity" placeholder="Qty" style="max-width: 120px;">
+                    <button type="button" class="btn btn-danger delete-item ml-2">Delete</button>
+                </div>
+            `;
+            document.getElementById('item-list').appendChild(listItem);
+            document.getElementById('suggestions').innerHTML = '';
+            document.getElementById('item-name').value = '';
+            itemIndex++;
+        });
     }
 
 

--- a/app/templates/transfers/edit_transfer.html
+++ b/app/templates/transfers/edit_transfer.html
@@ -79,17 +79,22 @@ document.addEventListener('click', function(event) {
 });
 
 function addItemToList(item, index) {
-    var listItem = document.createElement('div');
-    listItem.classList.add('item-container', 'd-flex', 'justify-content-between', 'align-items-center', 'mb-2');
-    listItem.innerHTML = `
-        <div style="padding-left: 15px; font-weight: bold;">${item.name}</div>
-        <div class="d-flex align-items-center">
-            <input type="hidden" name="items-${index}-item" value="${item.id}">
-            <input type="number" class="form-control quantity" name="items-${index}-quantity" value="${item.quantity}" placeholder="Qty" style="max-width: 120px;">
-            <button type="button" class="btn btn-danger delete-item ml-2">Delete</button>
-        </div>
-    `;
-    document.getElementById('item-list').appendChild(listItem);
+    fetch(`/items/${item.id}/units`).then(r => r.json()).then(units => {
+        var options = '';
+        units.forEach(u => { options += `<option value="${u.id}">${u.name}</option>`; });
+        var listItem = document.createElement('div');
+        listItem.classList.add('item-container', 'd-flex', 'justify-content-between', 'align-items-center', 'mb-2');
+        listItem.innerHTML = `
+            <div style="padding-left: 15px; font-weight: bold;">${item.name}</div>
+            <div class="d-flex align-items-center">
+                <input type="hidden" name="items-${index}-item" value="${item.id}">
+                <select name="items-${index}-unit" class="form-control mr-2" style="max-width: 120px;">${options}</select>
+                <input type="number" step="any" class="form-control quantity" name="items-${index}-quantity" value="${item.quantity}" placeholder="Qty" style="max-width: 120px;">
+                <button type="button" class="btn btn-danger delete-item ml-2">Delete</button>
+            </div>
+        `;
+        document.getElementById('item-list').appendChild(listItem);
+    });
 }
 
     document.getElementById('item-list').addEventListener('click', function(event) {

--- a/tests/test_product_recipe.py
+++ b/tests/test_product_recipe.py
@@ -1,6 +1,6 @@
 from werkzeug.security import generate_password_hash
 from app import db
-from app.models import User, Customer, Item, Product, ProductRecipeItem, Invoice
+from app.models import User, Customer, Item, ItemUnit, Product, ProductRecipeItem, Invoice
 from tests.test_user_flows import login
 
 
@@ -8,10 +8,17 @@ def setup_data(app):
     with app.app_context():
         user = User(email='chef@example.com', password=generate_password_hash('pass'), active=True)
         customer = Customer(first_name='Foo', last_name='Bar')
-        item1 = Item(name='Flour', quantity=100)
-        item2 = Item(name='Sugar', quantity=50)
+        item1 = Item(name='Flour', quantity=100, base_unit='gram')
+        item2 = Item(name='Sugar', quantity=50, base_unit='gram')
+        db.session.add_all([item1, item2])
+        db.session.commit()
+        db.session.add_all([
+            ItemUnit(item_id=item1.id, name='gram', factor=1, receiving_default=True, transfer_default=True),
+            ItemUnit(item_id=item2.id, name='gram', factor=1, receiving_default=True, transfer_default=True)
+        ])
+        db.session.commit()
         product = Product(name='Cake', price=5.0, cost=2.0, quantity=10)
-        db.session.add_all([user, customer, item1, item2, product])
+        db.session.add_all([user, customer, product])
         db.session.commit()
         db.session.add_all([
             ProductRecipeItem(product_id=product.id, item_id=item1.id, quantity=2, countable=True),


### PR DESCRIPTION
## Summary
- define `ItemUnit` table and track base units for items
- update transfer forms to select units and convert quantity
- display and edit units when managing items
- expose item units via API for dynamic forms
- adjust tests for new item fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3829426c832496b95ead59d073c8