### PR TITLE
Display cost on item pages

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -52,6 +52,7 @@ class Item(db.Model):
     name = db.Column(db.String(100), unique=True, nullable=False)
     base_unit = db.Column(db.String(20), nullable=False)
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
+    cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     transfers = db.relationship('Transfer', secondary=transfer_items, backref=db.backref('items', lazy='dynamic'))
     recipe_items = relationship("ProductRecipeItem", back_populates="item", cascade="all, delete-orphan")
     units = relationship("ItemUnit", back_populates="item", cascade="all, delete-orphan")

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -13,6 +13,10 @@
             {{ form.base_unit.label(class="form-label") }}
             {{ form.base_unit(class="form-control", value=item.base_unit) }}
         </div>
+        <div class="form-group">
+            <label class="form-label">Cost</label>
+            <input type="text" class="form-control" value="{{ item.cost }}" readonly>
+        </div>
         <h4>Units</h4>
         <div id="units-container">
         {% for unit in form.units %}

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -19,6 +19,7 @@
                 <tr>
                     <th scope="col"><input type="checkbox" id="select-all" style="transform: scale(1.5);"></th>
                     <th scope="col">Name</th>
+                    <th scope="col">Cost</th>
                     <th scope="col">Actions</th>
                 </tr>
             </thead>
@@ -27,6 +28,7 @@
                 <tr>
                     <td><input type="checkbox" name="item_ids" value="{{ item.id }}" style="transform: scale(1.5);"></td>
                     <td>{{ item.name }}</td>
+                    <td>{{ item.cost }}</td>
                     <td>
                         <a href="{{ url_for('item.edit_item', item_id=item.id) }}" class="btn btn-secondary">Edit</a>
                     </td>


### PR DESCRIPTION
## Summary
- add a `cost` column to the `Item` model
- show item cost on the item edit page
- include item cost in the items list table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7d5d89288324b8d2b358222a8507