### PR TITLE
Add setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ A Flask-based application for managing invoices, products and vendors. The proje
    pip install -r requirements.txt
    ```
 
+## Quick Setup
+
+If you'd like to automate the above steps, run one of the provided setup scripts
+from the project root:
+
+```bash
+./setup_linux.sh       # Linux/macOS
+# or
+powershell -ExecutionPolicy Bypass -File setup_windows.ps1  # Windows
+```
+
+The scripts will create a virtual environment, install the required
+dependencies, prompt for the values of `SECRET_KEY`, `ADMIN_EMAIL`, `ADMIN_PASS`
+and `GST`, and then generate a `.env` file. They also initialize the SQLite
+database and create the required directories.
+
 ## Required Environment Variables
 
 The application requires several variables to be present in your environment:

--- a/scripts/init_app.py
+++ b/scripts/init_app.py
@@ -1,0 +1,7 @@
+"""Initialize InvoiceManager database and admin user."""
+
+from app import create_app
+
+if __name__ == "__main__":
+    create_app([])
+    print("Initialization complete.")

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Setup script for InvoiceManager on Linux/macOS
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+read -p "Flask SECRET_KEY: " SECRET_KEY
+read -p "Admin email: " ADMIN_EMAIL
+read -p "Admin password: " ADMIN_PASS
+read -p "GST number (optional): " GST
+
+cat > .env <<ENV
+SECRET_KEY=$SECRET_KEY
+ADMIN_EMAIL=$ADMIN_EMAIL
+ADMIN_PASS=$ADMIN_PASS
+GST=$GST
+ENV
+
+python3 -m venv venv
+venv/bin/pip install -r requirements.txt
+venv/bin/python scripts/init_app.py
+
+echo "Setup complete. Activate with 'source venv/bin/activate' before running the app."

--- a/setup_windows.ps1
+++ b/setup_windows.ps1
@@ -1,0 +1,16 @@
+# Setup script for InvoiceManager on Windows using PowerShell
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Set-Location $scriptDir
+
+$secret = Read-Host "Flask SECRET_KEY"
+$adminEmail = Read-Host "Admin email"
+$adminPass = Read-Host "Admin password"
+$gst = Read-Host "GST number (optional)"
+
+@"`nSECRET_KEY=$secret`nADMIN_EMAIL=$adminEmail`nADMIN_PASS=$adminPass`nGST=$gst`n"@ | Out-File -Encoding UTF8 .env
+
+python -m venv venv
+.\venv\Scripts\pip install -r requirements.txt
+.\venv\Scripts\python scripts/init_app.py
+
+Write-Host "Setup complete. Activate with 'venv\\Scripts\\Activate.ps1' before running the app."


### PR DESCRIPTION
## Summary
- add quick setup scripts for Linux/macOS and Windows
- document the scripts in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7490bf3883248130d51574556e5d