### PR TITLE
Implement purchase invoice management

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -177,6 +177,7 @@ class PurchaseOrder(db.Model):
     order_date = db.Column(db.Date, nullable=False)
     expected_date = db.Column(db.Date, nullable=False)
     delivery_charge = db.Column(db.Float, nullable=False, default=0.0)
+    received = db.Column(db.Boolean, default=False, nullable=False)
     items = relationship('PurchaseOrderItem', backref='purchase_order', cascade='all, delete-orphan')
     vendor = relationship('Customer')
 
@@ -204,6 +205,7 @@ class PurchaseInvoice(db.Model):
     delivery_charge = db.Column(db.Float, nullable=False, default=0.0)
     items = relationship('PurchaseInvoiceItem', backref='invoice', cascade='all, delete-orphan')
     location = relationship('Location')
+    purchase_order = relationship('PurchaseOrder')
 
     @property
     def item_total(self):

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -59,6 +59,9 @@
                 <a class="nav-link" href="{{ url_for('purchase.view_purchase_orders') }}">Purchase Orders</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('purchase.view_purchase_invoices') }}">Purchase Invoices</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('customer.view_customers') }}">Customers</a>
             </li>
             <li class="nav-item">

--- a/app/templates/purchase_invoices/view_purchase_invoice.html
+++ b/app/templates/purchase_invoices/view_purchase_invoice.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Invoice {{ invoice.id }}</h2>
+    <p>Purchase Order: {{ invoice.purchase_order_id }}</p>
+    <p>Vendor: {{ invoice.purchase_order.vendor.first_name }} {{ invoice.purchase_order.vendor.last_name }}</p>
+    <p>Received: {{ invoice.received_date }}</p>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Item</th>
+                <th>Unit</th>
+                <th>Qty</th>
+                <th>Cost</th>
+                <th>Line Total</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for it in invoice.items %}
+            <tr>
+                <td>{{ it.item.name }}</td>
+                <td>{% if it.unit %}{{ it.unit.name }}{% endif %}</td>
+                <td>{{ it.quantity }}</td>
+                <td>{{ '%.2f'|format(it.cost) }}</td>
+                <td>{{ '%.2f'|format(it.line_total) }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <p><strong>Item Total:</strong> {{ '%.2f'|format(invoice.item_total) }}</p>
+    <p><strong>GST:</strong> {{ '%.2f'|format(invoice.gst) }}</p>
+    <p><strong>PST:</strong> {{ '%.2f'|format(invoice.pst) }}</p>
+    <p><strong>Delivery:</strong> {{ '%.2f'|format(invoice.delivery_charge) }}</p>
+    <p><strong>Total:</strong> {{ '%.2f'|format(invoice.total) }}</p>
+</div>
+{% endblock %}

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Purchase Invoices</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>PO</th>
+                <th>Vendor</th>
+                <th>Date</th>
+                <th>Total</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for inv in invoices %}
+            <tr>
+                <td>{{ inv.id }}</td>
+                <td>{{ inv.purchase_order_id }}</td>
+                <td>{{ inv.purchase_order.vendor.first_name }} {{ inv.purchase_order.vendor.last_name }}</td>
+                <td>{{ inv.received_date }}</td>
+                <td>{{ '%.2f'|format(inv.total) }}</td>
+                <td>
+                    <a href="{{ url_for('purchase.view_purchase_invoice', invoice_id=inv.id) }}" class="btn btn-sm btn-primary">View</a>
+                    <a href="{{ url_for('purchase.reverse_purchase_invoice', invoice_id=inv.id) }}" class="btn btn-sm btn-danger">Reverse</a>
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -44,7 +44,10 @@
         </div>
         <button id="add-item" type="button" class="btn btn-secondary mt-3">Add Item</button>
         <div class="form-group mt-3">
-            <label>Total: $<span id="item-total">0.00</span></label>
+            <label>Item Total: $<span id="item-total">0.00</span></label>
+        </div>
+        <div class="form-group mt-3">
+            <label>Grand Total: $<span id="grand-total">0.00</span></label>
         </div>
         <button type="submit" class="btn btn-primary mt-3">Submit</button>
     </form>
@@ -68,6 +71,19 @@
         return row;
     }
 
+    function fetchCost(row) {
+        const itemId = row.querySelector('.item-select').value;
+        const unitId = row.querySelector('.unit-select').value;
+        if (!itemId) return;
+        fetch(`/items/${itemId}/last_cost?unit_id=${unitId}`).then(r=>r.json()).then(d=>{
+            const input = row.querySelector('.cost');
+            if (!input.dataset.touched) {
+                input.value = parseFloat(d.cost).toFixed(2);
+            }
+            updateTotals();
+        });
+    }
+
     function fetchUnits(selectEl) {
         const itemId = selectEl.value;
         const unitSelect = selectEl.closest('.item-row').querySelector('.unit-select');
@@ -81,6 +97,7 @@
                 opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name}</option>`;
             });
             unitSelect.innerHTML = opts;
+            fetchCost(selectEl.closest('.item-row'));
         });
     }
 
@@ -97,6 +114,10 @@
             total += lineTotal;
         });
         document.getElementById('item-total').textContent = total.toFixed(2);
+        const gst = parseFloat(document.getElementById('gst').value) || 0;
+        const pst = parseFloat(document.getElementById('pst').value) || 0;
+        const del = parseFloat(document.getElementById('delivery_charge').value) || 0;
+        document.getElementById('grand-total').textContent = (total + gst + pst + del).toFixed(2);
     }
 
     document.getElementById('add-item').addEventListener('click', function(e) {
@@ -117,6 +138,9 @@
         if (e.target && e.target.classList.contains('item-select')) {
             fetchUnits(e.target);
         }
+        if (e.target && e.target.classList.contains('unit-select')) {
+            fetchCost(e.target.closest('.item-row'));
+        }
         if (e.target && (e.target.classList.contains('quantity') || e.target.classList.contains('cost') || e.target.classList.contains('return-item'))) {
             updateTotals();
         }
@@ -124,11 +148,15 @@
 
     document.getElementById('items').addEventListener('input', function(e) {
         if (e.target && (e.target.classList.contains('quantity') || e.target.classList.contains('cost'))) {
+            if (e.target.classList.contains('cost')) { e.target.dataset.touched = '1'; }
             updateTotals();
         }
     });
 
     document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
+    document.getElementById('gst').addEventListener('input', updateTotals);
+    document.getElementById('pst').addEventListener('input', updateTotals);
+    document.getElementById('delivery_charge').addEventListener('input', updateTotals);
     updateTotals();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `received` flag to purchase orders
- track purchase order cost per base unit when receiving invoices
- hide received purchase orders and redirect to purchase invoice list
- allow reversing a purchase invoice
- show purchase invoices and add navigation link
- auto-populate invoice costs from last received price and calculate totals with taxes
- test purchase invoice workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb888f424832483018fe1d169495b