### PR TITLE
Separate vendors from customers

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -27,7 +27,7 @@ from wtforms.validators import (
 )
 from wtforms.widgets import CheckboxInput, ListWidget
 
-from app.models import Item, Location, Product, Customer, ItemUnit, GLCode
+from app.models import Item, Location, Product, Customer, Vendor, ItemUnit, GLCode
 from wtforms.validators import ValidationError
 
 
@@ -246,7 +246,7 @@ class ProductSalesReportForm(FlaskForm):
 
 class InvoiceFilterForm(FlaskForm):
     invoice_id = StringField('Invoice ID', validators=[Optional()])
-    vendor_id = SelectField('Vendor', coerce=int, validators=[Optional()])
+    customer_id = SelectField('Customer', coerce=int, validators=[Optional()])
     start_date = DateField('Start Date', validators=[Optional()])
     end_date = DateField('End Date', validators=[Optional()])
     submit = SubmitField('Filter')
@@ -279,7 +279,7 @@ class PurchaseOrderForm(FlaskForm):
 
     def __init__(self, *args, **kwargs):
         super(PurchaseOrderForm, self).__init__(*args, **kwargs)
-        self.vendor.choices = [(c.id, f"{c.first_name} {c.last_name}") for c in Customer.query.all()]
+        self.vendor.choices = [(v.id, f"{v.first_name} {v.last_name}") for v in Vendor.query.all()]
         for item_form in self.items:
             item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
             item_form.product.choices = [(p.id, p.name) for p in Product.query.all()]

--- a/app/models.py
+++ b/app/models.py
@@ -112,6 +112,14 @@ class Customer(db.Model):
     invoices = db.relationship('Invoice', backref='customer', lazy=True)
 
 
