### PR TITLE
Implement location confirmation and show sales on stand sheets

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -331,6 +331,8 @@ class EventForm(FlaskForm):
 
 class EventLocationForm(FlaskForm):
     location_id = SelectField('Location', coerce=int, validators=[DataRequired()])
+    opening_count = DecimalField('Opening Count', validators=[InputRequired()], default=0)
+    closing_count = DecimalField('Closing Count', validators=[Optional()], default=0)
     submit = SubmitField('Submit')
 
     def __init__(self, *args, **kwargs):
@@ -339,7 +341,6 @@ class EventLocationForm(FlaskForm):
 
 
 class EventLocationConfirmForm(FlaskForm):
-    closing_count = DecimalField('Closing Count', validators=[InputRequired()], default=0)
     submit = SubmitField('Confirm')
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -294,6 +294,7 @@ class EventLocation(db.Model):
     location_id = db.Column(db.Integer, db.ForeignKey('location.id'), nullable=False)
     opening_count = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
     closing_count = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
+    confirmed = db.Column(db.Boolean, nullable=False, default=False, server_default='0')
 
     event = relationship('Event', back_populates='locations')
     location = relationship('Location', back_populates='event_locations')

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -74,13 +74,11 @@ def add_location(event_id):
         abort(404)
     form = EventLocationForm()
     if form.validate_on_submit():
-        location = db.session.get(Location, form.location_id.data)
-        opening = sum(item.expected_count for item in location.stand_items)
         el = EventLocation(
             event_id=event_id,
             location_id=form.location_id.data,
-            opening_count=opening,
-            closing_count=0,
+            opening_count=form.opening_count.data or 0,
+            closing_count=form.closing_count.data or 0,
         )
         db.session.add(el)
         db.session.commit()
@@ -95,16 +93,18 @@ def add_terminal_sale(event_id, el_id):
     el = db.session.get(EventLocation, el_id)
     if el is None or el.event_id != event_id:
         abort(404)
-    if request.method == 'POST':
-        for product in el.location.products:
-            qty = request.form.get(f'qty_{product.id}', type=float)
-            if qty:
-                sale = TerminalSale(event_location_id=el_id, product_id=product.id, quantity=qty)
-                db.session.add(sale)
+    form = TerminalSaleForm()
+    if form.validate_on_submit():
+        sale = TerminalSale(
+            event_location_id=el_id,
+            product_id=form.product_id.data,
+            quantity=form.quantity.data,
+        )
+        db.session.add(sale)
         db.session.commit()
-        flash('Sales recorded')
+        flash('Sale recorded')
         return redirect(url_for('event.view_event', event_id=event_id))
-    return render_template('events/add_terminal_sales.html', event_location=el)
+    return render_template('events/add_terminal_sale.html', form=form, event_location=el)
 
 
 @event.route('/events/<int:event_id>/locations/<int:el_id>/confirm', methods=['GET', 'POST'])
@@ -115,24 +115,35 @@ def confirm_location(event_id, el_id):
         abort(404)
     form = EventLocationConfirmForm()
     if form.validate_on_submit():
-        el.closing_count = form.closing_count.data or 0
+        el.confirmed = True
         db.session.commit()
         flash('Location confirmed')
         return redirect(url_for('event.view_event', event_id=event_id))
     return render_template('events/confirm_location.html', form=form, event_location=el)
 
 
-def _get_stand_items(location_id):
+def _get_stand_items(location_id, event_id=None):
     location = db.session.get(Location, location_id)
     stand_items = []
     seen = set()
+
+    sales_by_item = {}
+    if event_id is not None:
+        el = EventLocation.query.filter_by(event_id=event_id, location_id=location_id).first()
+        if el:
+            for sale in el.terminal_sales:
+                for ri in sale.product.recipe_items:
+                    if ri.countable:
+                        sales_by_item[ri.item_id] = sales_by_item.get(ri.item_id, 0) + sale.quantity * ri.quantity
+
     for product_obj in location.products:
         for recipe_item in product_obj.recipe_items:
             if recipe_item.countable and recipe_item.item_id not in seen:
                 seen.add(recipe_item.item_id)
                 record = LocationStandItem.query.filter_by(location_id=location_id, item_id=recipe_item.item_id).first()
                 expected = record.expected_count if record else 0
-                stand_items.append({'item': recipe_item.item, 'expected': expected})
+                sales = sales_by_item.get(recipe_item.item_id, 0)
+                stand_items.append({'item': recipe_item.item, 'expected': expected, 'sales': sales})
     return location, stand_items
 
 
@@ -142,7 +153,7 @@ def stand_sheet(event_id, location_id):
     ev = db.session.get(Event, event_id)
     if ev is None:
         abort(404)
