### PR TITLE
Add stand sheet persistence for events

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -299,6 +299,7 @@ class EventLocation(db.Model):
     event = relationship('Event', back_populates='locations')
     location = relationship('Location', back_populates='event_locations')
     terminal_sales = relationship('TerminalSale', back_populates='event_location', cascade='all, delete-orphan')
+    stand_sheet_items = relationship('EventStandSheetItem', back_populates='event_location', cascade='all, delete-orphan')
 
     __table_args__ = (db.UniqueConstraint('event_id', 'location_id', name='_event_loc_uc'),)
 
@@ -311,3 +312,22 @@ class TerminalSale(db.Model):
 
     event_location = relationship('EventLocation', back_populates='terminal_sales')
     product = relationship('Product', back_populates='terminal_sales')
+
+
+class EventStandSheetItem(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    event_location_id = db.Column(db.Integer, db.ForeignKey('event_location.id'), nullable=False)
+    item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
+    opening_count = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
+    transferred_in = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
+    transferred_out = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
+    eaten = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
+    spoiled = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
+    closing_count = db.Column(db.Float, nullable=False, default=0.0, server_default='0.0')
+
+    event_location = relationship('EventLocation', back_populates='stand_sheet_items')
+    item = relationship('Item')
+
+    __table_args__ = (
+        db.UniqueConstraint('event_location_id', 'item_id', name='_event_loc_item_uc'),
+    )

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, request, redirect, url_for, flash, abort
 from flask_login import login_required
 from app import db
-from app.models import Event, EventLocation, TerminalSale, Location, LocationStandItem, Product
+from app.models import Event, EventLocation, TerminalSale, Location, LocationStandItem, Product, EventStandSheetItem
 from app.forms import EventForm, EventLocationForm, EventLocationConfirmForm
 
 
@@ -133,6 +133,7 @@ def _get_stand_items(location_id, event_id=None):
     seen = set()
 
     sales_by_item = {}
+    sheet_map = {}
     if event_id is not None:
         el = EventLocation.query.filter_by(event_id=event_id, location_id=location_id).first()
         if el:
@@ -140,6 +141,8 @@ def _get_stand_items(location_id, event_id=None):
                 for ri in sale.product.recipe_items:
                     if ri.countable:
                         sales_by_item[ri.item_id] = sales_by_item.get(ri.item_id, 0) + sale.quantity * ri.quantity
+            for sheet in el.stand_sheet_items:
+                sheet_map[sheet.item_id] = sheet
 
     for product_obj in location.products:
         for recipe_item in product_obj.recipe_items:
@@ -148,17 +151,36 @@ def _get_stand_items(location_id, event_id=None):
                 record = LocationStandItem.query.filter_by(location_id=location_id, item_id=recipe_item.item_id).first()
                 expected = record.expected_count if record else 0
                 sales = sales_by_item.get(recipe_item.item_id, 0)
-                stand_items.append({'item': recipe_item.item, 'expected': expected, 'sales': sales})
+                stand_items.append({'item': recipe_item.item, 'expected': expected, 'sales': sales, 'sheet': sheet_map.get(recipe_item.item_id)})
     return location, stand_items
 
 
-@event.route('/events/<int:event_id>/stand_sheet/<int:location_id>')
+@event.route('/events/<int:event_id>/stand_sheet/<int:location_id>', methods=['GET', 'POST'])
 @login_required
 def stand_sheet(event_id, location_id):
     ev = db.session.get(Event, event_id)
     if ev is None:
         abort(404)
+    el = EventLocation.query.filter_by(event_id=event_id, location_id=location_id).first()
+    if el is None:
+        abort(404)
     location, stand_items = _get_stand_items(location_id, event_id)
+    if request.method == 'POST':
+        for entry in stand_items:
+            item_id = entry['item'].id
+            sheet = EventStandSheetItem.query.filter_by(event_location_id=el.id, item_id=item_id).first()
+            if not sheet:
+                sheet = EventStandSheetItem(event_location_id=el.id, item_id=item_id)
+                db.session.add(sheet)
+            sheet.opening_count = request.form.get(f'open_{item_id}', type=float, default=0) or 0
+            sheet.transferred_in = request.form.get(f'in_{item_id}', type=float, default=0) or 0
+            sheet.transferred_out = request.form.get(f'out_{item_id}', type=float, default=0) or 0
+            sheet.eaten = request.form.get(f'eaten_{item_id}', type=float, default=0) or 0
+            sheet.spoiled = request.form.get(f'spoiled_{item_id}', type=float, default=0) or 0
+            sheet.closing_count = request.form.get(f'close_{item_id}', type=float, default=0) or 0
+        db.session.commit()
+        flash('Stand sheet saved')
+        location, stand_items = _get_stand_items(location_id, event_id)
     return render_template('events/stand_sheet.html', event=ev, location=location, stand_items=stand_items)
 
 

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -3,6 +3,8 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Stand Sheet - {{ location.name }}</h2>
+    <form method="post">
+        {{ csrf_token() }}
     <table class="table table-bordered">
         <thead>
             <tr>
@@ -23,18 +25,20 @@
             <tr>
                 <td>{{ entry.item.name }}</td>
                 <td>{{ entry.expected }}</td>
-                <td><input type="number" class="form-control" name="open_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="in_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="out_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="eaten_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="spoiled_{{ entry.item.id }}"></td>
+                <td><input type="number" class="form-control" name="open_{{ entry.item.id }}" value="{{ entry.sheet.opening_count if entry.sheet else '' }}"></td>
+                <td><input type="number" class="form-control" name="in_{{ entry.item.id }}" value="{{ entry.sheet.transferred_in if entry.sheet else '' }}"></td>
+                <td><input type="number" class="form-control" name="out_{{ entry.item.id }}" value="{{ entry.sheet.transferred_out if entry.sheet else '' }}"></td>
+                <td><input type="number" class="form-control" name="eaten_{{ entry.item.id }}" value="{{ entry.sheet.eaten if entry.sheet else '' }}"></td>
+                <td><input type="number" class="form-control" name="spoiled_{{ entry.item.id }}" value="{{ entry.sheet.spoiled if entry.sheet else '' }}"></td>
                 <td class="sales" data-sales="{{ entry.sales }}">{{ entry.sales }}</td>
-                <td><input type="number" class="form-control" name="close_{{ entry.item.id }}"></td>
+                <td><input type="number" class="form-control" name="close_{{ entry.item.id }}" value="{{ entry.sheet.closing_count if entry.sheet else '' }}"></td>
                 <td class="variance">0</td>
             </tr>
             {% endfor %}
         </tbody>
     </table>
+    <button type="submit" class="btn btn-primary">Save</button>
+    </form>
 </div>
 <script>
     function calcVariance(row) {


### PR DESCRIPTION
## Summary
- support per-event stand sheet item tracking
- allow saving stand sheet counts through UI
- show saved stand sheet values when viewing
- test saving stand sheet values

## Testing
- `pytest tests/test_event_flow.py::test_save_stand_sheet -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864c6f376f4832488077a9cdd08736f