### PR TITLE
Fix run.py import and newline

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,5 +1,4 @@
 import sys
-from flask_socketio import SocketIO
 from app import create_app
 
 app, socketio = create_app(sys.argv)


### PR DESCRIPTION
## Summary
- remove unused SocketIO import
- ensure newline at end of run.py

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8209f0b08324ba1d3d38f2f4c4dd