### PR TITLE
Allow decimal quantities for recipe items

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -196,7 +196,7 @@ class ProductForm(FlaskForm):
 
 class RecipeItemForm(FlaskForm):
     item = SelectField('Item', coerce=int)
-    quantity = IntegerField('Quantity', validators=[InputRequired()])
+    quantity = DecimalField('Quantity', validators=[InputRequired()])
     countable = BooleanField('Countable')
 
 

--- a/tests/test_product_crud_with_recipe.py
+++ b/tests/test_product_crud_with_recipe.py
@@ -93,3 +93,23 @@ def test_recipe_accepts_integer_quantity(client, app):
         prod = Product.query.filter_by(name='Pie').first()
         assert prod is not None
         assert prod.recipe_items[0].quantity == 0
+
+
+def test_recipe_accepts_decimal_quantity(client, app):
+    email, item1_id, _ = setup_user_and_items(app)
+    with client:
+        login(client, email, 'pass')
+        resp = client.post('/products/create', data={
+            'name': 'Muffin',
+            'price': 3,
+            'cost': 1,
+            'gl_code': '4000',
+            'items-0-item': item1_id,
+            'items-0-quantity': 0.5,
+            'items-0-countable': 'y'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+    with app.app_context():
+        prod = Product.query.filter_by(name='Muffin').first()
+        assert prod is not None
+        assert prod.recipe_items[0].quantity == 0.5


### PR DESCRIPTION
## Summary
- use DecimalField for recipe item quantity field
- test support for decimal recipe quantities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648b4bf9e083249e4b9395298af275