### PR TITLE
Add product recipe import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ project root. Place your own data in these files or modify the provided examples
 - `example_locations.csv` – includes a `products` column listing product names
   separated by semicolons. The import will fail if any product name cannot be
   matched exactly.
-- `example_products.csv`
+- `example_products.csv` – may include a `recipe` column listing item names
+  separated by semicolons. The import will fail if any item name cannot be
+  matched exactly.
 - `example_items.txt`
 - `example_customers.csv`
 - `example_vendors.csv`

--- a/example_products.csv
+++ b/example_products.csv
@@ -1,3 +1,3 @@
-name,price,cost,gl_code
-Burger,5.99,3.00,4000
-Fries,2.50,1.00,4000
+name,price,cost,gl_code,recipe
+Burger,5.99,3.00,4000,Buns;Patties;Ketchup
+Fries,2.50,1.00,4000,

--- a/tests/test_product_import.py
+++ b/tests/test_product_import.py
@@ -1,0 +1,36 @@
+import pytest
+from app import db
+from app.models import Item, Product, ProductRecipeItem
+from app.routes.auth_routes import _import_products
+
+
+def setup_items(app):
+    with app.app_context():
+        bun = Item(name="Buns", base_unit="each")
+        patty = Item(name="Patties", base_unit="each")
+        db.session.add_all([bun, patty])
+        db.session.commit()
+
+
+def test_import_products_with_recipe(tmp_path, app):
+    csv_path = tmp_path / "prods.csv"
+    setup_items(app)
+    csv_path.write_text("name,price,cost,gl_code,recipe\nBurger,5.0,2.0,4000,Buns;Patties\n")
+    with app.app_context():
+        count = _import_products(str(csv_path))
+        assert count == 1
+        prod = Product.query.filter_by(name="Burger").first()
+        assert prod is not None
+        assert {ri.item.name for ri in prod.recipe_items} == {"Buns", "Patties"}
+
+
+def test_import_products_missing_item(tmp_path, app):
+    csv_path = tmp_path / "prods.csv"
+    with app.app_context():
+        db.session.add(Item(name="Buns", base_unit="each"))
+        db.session.commit()
+    csv_path.write_text("name,price,cost,gl_code,recipe\nBurger,5.0,2.0,4000,Buns;Missing\n")
+    with app.app_context():
+        with pytest.raises(ValueError):
+            _import_products(str(csv_path))
+        assert Product.query.count() == 0


### PR DESCRIPTION
## Summary
- support importing products with recipe items via new `_import_products`
- handle unknown items by raising error
- document recipe column in `README`
- update sample `example_products.csv`
- test product import of recipes

## Testing
- `pytest -q` *(fails: numpy.dtype size changed)*

------
https://chatgpt.com/codex/tasks/task_e_68656d1f8da08324aa1105e605c4d763