### PR TITLE
Add GL code support and tests

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -65,8 +65,14 @@ class ItemForm(FlaskForm):
         choices=[('ounce', 'Ounce'), ('gram', 'Gram'), ('each', 'Each'), ('millilitre', 'Millilitre')],
         validators=[DataRequired()]
     )
+    purchase_gl_code = SelectField('Purchase GL Code', coerce=int, validators=[Optional()])
     units = FieldList(FormField(ItemUnitForm), min_entries=1)
     submit = SubmitField('Submit')
+
+    def __init__(self, *args, **kwargs):
+        super(ItemForm, self).__init__(*args, **kwargs)
+        from app.models import GLCode
+        self.purchase_gl_code.choices = [(g.id, g.code) for g in GLCode.query.all()]
 
 
 class TransferItemForm(FlaskForm):
@@ -139,7 +145,13 @@ class ProductForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired()])
     price = DecimalField('Price', validators=[DataRequired(), NumberRange(min=0.0001)])
     cost = DecimalField('Cost', validators=[InputRequired(), NumberRange(min=0)], default=0.0)
+    sales_gl_code = SelectField('Sales GL Code', coerce=int, validators=[Optional()])
     submit = SubmitField('Submit')
+
+    def __init__(self, *args, **kwargs):
+        super(ProductForm, self).__init__(*args, **kwargs)
+        from app.models import GLCode
+        self.sales_gl_code.choices = [(g.id, g.code) for g in GLCode.query.all()]
 
 
 class RecipeItemForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -48,12 +48,19 @@ class Location(db.Model):
     stand_items = db.relationship('LocationStandItem', back_populates='location', cascade='all, delete-orphan')
 
 
+class GLCode(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(50), unique=True, nullable=False)
+
+
 class Item(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), unique=True, nullable=False)
     base_unit = db.Column(db.String(20), nullable=False)
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
+    purchase_gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
+    purchase_gl_code = relationship('GLCode', foreign_keys=[purchase_gl_code_id])
     transfers = db.relationship('Transfer', secondary=transfer_items, backref=db.backref('items', lazy='dynamic'))
     recipe_items = relationship("ProductRecipeItem", back_populates="item", cascade="all, delete-orphan")
     units = relationship("ItemUnit", back_populates="item", cascade="all, delete-orphan")
@@ -110,6 +117,8 @@ class Product(db.Model):
     price = db.Column(db.Float, nullable=False)
     cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
+    sales_gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
+    sales_gl_code = relationship('GLCode', foreign_keys=[sales_gl_code_id])
 
     # Define a one-to-many relationship with InvoiceProduct
     invoice_products = relationship("InvoiceProduct", back_populates="product", cascade="all, delete-orphan")

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -234,7 +234,11 @@ def add_item():
         if recv_count > 1 or trans_count > 1:
             flash('Only one unit can be set as receiving and transfer default.', 'error')
             return render_template('items/add_item.html', form=form)
-        item = Item(name=form.name.data, base_unit=form.base_unit.data)
+        item = Item(
+            name=form.name.data,
+            base_unit=form.base_unit.data,
+            purchase_gl_code_id=form.purchase_gl_code.data or None,
+        )
         db.session.add(item)
         db.session.commit()
 
@@ -271,6 +275,7 @@ def edit_item(item_id):
         abort(404)
     form = ItemForm(obj=item)
     if request.method == 'GET':
+        form.purchase_gl_code.data = item.purchase_gl_code_id
         for idx, unit in enumerate(item.units):
             if idx < len(form.units):
                 form.units[idx].form.name.data = unit.name
@@ -292,6 +297,7 @@ def edit_item(item_id):
             return render_template('items/edit_item.html', form=form, item=item)
         item.name = form.name.data
         item.base_unit = form.base_unit.data
+        item.purchase_gl_code_id = form.purchase_gl_code.data or None
         ItemUnit.query.filter_by(item_id=item.id).delete()
         receiving_set = False
         transfer_set = False
@@ -684,7 +690,8 @@ def create_product():
         product = Product(
             name=form.name.data,
             price=form.price.data,
-            cost=form.cost.data  # 👈 Save cost
+            cost=form.cost.data,
+            sales_gl_code_id=form.sales_gl_code.data or None,
         )
         db.session.add(product)
         db.session.commit()
@@ -720,6 +727,7 @@ def edit_product(product_id):
         product.name = form.name.data
         product.price = form.price.data
         product.cost = form.cost.data or 0.0  # 👈 Update cost
+        product.sales_gl_code_id = form.sales_gl_code.data or None
 
         ProductRecipeItem.query.filter_by(product_id=product.id).delete()
         for item_form in form.items:
@@ -743,6 +751,7 @@ def edit_product(product_id):
         form.name.data = product.name
         form.price.data = product.price
         form.cost.data = product.cost or 0.0  # 👈 Pre-fill cost
+        form.sales_gl_code.data = product.sales_gl_code_id
         form.items.min_entries = max(1, len(product.recipe_items))
         item_choices = [(itm.id, itm.name) for itm in Item.query.all()]
         for i, recipe_item in enumerate(product.recipe_items):

--- a/tests/test_gl_codes.py
+++ b/tests/test_gl_codes.py
@@ -1,0 +1,58 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import User, GLCode, Item, ItemUnit, Product, ProductRecipeItem
+from tests.test_user_flows import login
+
+
+def setup_data(app):
+    with app.app_context():
+        user = User(email='gl@example.com', password=generate_password_hash('pass'), active=True)
+        purchase = GLCode(code='6000')
+        sales = GLCode(code='5000')
+        item = Item(name='Widget', base_unit='each')
+        db.session.add_all([user, purchase, sales, item])
+        db.session.commit()
+        unit = ItemUnit(item_id=item.id, name='each', factor=1, receiving_default=True, transfer_default=True)
+        db.session.add(unit)
+        db.session.commit()
+        return user.email, purchase.id, sales.id, item.id
+
+
+def test_create_item_with_purchase_gl_code(client, app):
+    email, purchase_id, sales_id, item_id = setup_data(app)
+    with client:
+        login(client, email, 'pass')
+        resp = client.post('/items/add', data={
+            'name': 'GLItem',
+            'base_unit': 'each',
+            'purchase_gl_code': purchase_id,
+            'units-0-name': 'each',
+            'units-0-factor': 1,
+            'units-0-receiving_default': 'y',
+            'units-0-transfer_default': 'y'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+    with app.app_context():
+        item = Item.query.filter_by(name='GLItem').first()
+        assert item is not None
+        assert item.purchase_gl_code_id == purchase_id
+
+
+def test_create_product_with_sales_gl_code(client, app):
+    email, purchase_id, sales_id, item_id = setup_data(app)
+    with client:
+        login(client, email, 'pass')
+        resp = client.post('/products/create', data={
+            'name': 'GLProduct',
+            'price': 2,
+            'cost': 1,
+            'sales_gl_code': sales_id,
+            'items-0-item': item_id,
+            'items-0-quantity': 1,
+            'items-0-countable': 'y'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+    with app.app_context():
+        product = Product.query.filter_by(name='GLProduct').first()
+        assert product is not None
+        assert product.sales_gl_code_id == sales_id


### PR DESCRIPTION
## Summary
- add GLCode model and wire it into Item and Product
- include purchase and sales GL code selectors in forms and routes
- add regression tests for item and product GL code creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd553ca788324917a95c9833f5354