### PR TITLE
Use items for purchase orders

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -213,7 +213,7 @@ class RestoreBackupForm(FlaskForm):
 
 
 class POItemForm(FlaskForm):
-    product = SelectField('Product', coerce=int)
+    item = SelectField('Item', coerce=int)
     quantity = DecimalField('Quantity', validators=[InputRequired()])
 
 
@@ -229,17 +229,18 @@ class PurchaseOrderForm(FlaskForm):
         super(PurchaseOrderForm, self).__init__(*args, **kwargs)
         self.vendor.choices = [(c.id, f"{c.first_name} {c.last_name}") for c in Customer.query.all()]
         for item_form in self.items:
-            item_form.product.choices = [(p.id, p.name) for p in Product.query.all()]
+            item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
 
 
 class InvoiceItemReceiveForm(FlaskForm):
-    product = SelectField('Product', coerce=int)
+    item = SelectField('Item', coerce=int)
     quantity = DecimalField('Quantity', validators=[InputRequired()])
     cost = DecimalField('Cost', validators=[InputRequired()])
 
 
 class ReceiveInvoiceForm(FlaskForm):
     received_date = DateField('Received Date', validators=[DataRequired()])
+    location_id = SelectField('Location', coerce=int, validators=[DataRequired()])
     gst = DecimalField('GST Amount', validators=[Optional()], default=0)
     pst = DecimalField('PST Amount', validators=[Optional()], default=0)
     delivery_charge = DecimalField('Delivery Charge', validators=[Optional()], default=0)
@@ -248,8 +249,9 @@ class ReceiveInvoiceForm(FlaskForm):
 
     def __init__(self, *args, **kwargs):
         super(ReceiveInvoiceForm, self).__init__(*args, **kwargs)
+        self.location_id.choices = [(l.id, l.name) for l in Location.query.all()]
         for item_form in self.items:
-            item_form.product.choices = [(p.id, p.name) for p in Product.query.all()]
+            item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
 
 
 class DeleteForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -184,20 +184,22 @@ class PurchaseOrder(db.Model):
 class PurchaseOrderItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     purchase_order_id = db.Column(db.Integer, db.ForeignKey('purchase_order.id'), nullable=False)
-    product_id = db.Column(db.Integer, db.ForeignKey('product.id'), nullable=False)
+    item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
     quantity = db.Column(db.Float, nullable=False)
