### PR TITLE
Add cost/unit support for item import

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,10 @@ or modify the provided examples:
 - `example_products.csv` – may include a `recipe` column listing item names with
   quantities separated by semicolons (e.g. `Buns:2;Patties:1`). The import will
   fail if any item name cannot be matched exactly.
-- `example_items.txt`
+- `example_items.csv` – includes optional `cost`, `base_unit` and `units`
+  columns. The `units` column lists unit name and factor pairs separated by
+  semicolons (e.g. `each:1;case:12`). The first unit becomes the receiving and
+  transfer default.
 - `example_customers.csv`
 - `example_vendors.csv`
 - `example_users.csv`

--- a/import_files/example_items.csv
+++ b/import_files/example_items.csv
@@ -1,0 +1,4 @@
+name,base_unit,cost,units
+Buns,each,0.2,"each:1;case:12"
+Patties,each,0.5,"each:1;case:24"
+Ketchup,gram,0.05,"gram:1;bottle:1000"

--- a/import_files/example_items.txt
+++ b/import_files/example_items.txt
@@ -1,3 +1,0 @@
-Buns
-Patties
-Ketchup

--- a/tests/test_item_import.py
+++ b/tests/test_item_import.py
@@ -1,0 +1,36 @@
+from app.models import Item, ItemUnit
+from app.routes.auth_routes import _import_items
+
+
+def test_import_items_with_cost_and_units(tmp_path, app):
+    csv_path = tmp_path / "items.csv"
+    csv_path.write_text("name,base_unit,cost,units\nBuns,each,0.25,\"each:1;case:12\"\n")
+
+    with app.app_context():
+        count = _import_items(str(csv_path))
+        assert count == 1
+        item = Item.query.filter_by(name="Buns").first()
+        assert item is not None
+        assert item.base_unit == "each"
+        assert item.cost == 0.25
+        assert len(item.units) == 2
+        names = {u.name for u in item.units}
+        assert names == {"each", "case"}
+        defaults = [u for u in item.units if u.receiving_default and u.transfer_default]
+        assert len(defaults) == 1
+        assert defaults[0].name == "each"
+
+
+def test_import_items_txt(tmp_path, app):
+    txt_path = tmp_path / "items.txt"
+    txt_path.write_text("Widget\n")
+
+    with app.app_context():
+        count = _import_items(str(txt_path))
+        assert count == 1
+        item = Item.query.filter_by(name="Widget").first()
+        assert item is not None
+        assert item.base_unit == "each"
+        assert len(item.units) == 1
+        assert item.units[0].name == "each"
+


### PR DESCRIPTION
## Summary
- support cost and unit parsing in `_import_items`
- update example items file to CSV format with unit definitions
- document new format in README
- adjust import path mapping
- add unit tests for item import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686590e4abf08324acf63850896bd7a2