### PR TITLE
Fix stand sheet table borders in print

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -19,7 +19,10 @@
                 flex: 0 0 50% !important;
                 max-width: 50% !important;
             }
-            table.table-bordered,
+            table.table-bordered {
+                border: 1px solid #000 !important;
+                border-collapse: collapse !important;
+            }
             table.table-bordered th,
             table.table-bordered td {
                 border: 1px solid #000 !important;


### PR DESCRIPTION
## Summary
- ensure printed stand sheet tables collapse borders correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c4ab5a788324a6086a87b4ffd48a