### PR TITLE
Update expected count logic for transfers

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -23,6 +23,7 @@ class LocationStandItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     location_id = db.Column(db.Integer, db.ForeignKey('location.id'), nullable=False)
     item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
+    expected_count = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
 
     location = relationship('Location', back_populates='stand_items')
     item = relationship('Item')


### PR DESCRIPTION
## Summary
- track expected count for items per location
- add helper to update counts on transfer complete/uncomplete/delete
- test that completing/uncompleting a transfer adjusts expected counts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b7e52cacc8324bc7a8d20af47aad4