### PR TITLE
Allow editing product recipes inline

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -162,6 +162,16 @@ class ProductRecipeForm(FlaskForm):
             item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
 
 
+class ProductWithRecipeForm(ProductForm):
+    """Form used on product create/edit pages to also manage recipe items."""
+    items = FieldList(FormField(RecipeItemForm), min_entries=1)
+
+    def __init__(self, *args, **kwargs):
+        super(ProductWithRecipeForm, self).__init__(*args, **kwargs)
+        for item_form in self.items:
+            item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
+
+
 class InvoiceForm(FlaskForm):
     customer = SelectField('Customer', coerce=float, validators=[DataRequired()])
     products = HiddenField('Products JSON')

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -13,6 +13,7 @@ from app.forms import (
     DateRangeForm,
     CustomerForm,
     ProductForm,
+    ProductWithRecipeForm,
     ProductRecipeForm,
     InvoiceForm,
     SignupForm,
@@ -604,7 +605,7 @@ def view_products():
 @product.route('/products/create', methods=['GET', 'POST'])
 @login_required
 def create_product():
-    form = ProductForm()
+    form = ProductWithRecipeForm()
     if form.validate_on_submit():
         product = Product(
             name=form.name.data,
@@ -612,6 +613,21 @@ def create_product():
             cost=form.cost.data  # 👈 Save cost
         )
         db.session.add(product)
+        db.session.commit()
+
+        for item_form in form.items:
+            item_id = item_form.item.data
+            quantity = item_form.quantity.data
+            countable = item_form.countable.data
+            if item_id and quantity is not None:
+                db.session.add(
+                    ProductRecipeItem(
+                        product_id=product.id,
+                        item_id=item_id,
+                        quantity=quantity,
+                        countable=countable,
+                    )
+                )
         db.session.commit()
         log_activity(f'Created product {product.name}')
         flash('Product created successfully!', 'success')
@@ -625,11 +641,26 @@ def edit_product(product_id):
     product = db.session.get(Product, product_id)
     if product is None:
         abort(404)
-    form = ProductForm()
+    form = ProductWithRecipeForm()
     if form.validate_on_submit():
         product.name = form.name.data
         product.price = form.price.data
         product.cost = form.cost.data or 0.0  # 👈 Update cost
+
+        ProductRecipeItem.query.filter_by(product_id=product.id).delete()
+        for item_form in form.items:
+            item_id = item_form.item.data
+            quantity = item_form.quantity.data
+            countable = item_form.countable.data
+            if item_id and quantity is not None:
+                db.session.add(
+                    ProductRecipeItem(
+                        product_id=product.id,
+                        item_id=item_id,
+                        quantity=quantity,
+                        countable=countable,
+                    )
+                )
         db.session.commit()
         log_activity(f'Edited product {product.id}')
         flash('Product updated successfully!', 'success')
@@ -638,6 +669,13 @@ def edit_product(product_id):
         form.name.data = product.name
         form.price.data = product.price
         form.cost.data = product.cost or 0.0  # 👈 Pre-fill cost
+        form.items.min_entries = max(1, len(product.recipe_items))
+        for i, recipe_item in enumerate(product.recipe_items):
+            if len(form.items) <= i:
+                form.items.append_entry()
+            form.items[i].item.data = recipe_item.item_id
+            form.items[i].quantity.data = recipe_item.quantity
+            form.items[i].countable.data = recipe_item.countable
     else:
         print(form.errors)
         print(form.cost.data)

--- a/app/templates/create_product.html
+++ b/app/templates/create_product.html
@@ -38,6 +38,19 @@
             {% endif %}
         </div>
 
+        <div id="item-list">
+            {% for item in form.items %}
+            <div class="form-row mb-2">
+                <div class="col">{{ item.item(class="form-control") }}</div>
+                <div class="col">{{ item.quantity(class="form-control") }}</div>
+                <div class="col form-check">
+                    {{ item.countable(class="form-check-input") }}
+                    {{ item.countable.label(class="form-check-label") }}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+
         <button type="submit" class="btn btn-primary">Submit</button>
     </form>
 </div>

--- a/app/templates/edit_product.html
+++ b/app/templates/edit_product.html
@@ -38,6 +38,19 @@
             {% endfor %}
         </div>
 
+        <div id="item-list">
+            {% for item in form.items %}
+            <div class="form-row mb-2">
+                <div class="col">{{ item.item(class="form-control") }}</div>
+                <div class="col">{{ item.quantity(class="form-control") }}</div>
+                <div class="col form-check">
+                    {{ item.countable(class="form-check-input") }}
+                    {{ item.countable.label(class="form-check-label") }}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+
         <button type="submit" class="btn btn-primary">Submit</button>
     </form>
 </div>

--- a/tests/test_product_crud_with_recipe.py
+++ b/tests/test_product_crud_with_recipe.py
@@ -1,0 +1,73 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import User, Item, ItemUnit, Product, ProductRecipeItem
+from tests.test_user_flows import login
+
+
+def setup_user_and_items(app):
+    with app.app_context():
+        user = User(email='produser@example.com', password=generate_password_hash('pass'), active=True)
+        item1 = Item(name='Flour', base_unit='gram', quantity=100)
+        item2 = Item(name='Sugar', base_unit='gram', quantity=50)
+        db.session.add_all([item1, item2])
+        db.session.commit()
+        db.session.add_all([
+            ItemUnit(item_id=item1.id, name='gram', factor=1, receiving_default=True, transfer_default=True),
+            ItemUnit(item_id=item2.id, name='gram', factor=1, receiving_default=True, transfer_default=True)
+        ])
+        db.session.add(user)
+        db.session.commit()
+        return user.email, item1.id, item2.id
+
+
+def test_create_product_with_recipe_items(client, app):
+    email, item1_id, item2_id = setup_user_and_items(app)
+    with client:
+        login(client, email, 'pass')
+        resp = client.post('/products/create', data={
+            'name': 'Cake',
+            'price': 5,
+            'cost': 2,
+            'items-0-item': item1_id,
+            'items-0-quantity': 2,
+            'items-0-countable': 'y',
+            'items-1-item': item2_id,
+            'items-1-quantity': 1,
+            'items-1-countable': ''
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+    with app.app_context():
+        product = Product.query.filter_by(name='Cake').first()
+        assert product is not None
+        assert len(product.recipe_items) == 2
+        ids = {ri.item_id for ri in product.recipe_items}
+        assert ids == {item1_id, item2_id}
+
+
+def test_edit_product_recipe_on_edit_page(client, app):
+    email, item1_id, item2_id = setup_user_and_items(app)
+    with app.app_context():
+        product = Product(name='Bread', price=3.0, cost=1.0)
+        db.session.add(product)
+        db.session.commit()
+        db.session.add(ProductRecipeItem(product_id=product.id, item_id=item1_id, quantity=1, countable=True))
+        db.session.commit()
+        pid = product.id
+    with client:
+        login(client, email, 'pass')
+        resp = client.post(f'/products/{pid}/edit', data={
+            'name': 'Bread',
+            'price': 3.5,
+            'cost': 1.5,
+            'items-0-item': item2_id,
+            'items-0-quantity': 4,
+            'items-0-countable': ''
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+    with app.app_context():
+        product = db.session.get(Product, pid)
+        assert product.price == 3.5
+        assert len(product.recipe_items) == 1
+        ri = product.recipe_items[0]
+        assert ri.item_id == item2_id
+        assert ri.quantity == 4


### PR DESCRIPTION
## Summary
- support recipe selection on product create/edit forms
- show recipe item fields on create and edit product pages
- test creating and editing products with recipe items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7b1c6a708324a316ecb330437ed0