### PR TITLE
Fix GLCode model duplication and form setup

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -61,7 +61,7 @@ class ItemUnitForm(FlaskForm):
 
 class ItemForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired()])
-    gl_code = SelectField('GL Code', validators=[DataRequired()])
+    gl_code = SelectField('GL Code', validators=[Optional()])
     base_unit = SelectField(
         'Base Unit',
         choices=[('ounce', 'Ounce'), ('gram', 'Gram'), ('each', 'Each'), ('millilitre', 'Millilitre')],
@@ -74,7 +74,10 @@ class ItemForm(FlaskForm):
 
     def __init__(self, *args, **kwargs):
         super(ItemForm, self).__init__(*args, **kwargs)
-        self.gl_code.choices = [(g.code, g.code) for g in GLCode.query.all()]
+        codes = [(g.id, g.code) for g in GLCode.query.all()]
+        self.gl_code.choices = [(code, code) for _, code in codes]
+        self.gl_code_id.choices = codes
+        self.purchase_gl_code.choices = codes
 
     def validate_gl_code(self, field):
         if field.data and not str(field.data).startswith('5'):
@@ -152,7 +155,7 @@ class CustomerForm(FlaskForm):
 
 class ProductForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired()])
-    gl_code = SelectField('GL Code', validators=[DataRequired()])
+    gl_code = SelectField('GL Code', validators=[Optional()])
     price = DecimalField('Price', validators=[DataRequired(), NumberRange(min=0.0001)])
     cost = DecimalField('Cost', validators=[InputRequired(), NumberRange(min=0)], default=0.0)
     gl_code_id = SelectField('GL Code', coerce=int, validators=[Optional()], validate_choice=False)
@@ -161,7 +164,10 @@ class ProductForm(FlaskForm):
 
     def __init__(self, *args, **kwargs):
         super(ProductForm, self).__init__(*args, **kwargs)
-        self.gl_code.choices = [(g.code, g.code) for g in GLCode.query.all()]
+        codes = [(g.id, g.code) for g in GLCode.query.all()]
+        self.gl_code.choices = [(code, code) for _, code in codes]
+        self.gl_code_id.choices = codes
+        self.sales_gl_code.choices = codes
 
     def validate_gl_code(self, field):
         if field.data and not str(field.data).startswith('4'):

--- a/app/models.py
+++ b/app/models.py
@@ -48,14 +48,6 @@ class Location(db.Model):
     stand_items = db.relationship('LocationStandItem', back_populates='location', cascade='all, delete-orphan')
 
 
-class GLCode(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    code = db.Column(db.String(10), unique=True, nullable=False)
-    code = db.Column(db.String(20), unique=True, nullable=False)
-    description = db.Column(db.String(255))
-    items = db.relationship('Item', backref='gl_code')
-    products = db.relationship('Product', backref='gl_code')
-    code = db.Column(db.String(50), unique=True, nullable=False)
 
 
 class Item(db.Model):
@@ -66,13 +58,12 @@ class Item(db.Model):
     gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
-    gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
     purchase_gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
     purchase_gl_code = relationship('GLCode', foreign_keys=[purchase_gl_code_id])
     transfers = db.relationship('Transfer', secondary=transfer_items, backref=db.backref('items', lazy='dynamic'))
     recipe_items = relationship("ProductRecipeItem", back_populates="item", cascade="all, delete-orphan")
     units = relationship("ItemUnit", back_populates="item", cascade="all, delete-orphan")
-    gl_code = relationship('GLCode', backref='items')
+    gl_code_rel = relationship('GLCode', foreign_keys=[gl_code_id], backref='items')
 
 
 class ItemUnit(db.Model):
@@ -135,14 +126,13 @@ class Product(db.Model):
     cost = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
     gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
     quantity = db.Column(db.Float, nullable=False, default=0.0, server_default="0.0")
-    gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
     sales_gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
     sales_gl_code = relationship('GLCode', foreign_keys=[sales_gl_code_id])
 
     # Define a one-to-many relationship with InvoiceProduct
     invoice_products = relationship("InvoiceProduct", back_populates="product", cascade="all, delete-orphan")
     recipe_items = relationship("ProductRecipeItem", back_populates="product", cascade="all, delete-orphan")
-    gl_code = relationship('GLCode', backref='products')
+    gl_code_rel = relationship('GLCode', foreign_keys=[gl_code_id], backref='products')
 
 
 class Invoice(db.Model):

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -234,11 +234,11 @@ def add_item():
         if recv_count > 1 or trans_count > 1:
             flash('Only one unit can be set as receiving and transfer default.', 'error')
             return render_template('items/add_item.html', form=form)
-        item = Item(name=form.name.data, base_unit=form.base_unit.data, gl_code=form.gl_code.data)
-        item = Item(name=form.name.data, base_unit=form.base_unit.data, gl_code_id=form.gl_code_id.data)
         item = Item(
             name=form.name.data,
             base_unit=form.base_unit.data,
+            gl_code=form.gl_code.data,
+            gl_code_id=form.gl_code_id.data,
             purchase_gl_code_id=form.purchase_gl_code.data or None,
         )
         db.session.add(item)
@@ -304,7 +304,7 @@ def edit_item(item_id):
         item.gl_code_id = form.gl_code_id.data
         item.purchase_gl_code_id = form.purchase_gl_code.data or None
         ItemUnit.query.filter_by(item_id=item.id).delete()
-        receiving_set = Fals
+        receiving_set = False
         transfer_set = False
         for uf in form.units:
             unit_form = uf.form
@@ -695,11 +695,9 @@ def create_product():
         product = Product(
             name=form.name.data,
             price=form.price.data,
-            cost=form.cost.data,
-            gl_code=form.gl_code.data
             cost=form.cost.data,  # Save cost
-            gl_code_id=form.gl_code_id.data
-            cost=form.cost.data,
+            gl_code=form.gl_code.data,
+            gl_code_id=form.gl_code_id.data,
             sales_gl_code_id=form.sales_gl_code.data or None,
         )
         db.session.add(product)

--- a/tests/test_gl_code_model.py
+++ b/tests/test_gl_code_model.py
@@ -14,8 +14,8 @@ def test_glcode_relationships_and_uniqueness(app):
         db.session.add_all([item, product])
         db.session.commit()
 
-        assert item.gl_code == code
-        assert product.gl_code == code
+        assert item.gl_code_rel == code
+        assert product.gl_code_rel == code
 
         db.session.add(GLCode(code='123456', description='Duplicate'))
         with pytest.raises(Exception):

--- a/tests/test_gl_codes.py
+++ b/tests/test_gl_codes.py
@@ -8,7 +8,9 @@ def setup_data(app):
     with app.app_context():
         user = User(email='gl@example.com', password=generate_password_hash('pass'), active=True)
         purchase = GLCode(code='6000')
-        sales = GLCode(code='5000')
+        sales = GLCode.query.filter_by(code='5000').first()
+        if sales is None:
+            sales = GLCode(code='5000')
         item = Item(name='Widget', base_unit='each')
         db.session.add_all([user, purchase, sales, item])
         db.session.commit()


### PR DESCRIPTION
## Summary
- remove duplicate GLCode model and clean up relationships
- rename relationship fields to avoid conflicts
- simplify item/product creation routes
- make GL code fields optional and preload select options
- fix tests relying on existing GL codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cdaaaa80c832486132e547472d3c0