### PR TITLE
Add event management

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -105,6 +105,7 @@ def create_app(args: list):
         from app.routes.purchase_routes import purchase
         from app.routes.report_routes import report
         from app.routes.vendor_routes import vendor
+        from app.routes.event_routes import event
         from app.routes.glcode_routes import glcode_bp
         from app.models import User
 
@@ -120,6 +121,7 @@ def create_app(args: list):
         app.register_blueprint(purchase)
         app.register_blueprint(report)
         app.register_blueprint(vendor)
+        app.register_blueprint(event)
         app.register_blueprint(glcode_bp)
 
         db.create_all()

--- a/app/forms.py
+++ b/app/forms.py
@@ -321,3 +321,30 @@ class GLCodeForm(FlaskForm):
     description = StringField('Description', validators=[Optional()])
     submit = SubmitField('Submit')
 
+
+class EventForm(FlaskForm):
+    name = StringField('Name', validators=[DataRequired()])
+    start_date = DateField('Start Date', validators=[DataRequired()])
+    end_date = DateField('End Date', validators=[DataRequired()])
+    submit = SubmitField('Submit')
+
+
+class EventLocationForm(FlaskForm):
+    location_id = SelectField('Location', coerce=int, validators=[DataRequired()])
+    opening_count = DecimalField('Opening Count', validators=[InputRequired()], default=0)
+    closing_count = DecimalField('Closing Count', validators=[Optional()], default=0)
+    submit = SubmitField('Submit')
+
+    def __init__(self, *args, **kwargs):
+        super(EventLocationForm, self).__init__(*args, **kwargs)
+        self.location_id.choices = [(l.id, l.name) for l in Location.query.all()]
+
+
+class TerminalSaleForm(FlaskForm):
+    product_id = SelectField('Product', coerce=int, validators=[DataRequired()])
+    quantity = DecimalField('Quantity', validators=[InputRequired()])
+    submit = SubmitField('Submit')
+
+    def __init__(self, *args, **kwargs):
+        super(TerminalSaleForm, self).__init__(*args, **kwargs)
+        self.product_id.choices = [(p.id, p.name) for p in Product.query.all()]

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -1,0 +1,161 @@
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort
+from flask_login import login_required
+from app import db
+from app.models import Event, EventLocation, TerminalSale, Location, LocationStandItem, Product
+from app.forms import EventForm, EventLocationForm, TerminalSaleForm
+
+
+event = Blueprint('event', __name__)
+
+
+@event.route('/events')
+@login_required
+def view_events():
+    events = Event.query.all()
+    return render_template('events/view_events.html', events=events)
+
+
+@event.route('/events/create', methods=['GET', 'POST'])
+@login_required
+def create_event():
+    form = EventForm()
+    if form.validate_on_submit():
+        ev = Event(name=form.name.data, start_date=form.start_date.data, end_date=form.end_date.data)
+        db.session.add(ev)
+        db.session.commit()
+        flash('Event created')
+        return redirect(url_for('event.view_events'))
+    return render_template('events/create_event.html', form=form)
+
+
+@event.route('/events/<int:event_id>/edit', methods=['GET', 'POST'])
+@login_required
+def edit_event(event_id):
+    ev = db.session.get(Event, event_id)
+    if ev is None:
+        abort(404)
+    form = EventForm(obj=ev)
+    if form.validate_on_submit():
+        ev.name = form.name.data
+        ev.start_date = form.start_date.data
+        ev.end_date = form.end_date.data
+        db.session.commit()
+        flash('Event updated')
+        return redirect(url_for('event.view_events'))
+    return render_template('events/edit_event.html', form=form, event=ev)
+
+
+@event.route('/events/<int:event_id>/delete')
+@login_required
+def delete_event(event_id):
+    ev = db.session.get(Event, event_id)
+    if ev is None:
+        abort(404)
+    db.session.delete(ev)
+    db.session.commit()
+    flash('Event deleted')
+    return redirect(url_for('event.view_events'))
+
+
+@event.route('/events/<int:event_id>')
+@login_required
+def view_event(event_id):
+    ev = db.session.get(Event, event_id)
+    if ev is None:
+        abort(404)
+    return render_template('events/view_event.html', event=ev)
+
+
+@event.route('/events/<int:event_id>/add_location', methods=['GET', 'POST'])
+@login_required
+def add_location(event_id):
+    ev = db.session.get(Event, event_id)
+    if ev is None:
+        abort(404)
+    form = EventLocationForm()
+    if form.validate_on_submit():
+        el = EventLocation(
+            event_id=event_id,
+            location_id=form.location_id.data,
+            opening_count=form.opening_count.data or 0,
+            closing_count=form.closing_count.data or 0,
+        )
+        db.session.add(el)
+        db.session.commit()
+        flash('Location assigned')
+        return redirect(url_for('event.view_event', event_id=event_id))
+    return render_template('events/add_location.html', form=form, event=ev)
+
+
+@event.route('/events/<int:event_id>/locations/<int:el_id>/sales/add', methods=['GET', 'POST'])
+@login_required
+def add_terminal_sale(event_id, el_id):
+    el = db.session.get(EventLocation, el_id)
+    if el is None or el.event_id != event_id:
+        abort(404)
+    form = TerminalSaleForm()
+    if form.validate_on_submit():
+        sale = TerminalSale(
+            event_location_id=el_id,
+            product_id=form.product_id.data,
+            quantity=form.quantity.data,
+        )
+        db.session.add(sale)
+        db.session.commit()
+        flash('Sale recorded')
+        return redirect(url_for('event.view_event', event_id=event_id))
+    return render_template('events/add_terminal_sale.html', form=form, event_location=el)
+
+
+def _get_stand_items(location_id):
+    location = db.session.get(Location, location_id)
+    stand_items = []
+    seen = set()
+    for product_obj in location.products:
+        for recipe_item in product_obj.recipe_items:
+            if recipe_item.countable and recipe_item.item_id not in seen:
+                seen.add(recipe_item.item_id)
+                record = LocationStandItem.query.filter_by(location_id=location_id, item_id=recipe_item.item_id).first()
+                expected = record.expected_count if record else 0
+                stand_items.append({'item': recipe_item.item, 'expected': expected})
+    return location, stand_items
+
+
+@event.route('/events/<int:event_id>/stand_sheet/<int:location_id>')
+@login_required
+def stand_sheet(event_id, location_id):
+    ev = db.session.get(Event, event_id)
+    if ev is None:
+        abort(404)
+    location, stand_items = _get_stand_items(location_id)
+    return render_template('events/stand_sheet.html', event=ev, location=location, stand_items=stand_items)
+
+
+@event.route('/events/<int:event_id>/stand_sheets')
+@login_required
+def bulk_stand_sheets(event_id):
+    ev = db.session.get(Event, event_id)
+    if ev is None:
+        abort(404)
+    data = []
+    for el in ev.locations:
+        loc, items = _get_stand_items(el.location_id)
+        data.append({'location': loc, 'stand_items': items})
+    return render_template('events/bulk_stand_sheets.html', event=ev, data=data)
+
+
+@event.route('/events/<int:event_id>/close')
+@login_required
+def close_event(event_id):
+    ev = db.session.get(Event, event_id)
+    if ev is None:
+        abort(404)
+    for el in ev.locations:
+        lsi = LocationStandItem.query.filter_by(location_id=el.location_id).all()
+        for record in lsi:
+            record.expected_count = el.closing_count
+        TerminalSale.query.filter_by(event_location_id=el.id).delete()
+    ev.closed = True
+    db.session.commit()
+    flash('Event closed')
+    return redirect(url_for('event.view_events'))

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -74,6 +74,9 @@
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('invoice.view_invoices') }}">Invoices</a>
             </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('event.view_events') }}">Events</a>
