### PR TITLE
Fix CSRF token on stand sheet

### DIFF
--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -4,7 +4,7 @@
 <div class="container mt-4">
     <h2>Stand Sheet - {{ location.name }}</h2>
     <form method="post">
-        {{ csrf_token() }}
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <table class="table table-bordered">
         <thead>
             <tr>


### PR DESCRIPTION
## Summary
- ensure stand sheet form sends CSRF token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864cd936e2c832492d01b4db82ec3cf