### PR TITLE
Add unit selection to purchase orders

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -27,7 +27,7 @@ from wtforms.validators import (
 )
 from wtforms.widgets import CheckboxInput, ListWidget
 
-from app.models import Item, Location, Product, Customer
+from app.models import Item, Location, Product, Customer, ItemUnit
 
 
 class LoginForm(FlaskForm):
@@ -214,6 +214,7 @@ class RestoreBackupForm(FlaskForm):
 
 class POItemForm(FlaskForm):
     product = SelectField('Product', coerce=int)
+    unit = SelectField('Unit', coerce=int, validators=[Optional()], validate_choice=False)
     quantity = DecimalField('Quantity', validators=[InputRequired()])
 
 
@@ -230,6 +231,7 @@ class PurchaseOrderForm(FlaskForm):
         self.vendor.choices = [(c.id, f"{c.first_name} {c.last_name}") for c in Customer.query.all()]
         for item_form in self.items:
             item_form.product.choices = [(p.id, p.name) for p in Product.query.all()]
+            item_form.unit.choices = [(u.id, u.name) for u in ItemUnit.query.all()]
 
 
 class InvoiceItemReceiveForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -185,8 +185,10 @@ class PurchaseOrderItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     purchase_order_id = db.Column(db.Integer, db.ForeignKey('purchase_order.id'), nullable=False)
     product_id = db.Column(db.Integer, db.ForeignKey('product.id'), nullable=False)
+    unit_id = db.Column(db.Integer, db.ForeignKey('item_unit.id'), nullable=True)
     quantity = db.Column(db.Float, nullable=False)
     product = relationship('Product')
+    unit = relationship('ItemUnit')
 
 
 class PurchaseInvoice(db.Model):

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -1245,9 +1245,10 @@ def create_purchase_order():
         for field in items:
             index = field.split('-')[1]
             product_id = request.form.get(f'items-{index}-product', type=int)
+            unit_id = request.form.get(f'items-{index}-unit', type=int)
             quantity = request.form.get(f'items-{index}-quantity', type=float)
             if product_id and quantity:
-                db.session.add(PurchaseOrderItem(purchase_order_id=po.id, product_id=product_id, quantity=quantity))
+                db.session.add(PurchaseOrderItem(purchase_order_id=po.id, product_id=product_id, unit_id=unit_id, quantity=quantity))
 
         db.session.commit()
         log_activity(f'Created purchase order {po.id}')
@@ -1255,6 +1256,51 @@ def create_purchase_order():
         return redirect(url_for('purchase.view_purchase_orders'))
 
     return render_template('purchase_orders/create_purchase_order.html', form=form)
+
+
+@purchase.route('/purchase_orders/edit/<int:po_id>', methods=['GET', 'POST'])
+@login_required
+def edit_purchase_order(po_id):
+    po = db.session.get(PurchaseOrder, po_id)
+    if po is None:
+        abort(404)
+    form = PurchaseOrderForm()
+    if form.validate_on_submit():
+        po.vendor_id = form.vendor.data
+        po.order_date = form.order_date.data
+        po.expected_date = form.expected_date.data
+        po.delivery_charge = form.delivery_charge.data or 0.0
+
+        PurchaseOrderItem.query.filter_by(purchase_order_id=po.id).delete()
+
+        items = [key for key in request.form.keys() if key.startswith('items-') and key.endswith('-product')]
+        for field in items:
+            index = field.split('-')[1]
+            product_id = request.form.get(f'items-{index}-product', type=int)
+            unit_id = request.form.get(f'items-{index}-unit', type=int)
+            quantity = request.form.get(f'items-{index}-quantity', type=float)
+            if product_id and quantity:
+                db.session.add(PurchaseOrderItem(purchase_order_id=po.id, product_id=product_id, unit_id=unit_id, quantity=quantity))
+
+        db.session.commit()
+        log_activity(f'Edited purchase order {po.id}')
+        flash('Purchase order updated successfully!', 'success')
+        return redirect(url_for('purchase.view_purchase_orders'))
+
+    if request.method == 'GET':
+        form.vendor.data = po.vendor_id
+        form.order_date.data = po.order_date
+        form.expected_date.data = po.expected_date
+        form.delivery_charge.data = po.delivery_charge
+        form.items.min_entries = max(1, len(po.items))
+        for i, poi in enumerate(po.items):
+            if len(form.items) <= i:
+                form.items.append_entry()
+            form.items[i].product.data = poi.product_id
+            form.items[i].unit.data = poi.unit_id
+            form.items[i].quantity.data = poi.quantity
+
+    return render_template('purchase_orders/edit_purchase_order.html', form=form, po=po)
 
 
 @purchase.route('/purchase_orders/<int:po_id>/receive', methods=['GET', 'POST'])

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="container mt-4">
-    <h2>Create Purchase Order</h2>
+    <h2>Edit Purchase Order</h2>
     <form method="POST">
         {{ form.hidden_tag() }}
         <div class="form-group">

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -23,6 +23,7 @@
                 <td>{{ order.expected_date }}</td>
                 <td>{{ order.delivery_charge }}</td>
                 <td>
+                    <a href="{{ url_for('purchase.edit_purchase_order', po_id=order.id) }}" class="btn btn-sm btn-primary">Edit</a>
                     <a href="{{ url_for('purchase.receive_invoice', po_id=order.id) }}" class="btn btn-sm btn-success">Receive</a>
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
- let purchase orders capture a unit for each item
- show unit dropdown and allow editing purchase orders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b82acad8883248153669df9b9c5f7