+            </li>
             {% endif %}
         </ul>
         <ul class="navbar-nav">

--- a/app/templates/events/add_location.html
+++ b/app/templates/events/add_location.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Add Location</h2>
+<form method="post">
+    {{ form.csrf_token }}
+    {{ form.location_id.label }} {{ form.location_id(class='form-control') }}
+    {{ form.opening_count.label }} {{ form.opening_count(class='form-control') }}
+    {{ form.closing_count.label }} {{ form.closing_count(class='form-control') }}
+    {{ form.submit(class='btn btn-primary mt-2') }}
+</form>
+{% endblock %}

--- a/app/templates/events/add_terminal_sale.html
+++ b/app/templates/events/add_terminal_sale.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Add Terminal Sale</h2>
+<form method="post">
+    {{ form.csrf_token }}
+    {{ form.product_id.label }} {{ form.product_id(class='form-control') }}
+    {{ form.quantity.label }} {{ form.quantity(class='form-control') }}
+    {{ form.submit(class='btn btn-primary mt-2') }}
+</form>
+{% endblock %}

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ event.name }} - Stand Sheets</h2>
+{% for entry in data %}
+    <h3>{{ entry.location.name }}</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Item</th>
+                <th>Expected Opening</th>
+                <th>Opening Count</th>
+                <th>Transferred In</th>
+                <th>Transferred Out</th>
+                <th>Eaten</th>
+                <th>Spoiled</th>
+                <th>Closing Count</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for s in entry.stand_items %}
+            <tr>
+                <td>{{ s.item.name }}</td>
+                <td>{{ s.expected }}</td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endfor %}
+{% endblock %}

