### PR TITLE
Add cost calculation from recipe items

### DIFF
--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -616,7 +616,7 @@ def create_product():
         log_activity(f'Created product {product.name}')
         flash('Product created successfully!', 'success')
         return redirect(url_for('product.view_products'))
-    return render_template('create_product.html', form=form)
+    return render_template('create_product.html', form=form, product_id=None)
 
 
 @product.route('/products/<int:product_id>/edit', methods=['GET', 'POST'])
@@ -641,7 +641,7 @@ def edit_product(product_id):
     else:
         print(form.errors)
         print(form.cost.data)
-    return render_template('edit_product.html', form=form)
+    return render_template('edit_product.html', form=form, product_id=product.id)
 
 
 @product.route('/products/<int:product_id>/recipe', methods=['GET', 'POST'])
@@ -673,6 +673,23 @@ def edit_product_recipe(product_id):
             form.items[i].quantity.data = recipe_item.quantity
             form.items[i].countable.data = recipe_item.countable
     return render_template('edit_product_recipe.html', form=form, product=product)
+
+
+@product.route('/products/<int:product_id>/calculate_cost')
+@login_required
+def calculate_product_cost(product_id):
+    product = db.session.get(Product, product_id)
+    if product is None:
+        abort(404)
+    total = 0.0
+    for ri in product.recipe_items:
+        item_cost = getattr(ri.item, 'cost', 0.0)
+        try:
+            qty = float(ri.quantity or 0)
+        except (TypeError, ValueError):
+            qty = 0
+        total += (item_cost or 0) * qty
+    return jsonify({'cost': total})
 
 
 @product.route('/products/<int:product_id>/delete', methods=['GET'])

--- a/app/templates/create_product.html
+++ b/app/templates/create_product.html
@@ -30,7 +30,7 @@
 
         <div class="form-group">
             {{ form.cost.label(class="form-label") }}
-            {{ form.cost(class="form-control") }}
+            {{ form.cost(class="form-control", id="cost") }}
             {% if form.cost.errors %}
                 <div class="invalid-feedback">
                     {{ form.cost.errors[0] }}
@@ -38,7 +38,18 @@
             {% endif %}
         </div>
 
+        <button type="button" class="btn btn-secondary mb-2" id="calc-cost" disabled>Set Cost From Recipe</button>
+
         <button type="submit" class="btn btn-primary">Submit</button>
     </form>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const btn = document.getElementById('calc-cost');
+    if (!btn) return;
+    btn.addEventListener('click', function() {
+        alert('Product must be saved before cost can be calculated from recipe.');
+    });
+});
+</script>
 {% endblock %}

--- a/app/templates/edit_product.html
+++ b/app/templates/edit_product.html
@@ -30,7 +30,7 @@
 
         <div class="form-group">
             {{ form.cost.label(class="form-label") }}
-            {{ form.cost(class="form-control" + (" is-invalid" if form.cost.errors else "")) }}
+            {{ form.cost(class="form-control" + (" is-invalid" if form.cost.errors else ""), id="cost") }}
             {% for error in form.cost.errors %}
                 <div class="invalid-feedback d-block">
                     {{ error }}
@@ -38,7 +38,23 @@
             {% endfor %}
         </div>
 
+        <button type="button" class="btn btn-secondary mb-2" id="calc-cost" data-product-id="{{ product_id }}">Set Cost From Recipe</button>
+
         <button type="submit" class="btn btn-primary">Submit</button>
     </form>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const btn = document.getElementById('calc-cost');
+    if (!btn) return;
+    btn.addEventListener('click', function() {
+        const pid = btn.getAttribute('data-product-id');
+        if (!pid) return;
+        fetch(`/products/${pid}/calculate_cost`).then(resp => resp.json()).then(data => {
+            const costInput = document.getElementById('cost');
+            if (costInput) costInput.value = data.cost;
+        });
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a `calculate_product_cost` route
- show a button on create/edit product pages to update cost from recipe items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7ae7ea108324a0fe7d7196f22aa4