### PR TITLE
Preserve invoice lines when product removed

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -139,7 +139,7 @@ class Product(db.Model):
     sales_gl_code = relationship('GLCode', foreign_keys=[sales_gl_code_id])
 
     # Define a one-to-many relationship with InvoiceProduct
-    invoice_products = relationship("InvoiceProduct", back_populates="product", cascade="all, delete-orphan")
+    invoice_products = relationship("InvoiceProduct", back_populates="product")
     recipe_items = relationship("ProductRecipeItem", back_populates="product", cascade="all, delete-orphan")
     gl_code_rel = relationship('GLCode', foreign_keys=[gl_code_id], backref='products')
     terminal_sales = relationship('TerminalSale', back_populates='product', cascade='all, delete-orphan')
@@ -176,8 +176,9 @@ class InvoiceProduct(db.Model):
         nullable=False,
     )
     quantity = db.Column(db.Float, nullable=False)
-    product_id = db.Column(db.Integer, db.ForeignKey('product.id', ondelete='CASCADE'), nullable=False)
+    product_id = db.Column(db.Integer, db.ForeignKey('product.id', ondelete='SET NULL'), nullable=True)
     product = relationship("Product", back_populates="invoice_products")
+    product_name = db.Column(db.String(100), nullable=False)
     unit_price = db.Column(db.Float, nullable=False)
     line_subtotal = db.Column(db.Float, nullable=False)
     line_gst = db.Column(db.Float, nullable=False)

--- a/app/routes/invoice_routes.py
+++ b/app/routes/invoice_routes.py
@@ -100,6 +100,7 @@ def create_invoice():
                     invoice_product = InvoiceProduct(
                         invoice_id=invoice.id,
                         product_id=product.id,
+                        product_name=product.name,
                         quantity=quantity,
                         override_gst=override_gst,
                         override_pst=override_pst,
@@ -160,18 +161,22 @@ def view_invoice(invoice_id):
     gst_total = 0
     pst_total = 0
 
+    invoice_lines = []
     for invoice_product in invoice.products:
         # Use stored values instead of recalculating from current product price
         line_total = invoice_product.line_subtotal
         subtotal += line_total
         gst_total += invoice_product.line_gst
         pst_total += invoice_product.line_pst
+        name = invoice_product.product.name if invoice_product.product else invoice_product.product_name
+        invoice_lines.append((invoice_product, name))
 
     total = subtotal + gst_total + pst_total
 
     return render_template(
         'invoices/view_invoice.html',
         invoice=invoice,
+        invoice_lines=invoice_lines,
         subtotal=subtotal,
         gst=gst_total,
         pst=pst_total,

--- a/app/templates/invoices/view_invoice.html
+++ b/app/templates/invoices/view_invoice.html
@@ -28,9 +28,9 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for invoice_product in invoice.products %}
+                    {% for invoice_product, name in invoice_lines %}
                     <tr>
-                        <td>{{ invoice_product.product.name }}</td>
+                        <td>{{ name }}</td>
                         <td>{{ invoice_product.quantity }}</td>
                         <td>${{ "%.2f"|format(invoice_product.unit_price) }}</td>
                         <td>${{ "%.2f"|format(invoice_product.line_subtotal + invoice_product.line_gst +

--- a/tests/test_sales_invoice.py
+++ b/tests/test_sales_invoice.py
@@ -51,3 +51,31 @@ def test_sales_invoice_create_view_delete(client, app):
 
     with app.app_context():
         assert db.session.get(Invoice, invoice_id) is None
+
+
+def test_invoice_survives_product_deletion(client, app):
+    email, cust_id, prod_name, prod_id = setup_sales(app)
+
+    with client:
+        login(client, email, 'pass')
+        resp = client.post('/create_invoice', data={
+            'customer': float(cust_id),
+            'products': f'{prod_name}?1??'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    with app.app_context():
+        invoice = Invoice.query.filter_by(customer_id=cust_id).first()
+        assert invoice is not None
+        invoice_id = invoice.id
+
+    with client:
+        login(client, email, 'pass')
+        resp = client.get(f'/products/{prod_id}/delete', follow_redirects=True)
+        assert resp.status_code == 200
+
+    with client:
+        login(client, email, 'pass')
+        resp = client.get(f'/view_invoice/{invoice_id}')
+        assert resp.status_code == 200
+        assert prod_name.encode() in resp.data


### PR DESCRIPTION
## Summary
- store a product's name on each invoice line
- keep invoice lines when deleting a product
- display stored product name if the product was removed
- test product deletion doesn't remove invoice lines

## Testing
- `pytest -q` *(fails: numpy dtype size mismatch while importing pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68655f94e0a4832488b696f120eb1f56