### PR TITLE
Fix GL code dropdowns on item pages

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -74,17 +74,24 @@ class ItemForm(FlaskForm):
 
     def __init__(self, *args, **kwargs):
         super(ItemForm, self).__init__(*args, **kwargs)
-        codes = [(g.id, g.code) for g in GLCode.query.all()]
-        self.gl_code.choices = [(code, code) for _, code in codes]
-        self.gl_code_id.choices = codes
-        self.purchase_gl_code.choices = codes
+        purchase_codes = [
+            (g.id, g.code)
+            for g in GLCode.query.filter(GLCode.code.like('5%')).all()
+        ]
+        self.gl_code.choices = [(code, code) for _, code in purchase_codes]
+        self.gl_code_id.choices = purchase_codes
+        self.purchase_gl_code.choices = purchase_codes
 
     def validate_gl_code(self, field):
         if field.data and not str(field.data).startswith('5'):
             raise ValidationError('Item GL codes must start with 5')
         from app.models import GLCode
-        self.gl_code_id.choices = [(g.id, g.code) for g in GLCode.query.all()]
-        self.purchase_gl_code.choices = [(g.id, g.code) for g in GLCode.query.all()]
+        purchase_codes = [
+            (g.id, g.code)
+            for g in GLCode.query.filter(GLCode.code.like('5%')).all()
+        ]
+        self.gl_code_id.choices = purchase_codes
+        self.purchase_gl_code.choices = purchase_codes
 
 
 class TransferItemForm(FlaskForm):

--- a/app/templates/items/add_item.html
+++ b/app/templates/items/add_item.html
@@ -14,10 +14,8 @@
             {{ form.base_unit(class="form-control") }}
         </div>
         <div class="form-group">
-            {{ form.gl_code.label }}
-            {{ form.gl_code(class="form-control") }}
-            {{ form.gl_code_id.label }}
-            {{ form.gl_code_id(class="form-control") }}
+            {{ form.purchase_gl_code.label }}
+            {{ form.purchase_gl_code(class="form-control") }}
         </div>
         <h4>Units</h4>
         <div id="units-container">

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -14,10 +14,8 @@
             {{ form.base_unit(class="form-control", value=item.base_unit) }}
         </div>
         <div class="form-group">
-            {{ form.gl_code.label(class="form-label") }}
-            {{ form.gl_code(class="form-control") }}
-            {{ form.gl_code_id.label(class="form-label") }}
-            {{ form.gl_code_id(class="form-control") }}
+            {{ form.purchase_gl_code.label(class="form-label") }}
+            {{ form.purchase_gl_code(class="form-control") }}
         </div>
         <div class="form-group">
             <label class="form-label">Cost</label>

--- a/tests/test_gl_codes.py
+++ b/tests/test_gl_codes.py
@@ -7,7 +7,7 @@ from tests.test_user_flows import login
 def setup_data(app):
     with app.app_context():
         user = User(email='gl@example.com', password=generate_password_hash('pass'), active=True)
-        purchase = GLCode(code='6000')
+        purchase = GLCode(code='5100')
         sales = GLCode.query.filter_by(code='5000').first()
         if sales is None:
             sales = GLCode(code='5000')


### PR DESCRIPTION
## Summary
- show a single GL code dropdown for items
- filter GL code selections to purchase codes that start with `5`
- update test data for GL codes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cdf33db60832486769f00941840ef