### PR TITLE
Prefill delivery charge on invoice receipt

### DIFF
--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -1327,6 +1327,8 @@ def receive_invoice(po_id):
     if po is None:
         abort(404)
     form = ReceiveInvoiceForm()
+    if request.method == 'GET':
+        form.delivery_charge.data = po.delivery_charge
     if form.validate_on_submit():
         invoice = PurchaseInvoice(
             purchase_order_id=po.id,


### PR DESCRIPTION
## Summary
- auto-fill purchase order delivery charge when receiving invoice
- test that delivery charge defaults on the receive page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7e5a82848324a9795111af358065