+class Vendor(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    first_name = db.Column(db.String(50), nullable=False)
+    last_name = db.Column(db.String(50), nullable=False)
+    gst_exempt = db.Column(db.Boolean, default=False, nullable=False, server_default='0')
+    pst_exempt = db.Column(db.Boolean, default=False, nullable=False, server_default='0')
+
+
 class GLCode(db.Model):
     __tablename__ = 'gl_code'
     id = db.Column(db.Integer, primary_key=True)
@@ -193,14 +201,14 @@ class ProductRecipeItem(db.Model):
 
 class PurchaseOrder(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    vendor_id = db.Column(db.Integer, db.ForeignKey('customer.id'), nullable=False)
+    vendor_id = db.Column(db.Integer, db.ForeignKey('vendor.id'), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     order_date = db.Column(db.Date, nullable=False)
     expected_date = db.Column(db.Date, nullable=False)
     delivery_charge = db.Column(db.Float, nullable=False, default=0.0)
     received = db.Column(db.Boolean, default=False, nullable=False)
     items = relationship('PurchaseOrderItem', backref='purchase_order', cascade='all, delete-orphan')
-    vendor = relationship('Customer')
+    vendor = relationship('Vendor', backref='purchase_orders')
 
 
 class PurchaseOrderItem(db.Model):

--- a/app/routes/invoice_routes.py
+++ b/app/routes/invoice_routes.py
@@ -197,26 +197,26 @@ def get_customer_tax_status(customer_id):
 def view_invoices():
     """List invoices with optional filters."""
     form = InvoiceFilterForm()
-    form.vendor_id.choices = [(-1, 'All')] + [
+    form.customer_id.choices = [(-1, 'All')] + [
         (c.id, f"{c.first_name} {c.last_name}") for c in Customer.query.all()
     ]
 
     # Determine filter values from form submission or query params
     if form.validate_on_submit():
         invoice_id = form.invoice_id.data
-        vendor_id = form.vendor_id.data
+        customer_id = form.customer_id.data
         start_date = form.start_date.data
         end_date = form.end_date.data
     else:
         invoice_id = request.args.get('invoice_id', '')
-        vendor_id = request.args.get('vendor_id', type=int)
+        customer_id = request.args.get('customer_id', type=int)
         start_date_str = request.args.get('start_date')
         end_date_str = request.args.get('end_date')
         start_date = datetime.fromisoformat(start_date_str) if start_date_str else None
         end_date = datetime.fromisoformat(end_date_str) if end_date_str else None
         form.invoice_id.data = invoice_id
-        if vendor_id is not None:
-            form.vendor_id.data = vendor_id
+        if customer_id is not None:
+            form.customer_id.data = customer_id
         if start_date:
             form.start_date.data = start_date
         if end_date:
@@ -225,8 +225,8 @@ def view_invoices():
     query = Invoice.query
     if invoice_id:
         query = query.filter(Invoice.id.ilike(f"%{invoice_id}%"))
-    if vendor_id and vendor_id != -1:
-        query = query.filter(Invoice.customer_id == vendor_id)
+    if customer_id and customer_id != -1:
+        query = query.filter(Invoice.customer_id == customer_id)
     if start_date:
         query = query.filter(Invoice.date_created >= datetime.combine(start_date, datetime.min.time()))
     if end_date:

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -32,6 +32,7 @@ from app.models import (
     Transfer,
     TransferItem,
     Customer,
+    Vendor,
     Product,
     LocationStandItem,
     Invoice,

--- a/app/routes/report_routes.py
+++ b/app/routes/report_routes.py
@@ -32,6 +32,7 @@ from app.models import (
     Transfer,
     TransferItem,
     Customer,
+    Vendor,
     Product,
     LocationStandItem,
     Invoice,

--- a/app/routes/vendor_routes.py
+++ b/app/routes/vendor_routes.py
@@ -32,6 +32,7 @@ from app.models import (
     Transfer,
     TransferItem,
     Customer,
+    Vendor,
     Product,
     LocationStandItem,
     Invoice,
@@ -53,7 +54,7 @@ vendor = Blueprint('vendor', __name__)
 @login_required
 def view_vendors():
     """Display all vendors."""
-    vendors = Customer.query.all()
+    vendors = Vendor.query.all()
     return render_template('view_vendors.html', vendors=vendors)
 
 
@@ -63,7 +64,7 @@ def create_vendor():
     """Create a new vendor."""
     form = CustomerForm()
     if form.validate_on_submit():
-        vendor = Customer(
+        vendor = Vendor(
             first_name=form.first_name.data,
             last_name=form.last_name.data,
             gst_exempt=form.gst_exempt.data,
@@ -81,7 +82,7 @@ def create_vendor():
 @login_required
 def edit_vendor(vendor_id):
     """Edit vendor information."""
-    vendor = db.session.get(Customer, vendor_id)
+    vendor = db.session.get(Vendor, vendor_id)
     if vendor is None:
         abort(404)
     form = CustomerForm()
@@ -109,7 +110,7 @@ def edit_vendor(vendor_id):
 @login_required
 def delete_vendor(vendor_id):
     """Remove a vendor from the system."""
-    vendor = db.session.get(Customer, vendor_id)
+    vendor = db.session.get(Vendor, vendor_id)
     if vendor is None:
         abort(404)
     db.session.delete(vendor)

--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -19,7 +19,7 @@
         {{ form.hidden_tag() }}
         <div class="form-row">
             <div class="col-md-2">{{ form.invoice_id.label }} {{ form.invoice_id(class="form-control") }}</div>
-            <div class="col-md-3">{{ form.vendor_id.label }} {{ form.vendor_id(class="form-control") }}</div>
+            <div class="col-md-3">{{ form.customer_id.label }} {{ form.customer_id(class="form-control") }}</div>
             <div class="col-md-2">{{ form.start_date.label }} {{ form.start_date(class="form-control") }}</div>
             <div class="col-md-2">{{ form.end_date.label }} {{ form.end_date(class="form-control") }}</div>
             <div class="col-md-1 align-self-end"><button type="submit" class="btn btn-primary">Filter</button></div>

--- a/tests/test_invoice_filtering.py
+++ b/tests/test_invoice_filtering.py
@@ -33,11 +33,11 @@ def test_filter_by_invoice_id(client, app):
         assert b'INV3' not in response.data
 
 
-def test_filter_by_vendor(client, app):
+def test_filter_by_customer(client, app):
     user_email, c1_id, c2_id = setup_invoices(app)
     with client:
         login(client, user_email, 'pass')
-        response = client.get(f'/view_invoices?vendor_id={c1_id}', follow_redirects=True)
+        response = client.get(f'/view_invoices?customer_id={c1_id}', follow_redirects=True)
         assert b'INV1' in response.data
         assert b'INV3' in response.data
         assert b'INV2' not in response.data

--- a/tests/test_purchase_flow.py
+++ b/tests/test_purchase_flow.py
@@ -1,6 +1,6 @@
 from werkzeug.security import generate_password_hash
 from app import db
-from app.models import (User, Customer, Item, ItemUnit, Location, PurchaseOrder,
+from app.models import (User, Vendor, Item, ItemUnit, Location, PurchaseOrder,
                         PurchaseOrderItem, PurchaseInvoice, PurchaseInvoiceItem,
                         LocationStandItem, PurchaseOrderItemArchive)
 from tests.test_user_flows import login
@@ -9,7 +9,7 @@ from tests.test_user_flows import login
 def setup_purchase(app):
     with app.app_context():
         user = User(email='buyer@example.com', password=generate_password_hash('pass'), active=True)
-        vendor = Customer(first_name='Vend', last_name='Or')
+        vendor = Vendor(first_name='Vend', last_name='Or')
         item = Item(name='Part', base_unit='each')
         unit = ItemUnit(item=item, name='each', factor=1, receiving_default=True, transfer_default=True)
         location = Location(name='Main')
@@ -25,7 +25,7 @@ def setup_purchase_with_case(app):
     """Setup purchase scenario with an additional case unit."""
     with app.app_context():
         user = User(email='casebuyer@example.com', password=generate_password_hash('pass'), active=True)
-        vendor = Customer(first_name='Vend', last_name='Or')
+        vendor = Vendor(first_name='Vend', last_name='Or')
         item = Item(name='CaseItem', base_unit='each')
         each_unit = ItemUnit(item=item, name='each', factor=1, receiving_default=True, transfer_default=True)
         case_unit = ItemUnit(item=item, name='case', factor=24)
@@ -85,7 +85,7 @@ def test_purchase_and_receive(client, app):
 def test_purchase_order_multiple_items(client, app):
     with app.app_context():
         user = User(email='multi@example.com', password=generate_password_hash('pass'), active=True)
-        vendor = Customer(first_name='Multi', last_name='Vendor')
+        vendor = Vendor(first_name='Multi', last_name='Vendor')
         item1 = Item(name='PartA', base_unit='each')
         item2 = Item(name='PartB', base_unit='each')
         loc = Location(name='Main')

--- a/tests/test_vendor_crud.py
+++ b/tests/test_vendor_crud.py
@@ -1,7 +1,7 @@
 from werkzeug.security import generate_password_hash
 
 from app import db
-from app.models import User, Customer
+from app.models import User, Vendor
 from tests.test_user_flows import login
 
 
@@ -26,7 +26,7 @@ def test_vendor_crud_flow(client, app):
         assert resp.status_code == 200
 
     with app.app_context():
-        vendor = Customer.query.filter_by(first_name='Vend', last_name='Or').first()
+        vendor = Vendor.query.filter_by(first_name='Vend', last_name='Or').first()
         assert vendor is not None
         vid = vendor.id
 
@@ -41,7 +41,7 @@ def test_vendor_crud_flow(client, app):
         assert resp.status_code == 200
 
     with app.app_context():
-        vendor = db.session.get(Customer, vid)
+        vendor = db.session.get(Vendor, vid)
         assert vendor.first_name == 'New'
         assert vendor.pst_exempt
 
@@ -51,5 +51,5 @@ def test_vendor_crud_flow(client, app):
         assert resp.status_code == 200
 
     with app.app_context():
-        vendor = db.session.get(Customer, vid)
+        vendor = db.session.get(Vendor, vid)
         assert vendor is None


### PR DESCRIPTION
## Summary
- add `Vendor` model and reference it from purchase orders
- use customer for invoice filtering
- update vendor routes and forms
- adjust templates and tests for separate vendor model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68649232087483249376bddc6644c1aa