### PR TITLE
Preserve names on purchase invoice items

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -249,8 +249,18 @@ class PurchaseInvoice(db.Model):
 class PurchaseInvoiceItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     invoice_id = db.Column(db.Integer, db.ForeignKey('purchase_invoice.id'), nullable=False)
-    item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
-    unit_id = db.Column(db.Integer, db.ForeignKey('item_unit.id'), nullable=True)
+    item_id = db.Column(
+        db.Integer,
+        db.ForeignKey('item.id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    unit_id = db.Column(
+        db.Integer,
+        db.ForeignKey('item_unit.id', ondelete='SET NULL'),
+        nullable=True,
+    )
+    item_name = db.Column(db.String(100), nullable=False)
+    unit_name = db.Column(db.String(50), nullable=True)
     quantity = db.Column(db.Float, nullable=False)
     cost = db.Column(db.Float, nullable=False)
     item = relationship('Item')

--- a/app/templates/purchase_invoices/view_purchase_invoice.html
+++ b/app/templates/purchase_invoices/view_purchase_invoice.html
@@ -18,8 +18,10 @@
         <tbody>
         {% for it in invoice.items %}
             <tr>
-                <td>{{ it.item.name }}</td>
-                <td>{% if it.unit %}{{ it.unit.name }}{% endif %}</td>
+                <td>{{ it.item.name if it.item else it.item_name }}</td>
+                <td>
+                    {% if it.unit %}{{ it.unit.name }}{% else %}{{ it.unit_name }}{% endif %}
+                </td>
                 <td>{{ it.quantity }}</td>
                 <td>{{ '%.2f'|format(it.cost) }}</td>
                 <td>{{ '%.2f'|format(it.line_total) }}</td>


### PR DESCRIPTION
## Summary
- keep item and unit names on purchase invoice items
- store those names when receiving an invoice
- fall back to stored names when viewing invoices
- test deleting an item unit after receiving an invoice

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686560fff5348324b5f420b634227285