--- a/app/templates/events/create_event.html
+++ b/app/templates/events/create_event.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Create Event</h2>
+<form method="post">
+    {{ form.csrf_token }}
+    {{ form.name.label }} {{ form.name(class='form-control') }}
+    {{ form.start_date.label }} {{ form.start_date(class='form-control') }}
+    {{ form.end_date.label }} {{ form.end_date(class='form-control') }}
+    {{ form.submit(class='btn btn-primary mt-2') }}
+</form>
+{% endblock %}

--- a/app/templates/events/edit_event.html
+++ b/app/templates/events/edit_event.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Create Event</h2>
+<form method="post">
+    {{ form.csrf_token }}
+    {{ form.name.label }} {{ form.name(class='form-control') }}
+    {{ form.start_date.label }} {{ form.start_date(class='form-control') }}
+    {{ form.end_date.label }} {{ form.end_date(class='form-control') }}
+    {{ form.submit(class='btn btn-primary mt-2') }}
+</form>
+{% endblock %}

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Stand Sheet - {{ location.name }}</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Item</th>
+                <th>Expected Opening</th>
+                <th>Opening Count</th>
+                <th>Transferred In</th>
+                <th>Transferred Out</th>
+                <th>Eaten</th>
+                <th>Spoiled</th>
+                <th>Closing Count</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in stand_items %}
+            <tr>
+                <td>{{ entry.item.name }}</td>
+                <td>{{ entry.expected }}</td>
+                <td><input type="number" class="form-control" name="open_{{ entry.item.id }}"></td>
+                <td><input type="number" class="form-control" name="in_{{ entry.item.id }}"></td>
+                <td><input type="number" class="form-control" name="out_{{ entry.item.id }}"></td>
+                <td><input type="number" class="form-control" name="eaten_{{ entry.item.id }}"></td>
+                <td><input type="number" class="form-control" name="spoiled_{{ entry.item.id }}"></td>
+                <td><input type="number" class="form-control" name="close_{{ entry.item.id }}"></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ event.name }}</h2>
+<p>Start: {{ event.start_date }} End: {{ event.end_date }}</p>
+<a class="btn btn-secondary" href="{{ url_for('event.add_location', event_id=event.id) }}">Add Location</a>
+<a class="btn btn-secondary" href="{{ url_for('event.bulk_stand_sheets', event_id=event.id) }}">Stand Sheets</a>
+<a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
+<ul class="mt-3">
+{% for el in event.locations %}
+    <li>{{ el.location.name }} - <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a> | <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Add Sale</a></li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/app/templates/events/view_events.html
+++ b/app/templates/events/view_events.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Events</h2>
+<a class="btn btn-primary" href="{{ url_for('event.create_event') }}">Create Event</a>
+<table class="table mt-3">
+    <thead>
+        <tr><th>Name</th><th>Start</th><th>End</th><th>Closed</th><th></th></tr>
+    </thead>
+    <tbody>
+    {% for e in events %}
+        <tr>
+            <td>{{ e.name }}</td>
+            <td>{{ e.start_date }}</td>
+            <td>{{ e.end_date }}</td>
+            <td>{{ 'Yes' if e.closed else 'No' }}</td>
+            <td>
+                <a href="{{ url_for('event.view_event', event_id=e.id) }}">View</a>
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/tests/test_event_flow.py
+++ b/tests/test_event_flow.py
@@ -1,0 +1,111 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import (User, Location, Item, ItemUnit, Product, ProductRecipeItem,
+                       LocationStandItem, Event, EventLocation, TerminalSale)
+from tests.test_user_flows import login
+
+
+def setup_event_env(app):
+    with app.app_context():
+        user = User(email='event@example.com', password=generate_password_hash('pass'), active=True)
+        loc = Location(name='EventLoc')
+        item = Item(name='EItem', base_unit='each')
+        product = Product(name='EProd', price=1.0, cost=0.5)
+        db.session.add_all([user, loc, item, product])
+        db.session.commit()
+        iu = ItemUnit(item_id=item.id, name='each', factor=1, receiving_default=True, transfer_default=True)
+        db.session.add(iu)
+        db.session.add(LocationStandItem(location_id=loc.id, item_id=item.id, expected_count=10))
+        db.session.add(ProductRecipeItem(product_id=product.id, item_id=item.id, quantity=1, countable=True))
+        loc.products.append(product)
+        db.session.commit()
+        return user.email, loc.id, product.id
+
+
+def test_event_lifecycle(client, app):
+    email, loc_id, prod_id = setup_event_env(app)
+    with client:
+        login(client, email, 'pass')
+        client.post('/events/create', data={
+            'name': 'Test Event',
+            'start_date': '2023-01-01',
+            'end_date': '2023-01-02'
+        }, follow_redirects=True)
+
+    with app.app_context():
+        ev = Event.query.first()
+        assert ev is not None
+        eid = ev.id
+
+    with client:
+        login(client, email, 'pass')
+        client.post(f'/events/{eid}/add_location', data={
+            'location_id': loc_id,
+            'opening_count': 10,
+            'closing_count': 5
+        }, follow_redirects=True)
+
+    with app.app_context():
+        el = EventLocation.query.filter_by(event_id=eid, location_id=loc_id).first()
+        assert el is not None
+        elid = el.id
+
+    with client:
+        login(client, email, 'pass')
+        client.post(f'/events/{eid}/locations/{elid}/sales/add', data={
+            'product_id': prod_id,
+            'quantity': 3
+        }, follow_redirects=True)
+
+    with app.app_context():
+        sale = TerminalSale.query.filter_by(event_location_id=elid).first()
+        assert sale is not None and sale.quantity == 3
+
+    with client:
+        login(client, email, 'pass')
+        client.get(f'/events/{eid}/close', follow_redirects=True)
+
+    with app.app_context():
+        lsi = LocationStandItem.query.filter_by(location_id=loc_id).first()
+        assert lsi.expected_count == 5
+        assert TerminalSale.query.filter_by(event_location_id=elid).count() == 0
+
+
+def test_bulk_stand_sheet(client, app):
+    email, loc_id, prod_id = setup_event_env(app)
+    with app.app_context():
+        loc2 = Location(name='EventLoc2')
+        db.session.add(loc2)
+        db.session.commit()
+        LocationStandItem(location_id=loc2.id, item_id=Item.query.first().id, expected_count=0)
+        loc2.products.append(Product.query.first())
+        db.session.commit()
+        loc2_id = loc2.id
+
+    with client:
+        login(client, email, 'pass')
+        client.post('/events/create', data={
+            'name': 'BulkEvent',
+            'start_date': '2023-02-01',
+            'end_date': '2023-02-02'
+        }, follow_redirects=True)
+
+    with app.app_context():
+        ev = Event.query.filter_by(name='BulkEvent').first()
+        eid = ev.id
+
+    with client:
+        login(client, email, 'pass')
+        client.post(f'/events/{eid}/add_location', data={
+            'location_id': loc_id,
+            'opening_count': 0,
+            'closing_count': 0
+        }, follow_redirects=True)
+        client.post(f'/events/{eid}/add_location', data={
+            'location_id': loc2_id,
+            'opening_count': 0,
+            'closing_count': 0
+        }, follow_redirects=True)
+        resp = client.get(f'/events/{eid}/stand_sheets')
+        assert resp.status_code == 200
+        assert b'EventLoc' in resp.data and b'EventLoc2' in resp.data


### PR DESCRIPTION
## Summary
- introduce `Event`, `EventLocation`, and `TerminalSale` models
- build forms for events, assigning locations, and terminal sales
- implement blueprint with CRUD routes and stand sheet printing
- add navigation link and templates for event management
- close events by updating expected counts
- test event lifecycle and stand sheet printing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648fbfa2f083249ccb457c7dcee800