### PR TITLE
Add GL code fields for items and products

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -48,10 +48,16 @@ class Location(db.Model):
     stand_items = db.relationship('LocationStandItem', back_populates='location', cascade='all, delete-orphan')
 
 
+class GLCode(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(10), unique=True, nullable=False)
+
+
 class Item(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), unique=True, nullable=False)
     base_unit = db.Column(db.String(20), nullable=False)
+    gl_code = db.Column(db.String(10), nullable=True)
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     transfers = db.relationship('Transfer', secondary=transfer_items, backref=db.backref('items', lazy='dynamic'))
@@ -107,6 +113,7 @@ class Customer(db.Model):
 class Product(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
+    gl_code = db.Column(db.String(10), nullable=True)
     price = db.Column(db.Float, nullable=False)
     cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -234,7 +234,7 @@ def add_item():
         if recv_count > 1 or trans_count > 1:
             flash('Only one unit can be set as receiving and transfer default.', 'error')
             return render_template('items/add_item.html', form=form)
-        item = Item(name=form.name.data, base_unit=form.base_unit.data)
+        item = Item(name=form.name.data, base_unit=form.base_unit.data, gl_code=form.gl_code.data)
         db.session.add(item)
         db.session.commit()
 
@@ -271,6 +271,7 @@ def edit_item(item_id):
         abort(404)
     form = ItemForm(obj=item)
     if request.method == 'GET':
+        form.gl_code.data = item.gl_code
         for idx, unit in enumerate(item.units):
             if idx < len(form.units):
                 form.units[idx].form.name.data = unit.name
@@ -292,6 +293,7 @@ def edit_item(item_id):
             return render_template('items/edit_item.html', form=form, item=item)
         item.name = form.name.data
         item.base_unit = form.base_unit.data
+        item.gl_code = form.gl_code.data
         ItemUnit.query.filter_by(item_id=item.id).delete()
         receiving_set = False
         transfer_set = False
@@ -684,7 +686,8 @@ def create_product():
         product = Product(
             name=form.name.data,
             price=form.price.data,
-            cost=form.cost.data  # 👈 Save cost
+            cost=form.cost.data,
+            gl_code=form.gl_code.data
         )
         db.session.add(product)
         db.session.commit()
@@ -720,6 +723,7 @@ def edit_product(product_id):
         product.name = form.name.data
         product.price = form.price.data
         product.cost = form.cost.data or 0.0  # 👈 Update cost
+        product.gl_code = form.gl_code.data
 
         ProductRecipeItem.query.filter_by(product_id=product.id).delete()
         for item_form in form.items:
@@ -743,6 +747,7 @@ def edit_product(product_id):
         form.name.data = product.name
         form.price.data = product.price
         form.cost.data = product.cost or 0.0  # 👈 Pre-fill cost
+        form.gl_code.data = product.gl_code
         form.items.min_entries = max(1, len(product.recipe_items))
         item_choices = [(itm.id, itm.name) for itm in Item.query.all()]
         for i, recipe_item in enumerate(product.recipe_items):

--- a/app/templates/create_product.html
+++ b/app/templates/create_product.html
@@ -29,6 +29,11 @@
         </div>
 
         <div class="form-group">
+            {{ form.gl_code.label(class="form-label") }}
+            {{ form.gl_code(class="form-control") }}
+        </div>
+
+        <div class="form-group">
             {{ form.cost.label(class="form-label") }}
             {{ form.cost(class="form-control", id="cost") }}
             {% if form.cost.errors %}

--- a/app/templates/edit_product.html
+++ b/app/templates/edit_product.html
@@ -29,6 +29,11 @@
         </div>
 
         <div class="form-group">
+            {{ form.gl_code.label(class="form-label") }}
+            {{ form.gl_code(class="form-control") }}
+        </div>
+
+        <div class="form-group">
             {{ form.cost.label(class="form-label") }}
             {{ form.cost(class="form-control" + (" is-invalid" if form.cost.errors else ""), id="cost") }}
             {% for error in form.cost.errors %}

--- a/app/templates/items/add_item.html
+++ b/app/templates/items/add_item.html
@@ -13,6 +13,10 @@
             {{ form.base_unit.label }}
             {{ form.base_unit(class="form-control") }}
         </div>
+        <div class="form-group">
+            {{ form.gl_code.label }}
+            {{ form.gl_code(class="form-control") }}
+        </div>
         <h4>Units</h4>
         <div id="units-container">
         {% for unit in form.units %}

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -14,6 +14,10 @@
             {{ form.base_unit(class="form-control", value=item.base_unit) }}
         </div>
         <div class="form-group">
+            {{ form.gl_code.label(class="form-label") }}
+            {{ form.gl_code(class="form-control") }}
+        </div>
+        <div class="form-group">
             <label class="form-label">Cost</label>
             <input type="text" class="form-control" value="{{ item.cost }}" readonly>
         </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from app import create_app, db
+from app.models import GLCode
 
 @pytest.fixture
 def app(tmp_path):
@@ -33,3 +34,11 @@ def app(tmp_path):
 @pytest.fixture
 def client(app):
     return app.test_client()
+
+
+@pytest.fixture(autouse=True)
+def gl_codes(app):
+    with app.app_context():
+        if GLCode.query.count() == 0:
+            db.session.add_all([GLCode(code='4000'), GLCode(code='5000')])
+            db.session.commit()

--- a/tests/test_item_transfer_invoice.py
+++ b/tests/test_item_transfer_invoice.py
@@ -22,6 +22,7 @@ def test_item_lifecycle(client, app):
         resp = client.post('/items/add', data={
             'name': 'Widget',
             'base_unit': 'each',
+            'gl_code': '5000',
             'units-0-name': 'each',
             'units-0-factor': 1,
             'units-0-receiving_default': 'y',
@@ -39,6 +40,7 @@ def test_item_lifecycle(client, app):
         resp = client.post(f'/items/edit/{item_id}', data={
             'name': 'Gadget',
             'base_unit': 'each',
+            'gl_code': '5000',
             'units-0-name': 'each',
             'units-0-factor': 1,
             'units-0-receiving_default': 'y',

--- a/tests/test_multiple_units.py
+++ b/tests/test_multiple_units.py
@@ -19,6 +19,7 @@ def test_add_item_multiple_units(client, app):
         resp = client.post('/items/add', data={
             'name': 'Combo',
             'base_unit': 'each',
+            'gl_code': '5000',
             'units-0-name': 'each',
             'units-0-factor': 1,
             'units-0-receiving_default': 'y',
@@ -42,6 +43,7 @@ def test_reject_multiple_defaults(client, app):
         resp = client.post('/items/add', data={
             'name': 'BadItem',
             'base_unit': 'each',
+            'gl_code': '5000',
             'units-0-name': 'each',
             'units-0-factor': 1,
             'units-0-receiving_default': 'y',

--- a/tests/test_product_crud_with_recipe.py
+++ b/tests/test_product_crud_with_recipe.py
@@ -28,6 +28,7 @@ def test_create_product_with_recipe_items(client, app):
             'name': 'Cake',
             'price': 5,
             'cost': 2,
+            'gl_code': '4000',
             'items-0-item': item1_id,
             'items-0-quantity': 2,
             'items-0-countable': 'y',
@@ -59,6 +60,7 @@ def test_edit_product_recipe_on_edit_page(client, app):
             'name': 'Bread',
             'price': 3.5,
             'cost': 1.5,
+            'gl_code': '4000',
             'items-0-item': item2_id,
             'items-0-quantity': 4,
             'items-0-countable': ''
@@ -81,6 +83,7 @@ def test_recipe_accepts_integer_quantity(client, app):
             'name': 'Pie',
             'price': 4,
             'cost': 2,
+            'gl_code': '4000',
             'items-0-item': item1_id,
             'items-0-quantity': 0,
             'items-0-countable': 'y'


### PR DESCRIPTION
## Summary
- add GLCode model and gl_code columns for Item and Product
- populate GL codes in ItemForm and ProductForm
- update templates and routes to handle the new field
- ensure gl code is validated by prefix
- update tests for new required field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd5555c24832480c6b1935cf665c0