-    location, stand_items = _get_stand_items(location_id)
+    location, stand_items = _get_stand_items(location_id, event_id)
     return render_template('events/stand_sheet.html', event=ev, location=location, stand_items=stand_items)
 
 
@@ -154,7 +165,7 @@ def bulk_stand_sheets(event_id):
         abort(404)
     data = []
     for el in ev.locations:
-        loc, items = _get_stand_items(el.location_id)
+        loc, items = _get_stand_items(el.location_id, event_id)
         data.append({'location': loc, 'stand_items': items})
     return render_template('events/bulk_stand_sheets.html', event=ev, data=data)
 

--- a/app/templates/events/add_location.html
+++ b/app/templates/events/add_location.html
@@ -4,6 +4,8 @@
 <form method="post">
     {{ form.csrf_token }}
     {{ form.location_id.label }} {{ form.location_id(class='form-control') }}
+    {{ form.opening_count.label }} {{ form.opening_count(class='form-control') }}
+    {{ form.closing_count.label }} {{ form.closing_count(class='form-control') }}
     {{ form.submit(class='btn btn-primary mt-2') }}
 </form>
 {% endblock %}

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -13,7 +13,9 @@
                 <th>Transferred Out</th>
                 <th>Eaten</th>
                 <th>Spoiled</th>
+                <th>Terminal Sales</th>
                 <th>Closing Count</th>
+                <th>Variance</th>
             </tr>
         </thead>
         <tbody>
@@ -25,6 +27,8 @@
                 <td></td>
                 <td></td>
                 <td></td>
+                <td></td>
+                <td>{{ s.sales }}</td>
                 <td></td>
                 <td></td>
             </tr>

--- a/app/templates/events/confirm_location.html
+++ b/app/templates/events/confirm_location.html
@@ -3,7 +3,6 @@
 <h2>Confirm {{ event_location.location.name }} for {{ event_location.event.name }}</h2>
 <form method="post">
     {{ form.csrf_token }}
-    {{ form.closing_count.label }} {{ form.closing_count(class='form-control') }}
     {{ form.submit(class='btn btn-primary mt-2') }}
 </form>
 {% endblock %}

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -13,7 +13,9 @@
                 <th>Transferred Out</th>
                 <th>Eaten</th>
                 <th>Spoiled</th>
+                <th>Terminal Sales</th>
                 <th>Closing Count</th>
+                <th>Variance</th>
             </tr>
         </thead>
         <tbody>
@@ -26,10 +28,31 @@
                 <td><input type="number" class="form-control" name="out_{{ entry.item.id }}"></td>
                 <td><input type="number" class="form-control" name="eaten_{{ entry.item.id }}"></td>
                 <td><input type="number" class="form-control" name="spoiled_{{ entry.item.id }}"></td>
+                <td class="sales" data-sales="{{ entry.sales }}">{{ entry.sales }}</td>
                 <td><input type="number" class="form-control" name="close_{{ entry.item.id }}"></td>
+                <td class="variance">0</td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
 </div>
+<script>
+    function calcVariance(row) {
+        const sales = parseFloat(row.querySelector('.sales').dataset.sales) || 0;
+        const open = parseFloat(row.querySelector('input[name^="open_"]').value) || 0;
+        const tin = parseFloat(row.querySelector('input[name^="in_"]').value) || 0;
+        const tout = parseFloat(row.querySelector('input[name^="out_"]').value) || 0;
+        const eaten = parseFloat(row.querySelector('input[name^="eaten_"]').value) || 0;
+        const spoiled = parseFloat(row.querySelector('input[name^="spoiled_"]').value) || 0;
+        const close = parseFloat(row.querySelector('input[name^="close_"]').value) || 0;
+        const variance = open + tin - tout - eaten - spoiled - sales - close;
+        row.querySelector('.variance').textContent = variance.toFixed(2);
+    }
+
+    document.querySelectorAll('tbody tr').forEach(function(row){
+        row.querySelectorAll('input').forEach(function(inp){
+            inp.addEventListener('input', function(){ calcVariance(row); });
+        });
+    });
+</script>
 {% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -7,7 +7,13 @@
 <a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
 <ul class="mt-3">
 {% for el in event.locations %}
-    <li>{{ el.location.name }} - <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a> | <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> | <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a></li>
+    <li>{{ el.location.name }} - <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a> | <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a>
+        {% if el.confirmed %}
+            | Confirmed
+        {% else %}
+            | <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>
+        {% endif %}
+    </li>
 {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `confirmed` flag to event locations and mark confirmed on confirmation
- include opening/closing counts when adding event locations
- display confirmation status on event view
- show terminal sales and live variance in stand sheets
- provide single terminal sale entry form for events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864994dfd988324863355fd195fa895