### PR TITLE
Support multiple item units with defaults

### DIFF
--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -183,6 +183,11 @@ def view_items():
 def add_item():
     form = ItemForm()
     if form.validate_on_submit():
+        recv_count = sum(1 for uf in form.units if uf.form.name.data and uf.form.receiving_default.data)
+        trans_count = sum(1 for uf in form.units if uf.form.name.data and uf.form.transfer_default.data)
+        if recv_count > 1 or trans_count > 1:
+            flash('Only one unit can be set as receiving and transfer default.', 'error')
+            return render_template('items/add_item.html', form=form)
         item = Item(name=form.name.data, base_unit=form.base_unit.data)
         db.session.add(item)
         db.session.commit()
@@ -234,6 +239,11 @@ def edit_item(item_id):
                     'transfer_default': unit.transfer_default
                 })
     if form.validate_on_submit():
+        recv_count = sum(1 for uf in form.units if uf.form.name.data and uf.form.receiving_default.data)
+        trans_count = sum(1 for uf in form.units if uf.form.name.data and uf.form.transfer_default.data)
+        if recv_count > 1 or trans_count > 1:
+            flash('Only one unit can be set as receiving and transfer default.', 'error')
+            return render_template('items/edit_item.html', form=form, item=item)
         item.name = form.name.data
         item.base_unit = form.base_unit.data
         ItemUnit.query.filter_by(item_id=item.id).delete()

--- a/app/templates/items/add_item.html
+++ b/app/templates/items/add_item.html
@@ -14,15 +14,40 @@
             {{ form.base_unit(class="form-control") }}
         </div>
         <h4>Units</h4>
+        <div id="units-container">
         {% for unit in form.units %}
         <div class="form-row mb-2">
             <div class="col">{{ unit.form.name(class="form-control", placeholder="Name") }}</div>
             <div class="col">{{ unit.form.factor(class="form-control", placeholder="Factor") }}</div>
             <div class="col-auto">{{ unit.form.receiving_default() }} {{ unit.form.receiving_default.label }}</div>
             <div class="col-auto">{{ unit.form.transfer_default() }} {{ unit.form.transfer_default.label }}</div>
+            <button type="button" class="btn btn-danger btn-sm remove-unit ml-2">Delete</button>
         </div>
         {% endfor %}
+        </div>
+        <button type="button" class="btn btn-secondary" id="add-unit">Add Unit</button>
         {{ form.submit(class="btn btn-primary") }}
     </form>
 </div>
+<script>
+    let unitIndex = {{ form.units|length }};
+    document.getElementById('add-unit').addEventListener('click', function() {
+        const container = document.getElementById('units-container');
+        const row = document.createElement('div');
+        row.classList.add('form-row', 'mb-2');
+        row.innerHTML = `
+            <div class="col"><input type="text" name="units-${unitIndex}-name" class="form-control" placeholder="Name"></div>
+            <div class="col"><input type="number" step="any" name="units-${unitIndex}-factor" class="form-control" placeholder="Factor"></div>
+            <div class="col-auto"><input type="checkbox" name="units-${unitIndex}-receiving_default"> Receiving Default</div>
+            <div class="col-auto"><input type="checkbox" name="units-${unitIndex}-transfer_default"> Transfer Default</div>
+            <button type="button" class="btn btn-danger btn-sm remove-unit ml-2">Delete</button>`;
+        container.appendChild(row);
+        unitIndex++;
+    });
+    document.getElementById('units-container').addEventListener('click', function(e){
+        if(e.target && e.target.classList.contains('remove-unit')){
+            e.target.closest('.form-row').remove();
+        }
+    });
+</script>
 {% endblock %}

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -14,15 +14,40 @@
             {{ form.base_unit(class="form-control", value=item.base_unit) }}
         </div>
         <h4>Units</h4>
