### PR TITLE
Add GL code management

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -90,7 +90,7 @@ def create_app(args: list):
 
     with app.app_context():
         from app.routes import auth_routes
-        from app.routes.routes import main, location, item, transfer, customer, invoice, product, report, purchase, vendor
+        from app.routes.routes import main, location, item, transfer, customer, invoice, product, report, purchase, vendor, glcode_bp
         from app.routes.auth_routes import auth, admin
         from app.models import User
 
@@ -106,6 +106,7 @@ def create_app(args: list):
         app.register_blueprint(purchase)
         app.register_blueprint(report)
         app.register_blueprint(vendor)
+        app.register_blueprint(glcode_bp)
 
         db.create_all()
         create_admin_user()

--- a/app/forms.py
+++ b/app/forms.py
@@ -298,3 +298,9 @@ class DeleteForm(FlaskForm):
     """Simple form used for CSRF protection on delete actions."""
     submit = SubmitField('Delete')
 
+
+class GLCodeForm(FlaskForm):
+    code = StringField('Code', validators=[DataRequired(), Length(max=6)])
+    description = StringField('Description', validators=[Optional()])
+    submit = SubmitField('Submit')
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -57,6 +57,9 @@
                 <a class="nav-link" href="{{ url_for('product.view_products') }}">Products</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('glcode.view_gl_codes') }}">GL Codes</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('purchase.view_purchase_orders') }}">Purchase Orders</a>
             </li>
             <li class="nav-item">

--- a/app/templates/gl_codes/add_gl_code.html
+++ b/app/templates/gl_codes/add_gl_code.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block title %}Add GL Code{% endblock %}
+{% block content %}
+<div class="container mt-5">
+    <h2>Add GL Code</h2>
+    <form method="POST">
+        {{ form.hidden_tag() }}
+        <div class="form-group">
+            {{ form.code.label(class="form-label") }}
+            {{ form.code(class="form-control") }}
+        </div>
+        <div class="form-group">
+            {{ form.description.label(class="form-label") }}
+            {{ form.description(class="form-control") }}
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/gl_codes/edit_gl_code.html
+++ b/app/templates/gl_codes/edit_gl_code.html
@@ -1,0 +1,19 @@
+{% extends 'base.html' %}
+{% block title %}Edit GL Code{% endblock %}
+{% block content %}
+<div class="container mt-5">
+    <h2>Edit GL Code</h2>
+    <form method="POST">
+        {{ form.hidden_tag() }}
+        <div class="form-group">
+            {{ form.code.label(class="form-label") }}
+            {{ form.code(class="form-control") }}
+        </div>
+        <div class="form-group">
+            {{ form.description.label(class="form-label") }}
+            {{ form.description(class="form-control") }}
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/gl_codes/view_gl_codes.html
+++ b/app/templates/gl_codes/view_gl_codes.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block title %}GL Codes{% endblock %}
+{% block content %}
+<div class="container mt-5">
+    <h2>GL Codes</h2>
+    <a href="{{ url_for('glcode.create_gl_code') }}" class="btn btn-primary mb-3">Add GL Code</a>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Code</th>
+                <th>Description</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for code in codes %}
+            <tr>
+                <td>{{ code.code }}</td>
+                <td>{{ code.description or '' }}</td>
+                <td>
+                    <a href="{{ url_for('glcode.edit_gl_code', code_id=code.id) }}" class="btn btn-secondary btn-sm">Edit</a>
+                    <a href="{{ url_for('glcode.delete_gl_code', code_id=code.id) }}" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure?');">Delete</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `GLCodeForm`
- register `glcode_bp` blueprint
- add views for creating, editing and deleting GL Codes
- add templates for GL code management
- link GL Codes from the navbar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cddf51d4083248732658e854ec347