### PR TITLE
Fix invoice receive and PO edit flows

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -148,7 +148,7 @@ class ProductForm(FlaskForm):
 
 class RecipeItemForm(FlaskForm):
     item = SelectField('Item', coerce=int)
-    quantity = DecimalField('Quantity', validators=[InputRequired()])
+    quantity = IntegerField('Quantity', validators=[InputRequired()])
     countable = BooleanField('Countable')
 
 
@@ -242,6 +242,7 @@ class InvoiceItemReceiveForm(FlaskForm):
     item = SelectField('Item', coerce=int)
     quantity = DecimalField('Quantity', validators=[InputRequired()])
     cost = DecimalField('Cost', validators=[InputRequired()])
+    return_item = BooleanField('Return')
 
 
 class ReceiveInvoiceForm(FlaskForm):

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -23,9 +23,9 @@
         <h4>Items</h4>
         <div id="items">
         {% for item in form.items %}
-        <div class="form-row mt-2">
-            <div class="col">{{ item.product(class="form-control") }}</div>
-            <div class="col">{{ item.unit(class="form-control") }}</div>
+        <div class="form-row mt-2 item-row">
+            <div class="col">{{ item.item(class="form-control item-select") }}</div>
+            <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
             <div class="col">{{ item.quantity(class="form-control") }}</div>
             <div class="col-auto">
                 {% if loop.index0 > 0 %}
@@ -41,19 +41,40 @@
 </div>
 
 <script>
-    const productOptions = `{% for val, label in form.items[0].product.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
-    const unitOptions = `{% for val, label in form.items[0].unit.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
+    const itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
-    document.getElementById('add-item').addEventListener('click', function(e) {
-        e.preventDefault();
+
+    function createRow(index) {
         const row = document.createElement('div');
-        row.classList.add('form-row','mt-2');
+        row.classList.add('form-row','mt-2','item-row');
         row.innerHTML = `
-            <div class="col"><select name="items-${itemIndex}-product" class="form-control">${productOptions}</select></div>
-            <div class="col"><select name="items-${itemIndex}-unit" class="form-control">${unitOptions}</select></div>
-            <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
+            <div class="col"><select name="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
+            <div class="col"><select name="items-${index}-unit" class="form-control unit-select"></select></div>
+            <div class="col"><input type="number" step="any" name="items-${index}-quantity" class="form-control"></div>
             <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
         `;
+        return row;
+    }
+
+    function fetchUnits(selectEl) {
+        const itemId = selectEl.value;
+        const unitSelect = selectEl.closest('.item-row').querySelector('.unit-select');
+        if (!itemId) {
+            unitSelect.innerHTML = '';
+            return;
+        }
+        fetch(`/items/${itemId}/units`).then(r => r.json()).then(units => {
+            let opts = '';
+            units.forEach(u => {
+                opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name}</option>`;
+            });
+            unitSelect.innerHTML = opts;
+        });
+    }
+
+    document.getElementById('add-item').addEventListener('click', function(e) {
+        e.preventDefault();
+        const row = createRow(itemIndex);
         document.getElementById('items').appendChild(row);
         itemIndex++;
     });
@@ -63,6 +84,14 @@
             e.target.closest('.form-row').remove();
         }
     });
+
+    document.getElementById('items').addEventListener('change', function(e) {
+        if (e.target && e.target.classList.contains('item-select')) {
+            fetchUnits(e.target);
+        }
+    });
+
+    document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
 </script>
 </div>
 {% endblock %}

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -25,14 +25,41 @@
             {{ form.delivery_charge(class="form-control") }}
         </div>
         <h4>Items</h4>
+        <div id="items">
         {% for item in form.items %}
-        <div class="form-row">
-            <div class="col">{{ item.item(class="form-control") }}</div>
-            <div class="col">{{ item.quantity(class="form-control") }}</div>
-            <div class="col">{{ item.cost(class="form-control") }}</div>
+        <div class="form-row item-row mb-2 align-items-center">
+            <div class="col">{{ item.item(class="form-control", disabled=True) }}<input type="hidden" name="{{ item.item.name }}" value="{{ item.item.data }}"></div>
+            <div class="col mt-2">{{ po.items[loop.index0].unit.name }}</div>
+            <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
+            <div class="col">{{ item.cost(class="form-control cost") }}</div>
+            <div class="col form-check">{{ item.return_item(class="form-check-input return-item") }} {{ item.return_item.label(class="form-check-label") }}</div>
         </div>
         {% endfor %}
+        </div>
+        <div class="form-group mt-3">
+            <label>Total: $<span id="item-total">0.00</span></label>
+        </div>
         <button type="submit" class="btn btn-primary mt-3">Submit</button>
     </form>
 </div>
+<script>
+function updateTotal() {
+    let total = 0;
+    document.querySelectorAll('#items .item-row').forEach(row => {
+        const qty = parseFloat(row.querySelector('.quantity').value) || 0;
+        let price = parseFloat(row.querySelector('.cost').value) || 0;
+        if (row.querySelector('.return-item').checked) {
+            price = -price;
+        }
+        total += qty * price;
+    });
+    document.getElementById('item-total').textContent = total.toFixed(2);
+}
+
+document.querySelectorAll('.quantity, .cost, .return-item').forEach(el => {
+    el.addEventListener('input', updateTotal);
+    el.addEventListener('change', updateTotal);
+});
+updateTotal();
+</script>
 {% endblock %}

--- a/tests/test_product_crud_with_recipe.py
+++ b/tests/test_product_crud_with_recipe.py
@@ -71,3 +71,22 @@ def test_edit_product_recipe_on_edit_page(client, app):
         ri = product.recipe_items[0]
         assert ri.item_id == item2_id
         assert ri.quantity == 4
+
+
+def test_recipe_accepts_integer_quantity(client, app):
+    email, item1_id, _ = setup_user_and_items(app)
+    with client:
+        login(client, email, 'pass')
+        resp = client.post('/products/create', data={
+            'name': 'Pie',
+            'price': 4,
+            'cost': 2,
+            'items-0-item': item1_id,
+            'items-0-quantity': 0,
+            'items-0-countable': 'y'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+    with app.app_context():
+        prod = Product.query.filter_by(name='Pie').first()
+        assert prod is not None
+        assert prod.recipe_items[0].quantity == 0


### PR DESCRIPTION
## Summary
- prefill items when receiving invoices and support returns
- fix editing of purchase orders to save changes
- allow integer recipe quantities
- update invoice and purchase order templates
- add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c7fc8d5748324a3c930b6fe75837e