+        <div id="units-container">
         {% for unit in form.units %}
         <div class="form-row mb-2">
             <div class="col">{{ unit.form.name(class="form-control") }}</div>
             <div class="col">{{ unit.form.factor(class="form-control") }}</div>
             <div class="col-auto">{{ unit.form.receiving_default() }} {{ unit.form.receiving_default.label }}</div>
             <div class="col-auto">{{ unit.form.transfer_default() }} {{ unit.form.transfer_default.label }}</div>
+            <button type="button" class="btn btn-danger btn-sm remove-unit ml-2">Delete</button>
         </div>
         {% endfor %}
+        </div>
+        <button type="button" class="btn btn-secondary" id="add-unit">Add Unit</button>
         {{ form.submit(class="btn btn-success") }}
     </form>
 </div>
+<script>
+    let unitIndex = {{ form.units|length }};
+    document.getElementById('add-unit').addEventListener('click', function() {
+        const container = document.getElementById('units-container');
+        const row = document.createElement('div');
+        row.classList.add('form-row', 'mb-2');
+        row.innerHTML = `
+            <div class="col"><input type="text" name="units-${unitIndex}-name" class="form-control" placeholder="Name"></div>
+            <div class="col"><input type="number" step="any" name="units-${unitIndex}-factor" class="form-control" placeholder="Factor"></div>
+            <div class="col-auto"><input type="checkbox" name="units-${unitIndex}-receiving_default"> Receiving Default</div>
+            <div class="col-auto"><input type="checkbox" name="units-${unitIndex}-transfer_default"> Transfer Default</div>
+            <button type="button" class="btn btn-danger btn-sm remove-unit ml-2">Delete</button>`;
+        container.appendChild(row);
+        unitIndex++;
+    });
+    document.getElementById('units-container').addEventListener('click', function(e){
+        if(e.target && e.target.classList.contains('remove-unit')){
+            e.target.closest('.form-row').remove();
+        }
+    });
+</script>
 {% endblock %}

--- a/tests/test_multiple_units.py
+++ b/tests/test_multiple_units.py
@@ -1,0 +1,54 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import User, Item, ItemUnit
+from tests.test_user_flows import login
+
+
+def create_user(app, email='multi@example.com'):
+    with app.app_context():
+        user = User(email=email, password=generate_password_hash('pass'), active=True)
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def test_add_item_multiple_units(client, app):
+    create_user(app, 'multiuser@example.com')
+    with client:
+        login(client, 'multiuser@example.com', 'pass')
+        resp = client.post('/items/add', data={
+            'name': 'Combo',
+            'base_unit': 'each',
+            'units-0-name': 'each',
+            'units-0-factor': 1,
+            'units-0-receiving_default': 'y',
+            'units-0-transfer_default': 'y',
+            'units-1-name': 'case',
+            'units-1-factor': 12
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+    with app.app_context():
+        item = Item.query.filter_by(name='Combo').first()
+        assert item is not None
+        assert len(item.units) == 2
+        assert sum(1 for u in item.units if u.receiving_default) == 1
+        assert sum(1 for u in item.units if u.transfer_default) == 1
+
+
+def test_reject_multiple_defaults(client, app):
+    create_user(app, 'dupdefault@example.com')
+    with client:
+        login(client, 'dupdefault@example.com', 'pass')
+        resp = client.post('/items/add', data={
+            'name': 'BadItem',
+            'base_unit': 'each',
+            'units-0-name': 'each',
+            'units-0-factor': 1,
+            'units-0-receiving_default': 'y',
+            'units-1-name': 'box',
+            'units-1-factor': 6,
+            'units-1-receiving_default': 'y'
+        }, follow_redirects=True)
+        assert b'Only one unit can be set as receiving' in resp.data
+    with app.app_context():
+        assert Item.query.filter_by(name='BadItem').first() is None


### PR DESCRIPTION
## Summary
- allow multiple units per item in the add/edit item forms
- enforce only one receiving and one transfer default
- add tests covering multi-unit behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7aa676e0832483630023ec062ef2