### PR TITLE
Fix missing CSRF token on location deletion

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -241,3 +241,8 @@ class ReceiveInvoiceForm(FlaskForm):
         for item_form in self.items:
             item_form.product.choices = [(p.id, p.name) for p in Product.query.all()]
 
+
+class DeleteForm(FlaskForm):
+    """Simple form used for CSRF protection on delete actions."""
+    submit = SubmitField('Delete')
+

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -20,6 +20,7 @@ from app.forms import (
     InvoiceFilterForm,
     PurchaseOrderForm,
     ReceiveInvoiceForm,
+    DeleteForm,
 )
 from app.models import (
     Location,
@@ -151,7 +152,8 @@ def view_stand_sheet(location_id):
 @login_required
 def view_locations():
     locations = Location.query.all()
-    return render_template('locations/view_locations.html', locations=locations)
+    delete_form = DeleteForm()
+    return render_template('locations/view_locations.html', locations=locations, delete_form=delete_form)
 
 
 @location.route('/locations/delete/<int:location_id>', methods=['POST'])

--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -19,6 +19,7 @@
                     <a href="{{ url_for('locations.edit_location', location_id=location.id) }}" class="btn btn-info">Edit</a>
                     <a href="{{ url_for('locations.view_stand_sheet', location_id=location.id) }}" class="btn btn-secondary">Stand Sheet</a>
                     <form action="{{ url_for('locations.delete_location', location_id=location.id) }}" method="post" class="d-inline">
+                        {{ delete_form.hidden_tag() }}
                         <button type="submit" class="btn btn-danger">Delete</button>
                     </form>
                 </td>


### PR DESCRIPTION
## Summary
- create DeleteForm for CSRF-only actions
- use DeleteForm in locations list for delete buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b787fcd80832486ebc8a6fef2e978