### PR TITLE
Event location confirmation flow

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -331,13 +331,16 @@ class EventForm(FlaskForm):
 
 class EventLocationForm(FlaskForm):
     location_id = SelectField('Location', coerce=int, validators=[DataRequired()])
-    opening_count = DecimalField('Opening Count', validators=[InputRequired()], default=0)
-    closing_count = DecimalField('Closing Count', validators=[Optional()], default=0)
     submit = SubmitField('Submit')
 
     def __init__(self, *args, **kwargs):
         super(EventLocationForm, self).__init__(*args, **kwargs)
         self.location_id.choices = [(l.id, l.name) for l in Location.query.all()]
+
+
+class EventLocationConfirmForm(FlaskForm):
+    closing_count = DecimalField('Closing Count', validators=[InputRequired()], default=0)
+    submit = SubmitField('Confirm')
 
 
 class TerminalSaleForm(FlaskForm):

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash,
 from flask_login import login_required
 from app import db
 from app.models import Event, EventLocation, TerminalSale, Location, LocationStandItem, Product
-from app.forms import EventForm, EventLocationForm, TerminalSaleForm
+from app.forms import EventForm, EventLocationForm, TerminalSaleForm, EventLocationConfirmForm
 
 
 event = Blueprint('event', __name__)
@@ -74,11 +74,13 @@ def add_location(event_id):
         abort(404)
     form = EventLocationForm()
     if form.validate_on_submit():
+        location = db.session.get(Location, form.location_id.data)
+        opening = sum(item.expected_count for item in location.stand_items)
         el = EventLocation(
             event_id=event_id,
             location_id=form.location_id.data,
-            opening_count=form.opening_count.data or 0,
-            closing_count=form.closing_count.data or 0,
+            opening_count=opening,
+            closing_count=0,
         )
         db.session.add(el)
         db.session.commit()
@@ -93,18 +95,31 @@ def add_terminal_sale(event_id, el_id):
     el = db.session.get(EventLocation, el_id)
     if el is None or el.event_id != event_id:
         abort(404)
-    form = TerminalSaleForm()
-    if form.validate_on_submit():
-        sale = TerminalSale(
-            event_location_id=el_id,
-            product_id=form.product_id.data,
-            quantity=form.quantity.data,
-        )
-        db.session.add(sale)
+    if request.method == 'POST':
+        for product in el.location.products:
+            qty = request.form.get(f'qty_{product.id}', type=float)
+            if qty:
+                sale = TerminalSale(event_location_id=el_id, product_id=product.id, quantity=qty)
+                db.session.add(sale)
         db.session.commit()
-        flash('Sale recorded')
+        flash('Sales recorded')
         return redirect(url_for('event.view_event', event_id=event_id))
-    return render_template('events/add_terminal_sale.html', form=form, event_location=el)
+    return render_template('events/add_terminal_sales.html', event_location=el)
+
+
+@event.route('/events/<int:event_id>/locations/<int:el_id>/confirm', methods=['GET', 'POST'])
+@login_required
+def confirm_location(event_id, el_id):
+    el = db.session.get(EventLocation, el_id)
+    if el is None or el.event_id != event_id:
+        abort(404)
+    form = EventLocationConfirmForm()
+    if form.validate_on_submit():
+        el.closing_count = form.closing_count.data or 0
+        db.session.commit()
+        flash('Location confirmed')
+        return redirect(url_for('event.view_event', event_id=event_id))
+    return render_template('events/confirm_location.html', form=form, event_location=el)
 
 
 def _get_stand_items(location_id):

--- a/app/templates/events/add_location.html
+++ b/app/templates/events/add_location.html
@@ -4,8 +4,6 @@
 <form method="post">
     {{ form.csrf_token }}
     {{ form.location_id.label }} {{ form.location_id(class='form-control') }}
-    {{ form.opening_count.label }} {{ form.opening_count(class='form-control') }}
-    {{ form.closing_count.label }} {{ form.closing_count(class='form-control') }}
     {{ form.submit(class='btn btn-primary mt-2') }}
 </form>
 {% endblock %}

--- a/app/templates/events/add_terminal_sales.html
+++ b/app/templates/events/add_terminal_sales.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Terminal Sales - {{ event_location.location.name }}</h2>
+<form method="post">
+    {{ csrf_token() }}
+    <table class="table">
+        <thead>
+            <tr><th>Product</th><th>Quantity</th></tr>
+        </thead>
+        <tbody>
+        {% for product in event_location.location.products %}
+        <tr>
+            <td>{{ product.name }}</td>
+            <td><input type="number" step="any" name="qty_{{ product.id }}" class="form-control"></td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+{% endblock %}

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -31,5 +31,6 @@
         {% endfor %}
         </tbody>
     </table>
+    <div style="page-break-after: always;"></div>
 {% endfor %}
 {% endblock %}

--- a/app/templates/events/confirm_location.html
+++ b/app/templates/events/confirm_location.html
@@ -1,0 +1,9 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Confirm {{ event_location.location.name }} for {{ event_location.event.name }}</h2>
+<form method="post">
+    {{ form.csrf_token }}
+    {{ form.closing_count.label }} {{ form.closing_count(class='form-control') }}
+    {{ form.submit(class='btn btn-primary mt-2') }}
+</form>
+{% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -7,7 +7,7 @@
 <a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
 <ul class="mt-3">
 {% for el in event.locations %}
-    <li>{{ el.location.name }} - <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a> | <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Add Sale</a></li>
+    <li>{{ el.location.name }} - <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a> | <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> | <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a></li>
 {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- use location's stand sheet counts when attaching a location to an event
- streamline terminal sale entry by listing all products for a location
- add a confirmation step for event locations to capture closing count
- improve stand sheet bulk printing with page breaks

## Testing
- `pytest tests/test_event_flow.py::test_event_lifecycle -q` *(fails: AssertionError)*
- `pytest -q` *(fails: 1 failed, 40 passed)*


------
https://chatgpt.com/codex/tasks/task_e_6864953fe09c8324bd3dac0a3fc3d3af