### PR TITLE
Add recipe support in product imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ or modify the provided examples:
 - `example_locations.csv` – includes a `products` column listing product names
   separated by semicolons. The import will fail if any product name cannot be
   matched exactly.
-- `example_products.csv`
+- `example_products.csv` – may include a `recipe` column listing item names with
+  quantities separated by semicolons (e.g. `Buns:2;Patties:1`). The import will
+  fail if any item name cannot be matched exactly.
 - `example_items.txt`
 - `example_customers.csv`
 - `example_vendors.csv`

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -25,6 +25,7 @@ from app.models import (
     Location,
     Item,
     Product,
+    ProductRecipeItem,
     GLCode,
     Customer,
     Vendor,
@@ -375,6 +376,77 @@ def _import_locations(path):
     return len(pending)
 
 
+def _import_products(path):
+    """Import products with optional recipe items.
+
+    The CSV may include a ``recipe`` column listing item names with optional
+    quantities separated by semicolons, e.g. ``Bun:2;Patty:1``. If any item
+    name cannot be matched exactly, a ``ValueError`` is raised and no products
+    are added.
+    """
+    if not os.path.exists(path):
+        return 0
+
+    pending = []
+    with open(path, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            name = row.get('name', '').strip()
+            if not name:
+                continue
+            if Product.query.filter_by(name=name).first():
+                continue
+
+            gl_code_id = None
+            if row.get('gl_code'):
+                gl = GLCode.query.filter_by(code=row['gl_code']).first()
+                if gl:
+                    gl_code_id = gl.id
+
+            recipe_items = []
+            recipe_field = row.get('recipe', '')
+            if recipe_field:
+                for spec in recipe_field.split(';'):
+                    spec = spec.strip()
+                    if not spec:
+                        continue
+                    if ':' in spec:
+                        item_name, qty_str = spec.split(':', 1)
+                        try:
+                            qty = float(qty_str)
+                        except ValueError:
+                            qty = 0.0
+                    else:
+                        item_name = spec
+                        qty = 1.0
+                    item = Item.query.filter_by(name=item_name.strip()).first()
+                    if not item:
+                        db.session.rollback()
+                        raise ValueError(f'Unknown item: {item_name.strip()}')
+                    recipe_items.append((item.id, qty))
+
+            pending.append((name, float(row['price']), float(row.get('cost', 0) or 0), gl_code_id, recipe_items))
+
+    created = 0
+    for name, price, cost, gl_code_id, recipe_items in pending:
+        product = Product(name=name, price=price, cost=cost, gl_code_id=gl_code_id)
+        db.session.add(product)
+        db.session.flush()
+        for item_id, qty in recipe_items:
+            db.session.add(
+                ProductRecipeItem(
+                    product_id=product.id,
+                    item_id=item_id,
+                    quantity=qty,
+                    countable=False,
+                )
+            )
+        created += 1
+
+    db.session.commit()
+    return created
+
+
 @admin.route('/controlpanel/imports', methods=['GET'])
 @login_required
 def import_page():
@@ -416,29 +488,11 @@ def import_data(data_type):
             flash(str(exc), 'error')
             return redirect(url_for('admin.import_page'))
     elif data_type == 'products':
-        # map gl_code by code if provided
-        count = 0
-        if os.path.exists(path):
-            with open(path, newline='') as csvfile:
-                reader = csv.DictReader(csvfile)
-                for row in reader:
-                    name = row['name']
-                    if Product.query.filter_by(name=name).first():
-                        continue
-                    gl_code_id = None
-                    if row.get('gl_code'):
-                        gl = GLCode.query.filter_by(code=row['gl_code']).first()
-                        if gl:
-                            gl_code_id = gl.id
-                    product = Product(
-                        name=name,
-                        price=float(row['price']),
-                        cost=float(row.get('cost', 0) or 0),
-                        gl_code_id=gl_code_id,
-                    )
-                    db.session.add(product)
-                    count += 1
-            db.session.commit()
+        try:
+            count = _import_products(path)
+        except ValueError as exc:
+            flash(str(exc), 'error')
+            return redirect(url_for('admin.import_page'))
     elif data_type == 'gl_codes':
         count = _import_csv(path, GLCode, {'code': 'code', 'description': 'description'})
     elif data_type == 'items':

--- a/import_files/example_products.csv
+++ b/import_files/example_products.csv
@@ -1,3 +1,3 @@
-name,price,cost,gl_code
-Burger,5.99,3.00,4000
-Fries,2.50,1.00,4000
+name,price,cost,gl_code,recipe
+Burger,5.99,3.00,4000,"Buns:1;Patties:1"
+Fries,2.50,1.00,4000,"Ketchup:0.1"

--- a/tests/test_product_import.py
+++ b/tests/test_product_import.py
@@ -1,0 +1,37 @@
+import pytest
+from app import db
+from app.models import Product, Item, ProductRecipeItem
+from app.routes.auth_routes import _import_products
+
+
+def test_import_products_with_recipe(tmp_path, app):
+    csv_path = tmp_path / "prods.csv"
+    with app.app_context():
+        b = Item(name="Buns", base_unit="each")
+        p = Item(name="Patties", base_unit="each")
+        db.session.add_all([b, p])
+        db.session.commit()
+
+    csv_path.write_text("name,price,cost,gl_code,recipe\nBurger,5,3,4000,Buns:2;Patties:1\n")
+
+    with app.app_context():
+        count = _import_products(str(csv_path))
+        assert count == 1
+        prod = Product.query.filter_by(name="Burger").first()
+        assert prod is not None
+        items = {ri.item.name for ri in prod.recipe_items}
+        assert items == {"Buns", "Patties"}
+        qty_map = {ri.item.name: ri.quantity for ri in prod.recipe_items}
+        assert qty_map["Buns"] == 2
+        assert qty_map["Patties"] == 1
+
+
+def test_import_products_missing_item(tmp_path, app):
+    csv_path = tmp_path / "prods.csv"
+    csv_path.write_text("name,price,cost,gl_code,recipe\nBurger,5,3,4000,Missing:1\n")
+
+    with app.app_context():
+        with pytest.raises(ValueError):
+            _import_products(str(csv_path))
+        assert Product.query.count() == 0
+


### PR DESCRIPTION
## Summary
- allow linking items to products when importing
- add example recipe data for sample products
- document recipe column for product imports
- test product imports with recipe data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658b20fda08324ae8a34afa3604f91