### PR TITLE
Fix product GL code dropdown

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -171,17 +171,22 @@ class ProductForm(FlaskForm):
 
     def __init__(self, *args, **kwargs):
         super(ProductForm, self).__init__(*args, **kwargs)
-        codes = [(g.id, g.code) for g in GLCode.query.all()]
-        self.gl_code.choices = [(code, code) for _, code in codes]
-        self.gl_code_id.choices = codes
-        self.sales_gl_code.choices = codes
+        sales_codes = [
+            (g.id, g.code) for g in GLCode.query.filter(GLCode.code.like('4%')).all()
+        ]
+        self.gl_code.choices = [(code, code) for _, code in sales_codes]
+        self.gl_code_id.choices = sales_codes
+        self.sales_gl_code.choices = sales_codes
 
     def validate_gl_code(self, field):
         if field.data and not str(field.data).startswith('4'):
             raise ValidationError('Product GL codes must start with 4')
         from app.models import GLCode
-        self.gl_code_id.choices = [(g.id, g.code) for g in GLCode.query.all()]
-        self.sales_gl_code.choices = [(g.id, g.code) for g in GLCode.query.all()]
+        sales_codes = [
+            (g.id, g.code) for g in GLCode.query.filter(GLCode.code.like('4%')).all()
+        ]
+        self.gl_code_id.choices = sales_codes
+        self.sales_gl_code.choices = sales_codes
 
 
 class RecipeItemForm(FlaskForm):

--- a/app/routes/routes.py
+++ b/app/routes/routes.py
@@ -703,6 +703,10 @@ def create_product():
             gl_code_id=form.gl_code_id.data,
             sales_gl_code_id=form.sales_gl_code.data or None,
         )
+        if not product.gl_code and product.gl_code_id:
+            gl = db.session.get(GLCode, product.gl_code_id)
+            if gl:
+                product.gl_code = gl.code
         db.session.add(product)
         db.session.commit()
 
@@ -740,6 +744,10 @@ def edit_product(product_id):
         product.gl_code = form.gl_code.data
         product.gl_code_id = form.gl_code_id.data
         product.sales_gl_code_id = form.sales_gl_code.data or None
+        if not product.gl_code and product.gl_code_id:
+            gl = db.session.get(GLCode, product.gl_code_id)
+            if gl:
+                product.gl_code = gl.code
 
         ProductRecipeItem.query.filter_by(product_id=product.id).delete()
         for item_form in form.items:

--- a/app/templates/create_product.html
+++ b/app/templates/create_product.html
@@ -25,20 +25,15 @@
                 <div class="invalid-feedback">
                     {{ form.price.errors[0] }}
                 </div>
-            {% endif %}
-        </div>
+        {% endif %}
+    </div>
 
-        <div class="form-group">
-            {{ form.gl_code.label(class="form-label") }}
-            {{ form.gl_code(class="form-control") }}
-        </div>
-
-        <div class="form-group">
-            {{ form.cost.label(class="form-label") }}
-            {{ form.cost(class="form-control", id="cost") }}
-            {% if form.cost.errors %}
-                <div class="invalid-feedback">
-                    {{ form.cost.errors[0] }}
+    <div class="form-group">
+        {{ form.cost.label(class="form-label") }}
+        {{ form.cost(class="form-control", id="cost") }}
+        {% if form.cost.errors %}
+            <div class="invalid-feedback">
+                {{ form.cost.errors[0] }}
                 </div>
             {% endif %}
         </div>

--- a/app/templates/edit_product.html
+++ b/app/templates/edit_product.html
@@ -29,11 +29,6 @@
         </div>
 
         <div class="form-group">
-            {{ form.gl_code.label(class="form-label") }}
-            {{ form.gl_code(class="form-control") }}
-        </div>
-
-        <div class="form-group">
             {{ form.cost.label(class="form-label") }}
             {{ form.cost(class="form-control" + (" is-invalid" if form.cost.errors else ""), id="cost") }}
             {% for error in form.cost.errors %}

--- a/tests/test_gl_codes.py
+++ b/tests/test_gl_codes.py
@@ -8,9 +8,9 @@ def setup_data(app):
     with app.app_context():
         user = User(email='gl@example.com', password=generate_password_hash('pass'), active=True)
         purchase = GLCode(code='5100')
-        sales = GLCode.query.filter_by(code='5000').first()
+        sales = GLCode.query.filter_by(code='4000').first()
         if sales is None:
-            sales = GLCode(code='5000')
+            sales = GLCode(code='4000')
         item = Item(name='Widget', base_unit='each')
         db.session.add_all([user, purchase, sales, item])
         db.session.commit()


### PR DESCRIPTION
## Summary
- filter product GL codes to those starting with 4
- drop duplicate GL code dropdown from create/edit product forms
- auto-fill product.gl_code from selected code when none provided
- update sales gl code test to use a sales code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ce1751db48324a2c6dffc24ed761f