### PR TITLE
Add terminal sales upload feature

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from flask_wtf.file import FileRequired
+from flask_wtf.file import FileRequired, FileAllowed
 from wtforms import (
     BooleanField,
     DateField,
@@ -355,3 +355,15 @@ class TerminalSaleForm(FlaskForm):
     def __init__(self, *args, **kwargs):
         super(TerminalSaleForm, self).__init__(*args, **kwargs)
         self.product_id.choices = [(p.id, p.name) for p in Product.query.all()]
+
+
+class TerminalSalesUploadForm(FlaskForm):
+    """Form for uploading terminal sales from XLS or PDF."""
+    file = FileField(
+        "Sales File",
+        validators=[
+            FileRequired(),
+            FileAllowed({"xls", "pdf"}, "Only .xls or .pdf files are allowed."),
+        ],
+    )
+    submit = SubmitField("Upload")

--- a/app/templates/events/upload_terminal_sales.html
+++ b/app/templates/events/upload_terminal_sales.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Upload Terminal Sales for {{ event.name }}</h2>
+<form method="post" enctype="multipart/form-data">
+    {{ form.hidden_tag() }}
+    <div class="form-group">
+        {{ form.file.label }}
+        {{ form.file(class="form-control-file") }}
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+</form>
+{% if unmatched %}
+<div class="alert alert-warning mt-3">
+    <p>Unmatched locations:</p>
+    <ul>
+    {% for name in unmatched %}
+        <li>{{ name }}</li>
+    {% endfor %}
+    </ul>
+</div>
+{% endif %}
+{% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -10,8 +10,9 @@
     <li>{{ el.location.name }} -
         {% if not el.confirmed and not event.closed %}
             <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a> |
-            <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a>
-            | <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>
+            <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> |
+            <a href="{{ url_for('event.upload_terminal_sales', event_id=event.id) }}">Upload Sales</a> |
+            <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>
         {% else %}
             Stand Sheet | Terminal Sales
             {% if el.confirmed %}| Confirmed{% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ Flask-Migrate==4.1.0
 Flask-SocketIO==5.5.1
 
 email_validator==2.2.0
+pandas==1.5.3
+pdfplumber==0.9.0


### PR DESCRIPTION
## Summary
- add `TerminalSalesUploadForm` for XLS/PDF uploads
- implement `/events/<event_id>/sales/upload` route with pandas/pdfplumber parsing
- show an "Upload Sales" link on event pages
- create template for uploading sales
- add pandas and pdfplumber to requirements
- test XLS and PDF uploads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68655b41078c8324bef3cf6c54c5c44e