### PR TITLE
Add product assignment during location import

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Administrators can quickly seed the database using sample CSV files located in t
 project root. Place your own data in these files or modify the provided examples:
 
 - `example_gl_codes.csv`
-- `example_locations.csv`
+- `example_locations.csv` – includes a `products` column listing product names
+  separated by semicolons. The import will fail if any product name cannot be
+  matched exactly.
 - `example_products.csv`
 - `example_items.txt`
 - `example_customers.csv`

--- a/example_locations.csv
+++ b/example_locations.csv
@@ -1,3 +1,3 @@
-name
-Warehouse
-Front Counter
+name,products
+Warehouse,Burger;Fries
+Front Counter,Burger

--- a/tests/test_location_import.py
+++ b/tests/test_location_import.py
@@ -1,0 +1,38 @@
+import pytest
+from app import db
+from app.models import Location, Product
+from app.routes.auth_routes import _import_locations
+
+
+def test_import_locations_with_products(tmp_path, app):
+    csv_path = tmp_path / "locs.csv"
+    with app.app_context():
+        p1 = Product(name="Burger", price=1.0, cost=0.5)
+        p2 = Product(name="Fries", price=1.0, cost=0.5)
+        db.session.add_all([p1, p2])
+        db.session.commit()
+
+    csv_path.write_text("name,products\nWarehouse,Burger;Fries\n")
+
+    with app.app_context():
+        count = _import_locations(str(csv_path))
+        assert count == 1
+        loc = Location.query.filter_by(name="Warehouse").first()
+        assert loc is not None
+        assert {p.name for p in loc.products} == {"Burger", "Fries"}
+
+
+def test_import_locations_missing_product(tmp_path, app):
+    csv_path = tmp_path / "locs.csv"
+    with app.app_context():
+        db.session.query(Product).delete()
+        db.session.add(Product(name="Burger", price=1.0, cost=0.5))
+        db.session.commit()
+
+    csv_path.write_text("name,products\nWarehouse,Burger;Missing\n")
+
+    with app.app_context():
+        with pytest.raises(ValueError):
+            _import_locations(str(csv_path))
+        assert Location.query.count() == 0
+


### PR DESCRIPTION
## Summary
- allow location import CSVs to reference products
- show import error when a product name cannot be matched
- document new `products` column and update example file
- test the helper used for importing locations

## Testing
- `pytest -q` *(fails: numpy.dtype size changed)*

------
https://chatgpt.com/codex/tasks/task_e_686569f18fac83249b3665fde7080b46