### PR TITLE
Add data import utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ The tests automatically set the necessary environment variables, so no additiona
 - User authentication and admin features.
 - Reporting and backups.
 
+## Data Import
+
+Administrators can quickly seed the database using sample CSV files located in the
+project root. Place your own data in these files or modify the provided examples:
+
+- `example_gl_codes.csv`
+- `example_locations.csv`
+- `example_products.csv`
+- `example_items.txt`
+- `example_customers.csv`
+- `example_vendors.csv`
+- `example_users.csv`
+
+Visit **Control Panel → Data Imports** in the web interface and click the
+corresponding button to import each dataset.
+
 ## Test Defaults
 
 When running `pytest`, the fixtures in `tests/conftest.py` set up several default values so the application can start without manual configuration:
@@ -71,3 +87,4 @@ These defaults are provided for convenience during testing, but you can override
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+

--- a/app/forms.py
+++ b/app/forms.py
@@ -260,6 +260,11 @@ class RestoreBackupForm(FlaskForm):
     submit = SubmitField('Restore')
 
 
+class ImportForm(FlaskForm):
+    """Simple form used for one-click data imports."""
+    submit = SubmitField('Import')
+
+
 class POItemForm(FlaskForm):
     item = SelectField('Item', coerce=int)
     product = SelectField('Product', coerce=int, validators=[Optional()],

--- a/app/templates/admin/imports.html
+++ b/app/templates/admin/imports.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Data Imports</h2>
+    {% for key,label in labels.items() %}
+    <form action="{{ url_for('admin.import_data', data_type=key) }}" method="post" class="mb-2">
+        {{ forms[key].hidden_tag() }}
+        <button type="submit" class="btn btn-primary">{{ label }}</button>
+    </form>
+    {% endfor %}
+</div>
+{% endblock %}
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -104,6 +104,9 @@
                 <a class="nav-link" href="{{ url_for('admin.backups') }}">Backups</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="{{ url_for('admin.import_page') }}">Data Imports</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('admin.activity_logs') }}">Activity Logs</a>
             </li>
             {% endif %}

--- a/example_customers.csv
+++ b/example_customers.csv
@@ -1,0 +1,3 @@
+first_name,last_name,gst_exempt,pst_exempt
+John,Doe,0,0
+Acme,Corp,1,1

--- a/example_gl_codes.csv
+++ b/example_gl_codes.csv
@@ -1,0 +1,3 @@
+code,description
+4000,Sales Revenue
+5000,Cost of Goods

--- a/example_items.txt
+++ b/example_items.txt
@@ -1,0 +1,3 @@
+Buns
+Patties
+Ketchup

--- a/example_locations.csv
+++ b/example_locations.csv
@@ -1,0 +1,3 @@
+name
+Warehouse
+Front Counter

--- a/example_products.csv
+++ b/example_products.csv
@@ -1,0 +1,3 @@
+name,price,cost,gl_code
+Burger,5.99,3.00,4000
+Fries,2.50,1.00,4000

--- a/example_users.csv
+++ b/example_users.csv
@@ -1,0 +1,3 @@
+email,password,is_admin,active
+admin2@example.com,adminpass,1,1
+user@example.com,userpass,0,1

--- a/example_vendors.csv
+++ b/example_vendors.csv
@@ -1,0 +1,2 @@
+first_name,last_name,gst_exempt,pst_exempt
+Food,Supplier,0,0


### PR DESCRIPTION
## Summary
- create ImportForm
- add admin Data Imports page and routes
- include example CSV and text files for importing
- link Data Imports from nav bar
- document data import process in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686565c9330c83249d103d6bcdc2ada9