-    product = relationship('Product')
+    item = relationship('Item')
 
 
 class PurchaseInvoice(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     purchase_order_id = db.Column(db.Integer, db.ForeignKey('purchase_order.id'), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    location_id = db.Column(db.Integer, db.ForeignKey('location.id'), nullable=False)
     received_date = db.Column(db.Date, nullable=False)
     gst = db.Column(db.Float, nullable=False, default=0.0)
     pst = db.Column(db.Float, nullable=False, default=0.0)
     delivery_charge = db.Column(db.Float, nullable=False, default=0.0)
     items = relationship('PurchaseInvoiceItem', backref='invoice', cascade='all, delete-orphan')
+    location = relationship('Location')
 
     @property
     def item_total(self):
@@ -211,10 +213,10 @@ class PurchaseInvoice(db.Model):
 class PurchaseInvoiceItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     invoice_id = db.Column(db.Integer, db.ForeignKey('purchase_invoice.id'), nullable=False)
-    product_id = db.Column(db.Integer, db.ForeignKey('product.id'), nullable=False)
+    item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
     quantity = db.Column(db.Float, nullable=False)
     cost = db.Column(db.Float, nullable=False)
-    product = relationship('Product')
+    item = relationship('Item')
 
 
 class ActivityLog(db.Model):

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -1241,13 +1241,13 @@ def create_purchase_order():
         db.session.add(po)
         db.session.commit()
 
-        items = [key for key in request.form.keys() if key.startswith('items-') and key.endswith('-product')]
+        items = [key for key in request.form.keys() if key.startswith('items-') and key.endswith('-item')]
         for field in items:
             index = field.split('-')[1]
-            product_id = request.form.get(f'items-{index}-product', type=int)
+            item_id = request.form.get(f'items-{index}-item', type=int)
             quantity = request.form.get(f'items-{index}-quantity', type=float)
-            if product_id and quantity:
-                db.session.add(PurchaseOrderItem(purchase_order_id=po.id, product_id=product_id, quantity=quantity))
+            if item_id and quantity:
+                db.session.add(PurchaseOrderItem(purchase_order_id=po.id, item_id=item_id, quantity=quantity))
 
         db.session.commit()
         log_activity(f'Created purchase order {po.id}')
@@ -1268,6 +1268,7 @@ def receive_invoice(po_id):
         invoice = PurchaseInvoice(
             purchase_order_id=po.id,
             user_id=current_user.id,
+            location_id=form.location_id.data,
             received_date=form.received_date.data,
             gst=form.gst.data or 0.0,
             pst=form.pst.data or 0.0,
@@ -1276,18 +1277,23 @@ def receive_invoice(po_id):
         db.session.add(invoice)
         db.session.commit()
 
-        items = [key for key in request.form.keys() if key.startswith('items-') and key.endswith('-product')]
+        items = [key for key in request.form.keys() if key.startswith('items-') and key.endswith('-item')]
         for field in items:
             index = field.split('-')[1]
-            product_id = request.form.get(f'items-{index}-product', type=int)
+            item_id = request.form.get(f'items-{index}-item', type=int)
             quantity = request.form.get(f'items-{index}-quantity', type=float)
             cost = request.form.get(f'items-{index}-cost', type=float)
-            if product_id and quantity is not None and cost is not None:
-                db.session.add(PurchaseInvoiceItem(invoice_id=invoice.id, product_id=product_id, quantity=quantity, cost=cost))
-                product = db.session.get(Product, product_id)
-                if product:
-                    product.quantity = (product.quantity or 0) + quantity
-                    product.cost = cost
+            if item_id and quantity is not None and cost is not None:
+                db.session.add(PurchaseInvoiceItem(invoice_id=invoice.id, item_id=item_id, quantity=quantity, cost=cost))
+                item_obj = db.session.get(Item, item_id)
+                if item_obj:
+                    item_obj.quantity = (item_obj.quantity or 0) + quantity
+                    item_obj.cost = cost
+                    record = LocationStandItem.query.filter_by(location_id=invoice.location_id, item_id=item_id).first()
+                    if not record:
+                        record = LocationStandItem(location_id=invoice.location_id, item_id=item_id, expected_count=0)
+                        db.session.add(record)
+                    record.expected_count += quantity
 
         db.session.commit()
         log_activity(f'Received invoice {invoice.id} for PO {po.id}')

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -24,7 +24,7 @@
         <div id="items">
         {% for item in form.items %}
         <div class="form-row mt-2">
-            <div class="col">{{ item.product(class="form-control") }}</div>
+            <div class="col">{{ item.item(class="form-control") }}</div>
             <div class="col">{{ item.quantity(class="form-control") }}</div>
             <div class="col-auto">
                 {% if loop.index0 > 0 %}
@@ -40,14 +40,14 @@
 </div>
 
 <script>
-    const productOptions = `{% for val, label in form.items[0].product.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
+    const productOptions = `{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
     document.getElementById('add-item').addEventListener('click', function(e) {
         e.preventDefault();
         const row = document.createElement('div');
         row.classList.add('form-row','mt-2');
         row.innerHTML = `
-            <div class="col"><select name="items-${itemIndex}-product" class="form-control">${productOptions}</select></div>
+            <div class="col"><select name="items-${itemIndex}-item" class="form-control">${productOptions}</select></div>
             <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
             <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
         `;

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -13,6 +13,10 @@
             {{ form.gst(class="form-control") }}
         </div>
         <div class="form-group">
+            {{ form.location_id.label(class="form-label") }}
+            {{ form.location_id(class="form-control") }}
+        </div>
+        <div class="form-group">
             {{ form.pst.label(class="form-label") }}
             {{ form.pst(class="form-control") }}
         </div>
@@ -23,7 +27,7 @@
         <h4>Items</h4>
         {% for item in form.items %}
         <div class="form-row">
-            <div class="col">{{ item.product(class="form-control") }}</div>
+            <div class="col">{{ item.item(class="form-control") }}</div>
             <div class="col">{{ item.quantity(class="form-control") }}</div>
             <div class="col">{{ item.cost(class="form-control") }}</div>
         </div>

--- a/tests/test_purchase_flow.py
+++ b/tests/test_purchase_flow.py
@@ -1,6 +1,6 @@
 from werkzeug.security import generate_password_hash
 from app import db
-from app.models import User, Customer, Product, PurchaseOrder, PurchaseOrderItem
+from app.models import User, Customer, Item, ItemUnit, Location, PurchaseOrder, PurchaseOrderItem, PurchaseInvoice, LocationStandItem
 from tests.test_user_flows import login
 
 
@@ -8,14 +8,19 @@ def setup_purchase(app):
     with app.app_context():
         user = User(email='buyer@example.com', password=generate_password_hash('pass'), active=True)
         vendor = Customer(first_name='Vend', last_name='Or')
-        product = Product(name='Part', price=5.0, cost=1.0)
-        db.session.add_all([user, vendor, product])
+        item = Item(name='Part', base_unit='each')
+        unit = ItemUnit(item=item, name='each', factor=1, receiving_default=True, transfer_default=True)
+        location = Location(name='Main')
+        db.session.add_all([user, vendor, item, unit, location])
         db.session.commit()
-        return user.email, vendor.id, product.id
+        lsi = LocationStandItem(location_id=location.id, item_id=item.id, expected_count=0)
+        db.session.add(lsi)
+        db.session.commit()
+        return user.email, vendor.id, item.id, location.id
 
 
 def test_purchase_and_receive(client, app):
-    email, vendor_id, product_id = setup_purchase(app)
+    email, vendor_id, item_id, location_id = setup_purchase(app)
     with client:
         login(client, email, 'pass')
         resp = client.post('/purchase_orders/create', data={
@@ -23,7 +28,7 @@ def test_purchase_and_receive(client, app):
             'order_date': '2023-01-01',
             'expected_date': '2023-01-05',
             'delivery_charge': 2,
-            'items-0-product': product_id,
+            'items-0-item': item_id,
             'items-0-quantity': 3
         }, follow_redirects=True)
         assert resp.status_code == 200
@@ -40,29 +45,40 @@ def test_purchase_and_receive(client, app):
             'gst': 0.25,
             'pst': 0.35,
             'delivery_charge': 2,
-            'items-0-product': product_id,
+            'location_id': location_id,
+            'items-0-item': item_id,
             'items-0-quantity': 3,
             'items-0-cost': 2.5
         }, follow_redirects=True)
         assert resp.status_code == 200
 
     with app.app_context():
-        product = db.session.get(Product, product_id)
-        assert product.quantity == 3
-        assert product.cost == 2.5
+        item = db.session.get(Item, item_id)
+        assert item.quantity == 3
+        assert item.cost == 2.5
+        lsi = LocationStandItem.query.filter_by(location_id=location_id, item_id=item_id).first()
+        assert lsi.expected_count == 3
 
 
 def test_purchase_order_multiple_items(client, app):
     with app.app_context():
         user = User(email='multi@example.com', password=generate_password_hash('pass'), active=True)
         vendor = Customer(first_name='Multi', last_name='Vendor')
-        product1 = Product(name='PartA', price=1.0, cost=0.5)
-        product2 = Product(name='PartB', price=2.0, cost=0.8)
-        db.session.add_all([user, vendor, product1, product2])
+        item1 = Item(name='PartA', base_unit='each')
+        item2 = Item(name='PartB', base_unit='each')
+        loc = Location(name='Main')
+        db.session.add_all([user, vendor, item1, item2, loc])
+        db.session.commit()
+        db.session.add_all([
+            ItemUnit(item_id=item1.id, name='each', factor=1, receiving_default=True, transfer_default=True),
+            ItemUnit(item_id=item2.id, name='each', factor=1, receiving_default=True, transfer_default=True),
+            LocationStandItem(location_id=loc.id, item_id=item1.id, expected_count=0),
+            LocationStandItem(location_id=loc.id, item_id=item2.id, expected_count=0),
+        ])
         db.session.commit()
         vendor_id = vendor.id
-        prod1_id = product1.id
-        prod2_id = product2.id
+        item1_id = item1.id
+        item2_id = item2.id
 
     with client:
         login(client, 'multi@example.com', 'pass')
@@ -70,9 +86,9 @@ def test_purchase_order_multiple_items(client, app):
             'vendor': vendor_id,
             'order_date': '2023-02-01',
             'expected_date': '2023-02-05',
-            'items-0-product': prod1_id,
+            'items-0-item': item1_id,
             'items-0-quantity': 4,
-            'items-1-product': prod2_id,
+            'items-1-item': item2_id,
             'items-1-quantity': 6
         }, follow_redirects=True)
         assert resp.status_code == 200
@@ -81,5 +97,5 @@ def test_purchase_order_multiple_items(client, app):
         po = PurchaseOrder.query.order_by(PurchaseOrder.id.desc()).first()
         assert po.vendor_id == vendor_id
         assert len(po.items) == 2
-        ids = {i.product_id for i in po.items}
-        assert ids == {prod1_id, prod2_id}
+        ids = {i.item_id for i in po.items}
+        assert ids == {item1_id, item2_id}


### PR DESCRIPTION
## Summary
- make purchase orders and invoices work with items instead of products
- track the location when receiving a purchase invoice
- update item and location inventories when an invoice is received
- update tests for new purchase flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b81b5998c8324b76568b8224b123c