### PR TITLE
Fix CSRF token display

### DIFF
--- a/app/templates/events/add_terminal_sales.html
+++ b/app/templates/events/add_terminal_sales.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>Terminal Sales - {{ event_location.location.name }}</h2>
 <form method="post">
-    {{ csrf_token() }}
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <table class="table">
         <thead>
             <tr><th>Product</th><th>Quantity</th></tr>


### PR DESCRIPTION
## Summary
- hide CSRF token in terminal sales form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c1734b5c83248693f64c3ba23a92