### PR TITLE
Add borders to stand sheet tables

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -3,7 +3,7 @@
 <h2>{{ event.name }} - Stand Sheets</h2>
 {% for entry in data %}
     <h3>{{ entry.location.name }}</h3>
-    <table class="table">
+    <table class="table table-bordered">
         <thead>
             <tr>
                 <th>Item</th>

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Stand Sheet - {{ location.name }}</h2>
-    <table class="table">
+    <table class="table table-bordered">
         <thead>
             <tr>
                 <th>Item</th>

--- a/app/templates/locations/stand_sheet.html
+++ b/app/templates/locations/stand_sheet.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Stand Sheet - {{ location.name }}</h2>
-    <table class="table">
+    <table class="table table-bordered">
         <thead>
             <tr>
                 <th>Item</th>


### PR DESCRIPTION
## Summary
- improve stand sheet readability for printing by adding `table-bordered` to stand sheet tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864c22999f483249c763fcc0cc38843