### PR TITLE
Fix item list alignment and first-row remove buttons

### DIFF
--- a/app/templates/create_product.html
+++ b/app/templates/create_product.html
@@ -43,14 +43,12 @@
             <div class="form-row mb-2 align-items-center">
                 <div class="col">{{ item.item(class="form-control") }}</div>
                 <div class="col">{{ item.quantity(class="form-control") }}</div>
-                <div class="col form-check">
+                <div class="col-auto form-check d-flex align-items-center">
                     {{ item.countable(class="form-check-input") }}
-                    {{ item.countable.label(class="form-check-label") }}
+                    {{ item.countable.label(class="form-check-label ms-1") }}
                 </div>
                 <div class="col-auto">
-                    {% if loop.index0 > 0 %}
                     <button type="button" class="btn btn-danger remove-item">Remove</button>
-                    {% endif %}
                 </div>
             </div>
             {% endfor %}
@@ -80,9 +78,9 @@ document.addEventListener('DOMContentLoaded', function() {
         row.innerHTML = `
             <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
             <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
-            <div class="col form-check">
+            <div class="col-auto form-check d-flex align-items-center">
                 <input type="checkbox" name="items-${itemIndex}-countable" class="form-check-input" id="items-${itemIndex}-countable">
-                <label class="form-check-label" for="items-${itemIndex}-countable">${countableLabel}</label>
+                <label class="form-check-label ms-1" for="items-${itemIndex}-countable">${countableLabel}</label>
             </div>
             <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
         `;

--- a/app/templates/edit_product.html
+++ b/app/templates/edit_product.html
@@ -43,14 +43,12 @@
             <div class="form-row mb-2 align-items-center">
                 <div class="col">{{ item.item(class="form-control") }}</div>
                 <div class="col">{{ item.quantity(class="form-control") }}</div>
-                <div class="col form-check">
+                <div class="col-auto form-check d-flex align-items-center">
                     {{ item.countable(class="form-check-input") }}
-                    {{ item.countable.label(class="form-check-label") }}
+                    {{ item.countable.label(class="form-check-label ms-1") }}
                 </div>
                 <div class="col-auto">
-                    {% if loop.index0 > 0 %}
                     <button type="button" class="btn btn-danger remove-item">Remove</button>
-                    {% endif %}
                 </div>
             </div>
             {% endfor %}
@@ -85,9 +83,9 @@ document.addEventListener('DOMContentLoaded', function() {
         row.innerHTML = `
             <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
             <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
-            <div class="col form-check">
+            <div class="col-auto form-check d-flex align-items-center">
                 <input type="checkbox" name="items-${itemIndex}-countable" class="form-check-input" id="items-${itemIndex}-countable">
-                <label class="form-check-label" for="items-${itemIndex}-countable">${countableLabel}</label>
+                <label class="form-check-label ms-1" for="items-${itemIndex}-countable">${countableLabel}</label>
             </div>
             <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
         `;

--- a/app/templates/edit_product_recipe.html
+++ b/app/templates/edit_product_recipe.html
@@ -6,12 +6,12 @@
         {{ form.hidden_tag() }}
         <div id="item-list">
             {% for item in form.items %}
-            <div class="form-row mb-2">
+            <div class="form-row mb-2 align-items-center">
                 <div class="col">{{ item.item(class="form-control") }}</div>
                 <div class="col">{{ item.quantity(class="form-control") }}</div>
-                <div class="col form-check">
+                <div class="col-auto form-check d-flex align-items-center">
                     {{ item.countable(class="form-check-input") }}
-                    {{ item.countable.label(class="form-check-label") }}
+                    {{ item.countable.label(class="form-check-label ms-1") }}
                 </div>
             </div>
             {% endfor %}

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -23,14 +23,12 @@
         <h4>Items</h4>
         <div id="items">
         {% for item in form.items %}
-        <div class="form-row mt-2 item-row">
+        <div class="form-row mt-2 item-row align-items-center">
             <div class="col">{{ item.item(class="form-control item-select") }}</div>
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
             <div class="col">{{ item.quantity(class="form-control") }}</div>
             <div class="col-auto">
-                {% if loop.index0 > 0 %}
                 <button type="button" class="btn btn-danger remove-item">Remove</button>
-                {% endif %}
             </div>
         </div>
         {% endfor %}
@@ -46,7 +44,7 @@
 
     function createRow(index) {
         const row = document.createElement('div');
-        row.classList.add('form-row','mt-2','item-row');
+        row.classList.add('form-row','mt-2','item-row','align-items-center');
         row.innerHTML = `
             <div class="col"><select name="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
             <div class="col"><select name="items-${index}-unit" class="form-control unit-select"></select></div>

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -23,14 +23,12 @@
         <h4>Items</h4>
         <div id="items">
         {% for item in form.items %}
-        <div class="form-row mt-2 item-row">
+        <div class="form-row mt-2 item-row align-items-center">
             <div class="col">{{ item.item(class="form-control item-select") }}</div>
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
             <div class="col">{{ item.quantity(class="form-control") }}</div>
             <div class="col-auto">
-                {% if loop.index0 > 0 %}
                 <button type="button" class="btn btn-danger remove-item">Remove</button>
-                {% endif %}
             </div>
         </div>
         {% endfor %}
@@ -46,7 +44,7 @@
 
     function createRow(index) {
         const row = document.createElement('div');
-        row.classList.add('form-row','mt-2','item-row');
+        row.classList.add('form-row','mt-2','item-row','align-items-center');
         row.innerHTML = `
             <div class="col"><select name="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
             <div class="col"><select name="items-${index}-unit" class="form-control unit-select"></select></div>

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -33,11 +33,9 @@
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col">{{ item.cost(class="form-control cost") }}</div>
             <div class="col"><span class="line-total">0.00</span></div>
-            <div class="col form-check">{{ item.return_item(class="form-check-input return-item") }} {{ item.return_item.label(class="form-check-label") }}</div>
+            <div class="col-auto form-check d-flex align-items-center">{{ item.return_item(class="form-check-input return-item") }} {{ item.return_item.label(class="form-check-label ms-1") }}</div>
             <div class="col-auto">
-                {% if loop.index0 > 0 %}
                 <button type="button" class="btn btn-danger remove-item">Remove</button>
-                {% endif %}
             </div>
         </div>
         {% endfor %}
@@ -65,7 +63,7 @@
             <div class="col"><input type="number" step="any" name="items-${index}-quantity" class="form-control quantity"></div>
             <div class="col"><input type="number" step="any" name="items-${index}-cost" class="form-control cost"></div>
             <div class="col"><span class="line-total">0.00</span></div>
-            <div class="col form-check"><input type="checkbox" name="items-${index}-return_item" class="form-check-input return-item"></div>
+            <div class="col-auto form-check d-flex align-items-center"><input type="checkbox" name="items-${index}-return_item" class="form-check-input return-item"></div>
             <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
         `;
         return row;


### PR DESCRIPTION
## Summary
- ensure recipe items show remove button on all rows and align with checkbox
- align purchase order and invoice item rows and allow first-row removal

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cccae54cc83249731f3093f4503e3