### PR TITLE
Fix print styles for table borders

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -19,6 +19,11 @@
                 flex: 0 0 50% !important;
                 max-width: 50% !important;
             }
+            table.table-bordered,
+            table.table-bordered th,
+            table.table-bordered td {
+                border: 1px solid #000 !important;
+            }
         }
 
         .suggestion {


### PR DESCRIPTION
## Summary
- adjust print CSS to ensure table borders show up on paper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864c339ede0832493ca819c7c5ac087