### PR TITLE
Fix purchase order form options

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -234,6 +234,8 @@ class PurchaseOrderForm(FlaskForm):
         self.vendor.choices = [(c.id, f"{c.first_name} {c.last_name}") for c in Customer.query.all()]
         for item_form in self.items:
             item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
+            item_form.product.choices = [(p.id, p.name) for p in Product.query.all()]
+            item_form.unit.choices = [(u.id, u.name) for u in ItemUnit.query.all()]
 
 
 class InvoiceItemReceiveForm(FlaskForm):

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -44,7 +44,7 @@
 <script>
     const productOptions = `{% for val, label in form.items[0].product.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     const unitOptions = `{% for val, label in form.items[0].unit.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
-    const productOptions = `{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
+    const itemOptions = `{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
     document.getElementById('add-item').addEventListener('click', function(e) {
         e.preventDefault();
@@ -53,7 +53,7 @@
         row.innerHTML = `
             <div class="col"><select name="items-${itemIndex}-product" class="form-control">${productOptions}</select></div>
             <div class="col"><select name="items-${itemIndex}-unit" class="form-control">${unitOptions}</select></div>
-            <div class="col"><select name="items-${itemIndex}-item" class="form-control">${productOptions}</select></div>
+            <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
             <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
             <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
         `;


### PR DESCRIPTION
## Summary
- populate product and unit choices for purchase order form items
- fix variable names in JS template for creating purchase orders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c78f9d3cc83249874fae4b8cd394f