### PR TITLE
Fix PO form item field

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -213,8 +213,7 @@ class RestoreBackupForm(FlaskForm):
 
 
 class POItemForm(FlaskForm):
-    product = SelectField('Product', coerce=int)
-    unit = SelectField('Unit', coerce=int, validators=[Optional()], validate_choice=False)
+    item = SelectField('Item', coerce=int)
     quantity = DecimalField('Quantity', validators=[InputRequired()])
 
 
@@ -230,8 +229,7 @@ class PurchaseOrderForm(FlaskForm):
         super(PurchaseOrderForm, self).__init__(*args, **kwargs)
         self.vendor.choices = [(c.id, f"{c.first_name} {c.last_name}") for c in Customer.query.all()]
         for item_form in self.items:
-            item_form.product.choices = [(p.id, p.name) for p in Product.query.all()]
-            item_form.unit.choices = [(u.id, u.name) for u in ItemUnit.query.all()]
+            item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
 
 
 class InvoiceItemReceiveForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -184,13 +184,12 @@ class PurchaseOrder(db.Model):
 class PurchaseOrderItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     purchase_order_id = db.Column(db.Integer, db.ForeignKey('purchase_order.id'), nullable=False)
-    product_id = db.Column(db.Integer, db.ForeignKey('product.id'), nullable=False)
+    product_id = db.Column(db.Integer, db.ForeignKey('product.id'), nullable=True)
     unit_id = db.Column(db.Integer, db.ForeignKey('item_unit.id'), nullable=True)
+    item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
     quantity = db.Column(db.Float, nullable=False)
     product = relationship('Product')
     unit = relationship('ItemUnit')
-    item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
-    quantity = db.Column(db.Float, nullable=False)
     item = relationship('Item')
 
 

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -1244,12 +1244,6 @@ def create_purchase_order():
         items = [key for key in request.form.keys() if key.startswith('items-') and key.endswith('-item')]
         for field in items:
             index = field.split('-')[1]
-            product_id = request.form.get(f'items-{index}-product', type=int)
-            unit_id = request.form.get(f'items-{index}-unit', type=int)
-            quantity = request.form.get(f'items-{index}-quantity', type=float)
-            if product_id and quantity:
-                db.session.add(PurchaseOrderItem(purchase_order_id=po.id, product_id=product_id, unit_id=unit_id, quantity=quantity))
-
             item_id = request.form.get(f'items-{index}-item', type=int)
             quantity = request.form.get(f'items-{index}-quantity', type=float)
             if item_id and quantity:


### PR DESCRIPTION
## Summary
- restore POItemForm item field instead of product/unit
- handle purchase order creation with just item and quantity
- allow product_id to be optional in PurchaseOrderItem model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b872fefd4832496430935d59ac914