### PR TITLE
Add GLCode model with item/product links

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -54,9 +54,11 @@ class Item(db.Model):
     base_unit = db.Column(db.String(20), nullable=False)
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
+    gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
     transfers = db.relationship('Transfer', secondary=transfer_items, backref=db.backref('items', lazy='dynamic'))
     recipe_items = relationship("ProductRecipeItem", back_populates="item", cascade="all, delete-orphan")
     units = relationship("ItemUnit", back_populates="item", cascade="all, delete-orphan")
+    gl_code = relationship('GLCode', backref='items')
 
 
 class ItemUnit(db.Model):
@@ -104,16 +106,25 @@ class Customer(db.Model):
     invoices = db.relationship('Invoice', backref='customer', lazy=True)
 
 
+class GLCode(db.Model):
+    __tablename__ = 'gl_code'
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(6), unique=True, nullable=False)
+    description = db.Column(db.String(255))
+
+
 class Product(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
     price = db.Column(db.Float, nullable=False)
     cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
+    gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
 
     # Define a one-to-many relationship with InvoiceProduct
     invoice_products = relationship("InvoiceProduct", back_populates="product", cascade="all, delete-orphan")
     recipe_items = relationship("ProductRecipeItem", back_populates="product", cascade="all, delete-orphan")
+    gl_code = relationship('GLCode', backref='products')
 
 
 class Invoice(db.Model):

--- a/tests/test_gl_code_model.py
+++ b/tests/test_gl_code_model.py
@@ -1,0 +1,23 @@
+import pytest
+from app import db
+from app.models import GLCode, Item, Product
+
+
+def test_glcode_relationships_and_uniqueness(app):
+    with app.app_context():
+        code = GLCode(code='123456', description='Test code')
+        db.session.add(code)
+        db.session.commit()
+
+        item = Item(name='UniqueItem', base_unit='each', gl_code_id=code.id)
+        product = Product(name='UniqueProduct', price=1.0, cost=0.5, gl_code_id=code.id)
+        db.session.add_all([item, product])
+        db.session.commit()
+
+        assert item.gl_code == code
+        assert product.gl_code == code
+
+        db.session.add(GLCode(code='123456', description='Duplicate'))
+        with pytest.raises(Exception):
+            db.session.commit()
+        db.session.rollback()


### PR DESCRIPTION
## Summary
- add `GLCode` model for accounting codes
- link items and products to GL codes via FK fields
- test GLCode relationships and uniqueness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd555849c8324b7bd514d3fba40c7