### PR TITLE
Prefill terminal sales form inputs

### DIFF
--- a/app/templates/events/add_terminal_sales.html
+++ b/app/templates/events/add_terminal_sales.html
@@ -11,7 +11,10 @@
         {% for product in event_location.location.products %}
         <tr>
             <td>{{ product.name }}</td>
-            <td><input type="number" step="any" name="qty_{{ product.id }}" class="form-control"></td>
+            <td>
+                <input type="number" step="any" name="qty_{{ product.id }}" class="form-control"
+                       value="{{ existing_sales.get(product.id, '') }}">
+            </td>
         </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- persist terminal sales inputs when returning to the page
- allow updating terminal sales records instead of adding duplicates
- test that terminal sales values are shown on revisit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864cdcd10688324909462563af03c2d