### PR TITLE
Add GL code linking and recipe unit support

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -196,6 +196,7 @@ class ProductForm(FlaskForm):
 
 class RecipeItemForm(FlaskForm):
     item = SelectField('Item', coerce=int)
+    unit = SelectField('Unit', coerce=int, validators=[Optional()], validate_choice=False)
     quantity = DecimalField('Quantity', validators=[InputRequired()])
     countable = BooleanField('Countable')
 
@@ -208,6 +209,7 @@ class ProductRecipeForm(FlaskForm):
         super(ProductRecipeForm, self).__init__(*args, **kwargs)
         for item_form in self.items:
             item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
+            item_form.unit.choices = [(u.id, u.name) for u in ItemUnit.query.all()]
 
 
 class ProductWithRecipeForm(ProductForm):
@@ -218,6 +220,7 @@ class ProductWithRecipeForm(ProductForm):
         super(ProductWithRecipeForm, self).__init__(*args, **kwargs)
         for item_form in self.items:
             item_form.item.choices = [(i.id, i.name) for i in Item.query.all()]
+            item_form.unit.choices = [(u.id, u.name) for u in ItemUnit.query.all()]
 
 
 class InvoiceForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -193,11 +193,13 @@ class ProductRecipeItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     product_id = db.Column(db.Integer, db.ForeignKey('product.id'), nullable=False)
     item_id = db.Column(db.Integer, db.ForeignKey('item.id'), nullable=False)
+    unit_id = db.Column(db.Integer, db.ForeignKey('item_unit.id'), nullable=True)
     quantity = db.Column(db.Float, nullable=False)
     countable = db.Column(db.Boolean, default=False, nullable=False, server_default='0')
 
     product = relationship('Product', back_populates='recipe_items')
     item = relationship('Item', back_populates='recipe_items')
+    unit = relationship('ItemUnit')
 
 
 class PurchaseOrder(db.Model):

--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -284,8 +284,9 @@ def _get_stand_items(location_id, event_id=None):
             for sale in el.terminal_sales:
                 for ri in sale.product.recipe_items:
                     if ri.countable:
+                        factor = ri.unit.factor if ri.unit else 1
                         sales_by_item[ri.item_id] = (
-                            sales_by_item.get(ri.item_id, 0) + sale.quantity * ri.quantity
+                            sales_by_item.get(ri.item_id, 0) + sale.quantity * ri.quantity * factor
                         )
             for sheet in el.stand_sheet_items:
                 sheet_map[sheet.item_id] = sheet

--- a/app/routes/invoice_routes.py
+++ b/app/routes/invoice_routes.py
@@ -117,7 +117,8 @@ def create_invoice():
                     # Reduce item inventories based on recipe
                     for recipe_item in product.recipe_items:
                         item = recipe_item.item
-                        item.quantity = (item.quantity or 0) - (recipe_item.quantity * quantity)
+                        factor = recipe_item.unit.factor if recipe_item.unit else 1
+                        item.quantity = (item.quantity or 0) - (recipe_item.quantity * factor * quantity)
                 else:
                     flash(f"Product '{product_name}' not found.", 'danger')
 

--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -80,6 +80,7 @@ def create_product():
 
         for item_form in form.items:
             item_id = item_form.item.data
+            unit_id = item_form.unit.data or None
             quantity = item_form.quantity.data
             countable = item_form.countable.data
             if item_id and quantity is not None:
@@ -87,6 +88,7 @@ def create_product():
                     ProductRecipeItem(
                         product_id=product.id,
                         item_id=item_id,
+                        unit_id=unit_id,
                         quantity=quantity,
                         countable=countable,
                     )
@@ -121,6 +123,7 @@ def edit_product(product_id):
         ProductRecipeItem.query.filter_by(product_id=product.id).delete()
         for item_form in form.items:
             item_id = item_form.item.data
+            unit_id = item_form.unit.data or None
             quantity = item_form.quantity.data
             countable = item_form.countable.data
             if item_id and quantity is not None:
@@ -128,6 +131,7 @@ def edit_product(product_id):
                     ProductRecipeItem(
                         product_id=product.id,
                         item_id=item_id,
+                        unit_id=unit_id,
                         quantity=quantity,
                         countable=countable,
                     )
@@ -145,13 +149,17 @@ def edit_product(product_id):
         form.sales_gl_code.data = product.sales_gl_code_id
         form.items.min_entries = max(1, len(product.recipe_items))
         item_choices = [(itm.id, itm.name) for itm in Item.query.all()]
+        unit_choices = [(u.id, u.name) for u in ItemUnit.query.all()]
         for i, recipe_item in enumerate(product.recipe_items):
             if len(form.items) <= i:
                 form.items.append_entry()
                 form.items[i].item.choices = item_choices
+                form.items[i].unit.choices = unit_choices
             else:
                 form.items[i].item.choices = item_choices
+                form.items[i].unit.choices = unit_choices
             form.items[i].item.data = recipe_item.item_id
+            form.items[i].unit.data = recipe_item.unit_id
             form.items[i].quantity.data = recipe_item.quantity
             form.items[i].countable.data = recipe_item.countable
     else:
@@ -174,23 +182,28 @@ def edit_product_recipe(product_id):
         for field in items:
             index = field.split('-')[1]
             item_id = request.form.get(f'items-{index}-item', type=int)
+            unit_id = request.form.get(f'items-{index}-unit', type=int)
             quantity = request.form.get(f'items-{index}-quantity', type=float)
             countable = request.form.get(f'items-{index}-countable') == 'y'
             if item_id and quantity is not None:
-                db.session.add(ProductRecipeItem(product_id=product.id, item_id=item_id, quantity=quantity, countable=countable))
+                db.session.add(ProductRecipeItem(product_id=product.id, item_id=item_id, unit_id=unit_id, quantity=quantity, countable=countable))
         db.session.commit()
         flash('Recipe updated successfully!', 'success')
         return redirect(url_for('product.view_products'))
     elif request.method == 'GET':
         form.items.min_entries = max(1, len(product.recipe_items))
         item_choices = [(itm.id, itm.name) for itm in Item.query.all()]
+        unit_choices = [(u.id, u.name) for u in ItemUnit.query.all()]
         for i, recipe_item in enumerate(product.recipe_items):
             if len(form.items) <= i:
                 form.items.append_entry()
                 form.items[i].item.choices = item_choices
+                form.items[i].unit.choices = unit_choices
             else:
                 form.items[i].item.choices = item_choices
+                form.items[i].unit.choices = unit_choices
             form.items[i].item.data = recipe_item.item_id
+            form.items[i].unit.data = recipe_item.unit_id
             form.items[i].quantity.data = recipe_item.quantity
             form.items[i].countable.data = recipe_item.countable
     return render_template('edit_product_recipe.html', form=form, product=product)
@@ -210,7 +223,8 @@ def calculate_product_cost(product_id):
             qty = float(ri.quantity or 0)
         except (TypeError, ValueError):
             qty = 0
-    total += (item_cost or 0) * qty
+        factor = ri.unit.factor if ri.unit else 1
+        total += (item_cost or 0) * qty * factor
     return jsonify({'cost': total})
 
 

--- a/app/templates/create_product.html
+++ b/app/templates/create_product.html
@@ -52,6 +52,7 @@
             {% for item in form.items %}
             <div class="form-row mb-2 align-items-center">
                 <div class="col">{{ item.item(class="form-control") }}</div>
+                <div class="col">{{ item.unit(class="form-control") }}</div>
                 <div class="col">{{ item.quantity(class="form-control") }}</div>
                 <div class="col-auto form-check d-flex align-items-center">
                     {{ item.countable(class="form-check-input") }}
@@ -78,6 +79,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     const itemOptions = `{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
+    const unitOptions = `{% for val, label in form.items[0].unit.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     const countableLabel = "{{ form.items[0].countable.label.text }}";
     let itemIndex = {{ form.items|length }};
 
@@ -87,6 +89,7 @@ document.addEventListener('DOMContentLoaded', function() {
         row.classList.add('form-row', 'mb-2', 'align-items-center');
         row.innerHTML = `
             <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
+            <div class="col"><select name="items-${itemIndex}-unit" class="form-control">${unitOptions}</select></div>
             <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
             <div class="col-auto form-check d-flex align-items-center">
                 <input type="checkbox" name="items-${itemIndex}-countable" class="form-check-input" id="items-${itemIndex}-countable">

--- a/app/templates/edit_product.html
+++ b/app/templates/edit_product.html
@@ -52,6 +52,7 @@
             {% for item in form.items %}
             <div class="form-row mb-2 align-items-center">
                 <div class="col">{{ item.item(class="form-control") }}</div>
+                <div class="col">{{ item.unit(class="form-control") }}</div>
                 <div class="col">{{ item.quantity(class="form-control") }}</div>
                 <div class="col-auto form-check d-flex align-items-center">
                     {{ item.countable(class="form-check-input") }}
@@ -83,6 +84,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     const itemOptions = `{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
+    const unitOptions = `{% for val, label in form.items[0].unit.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     const countableLabel = "{{ form.items[0].countable.label.text }}";
     let itemIndex = {{ form.items|length }};
 
@@ -92,6 +94,7 @@ document.addEventListener('DOMContentLoaded', function() {
         row.classList.add('form-row', 'mb-2', 'align-items-center');
         row.innerHTML = `
             <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
+            <div class="col"><select name="items-${itemIndex}-unit" class="form-control">${unitOptions}</select></div>
             <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
             <div class="col-auto form-check d-flex align-items-center">
                 <input type="checkbox" name="items-${itemIndex}-countable" class="form-check-input" id="items-${itemIndex}-countable">

--- a/app/templates/items/add_item.html
+++ b/app/templates/items/add_item.html
@@ -14,6 +14,10 @@
             {{ form.base_unit(class="form-control") }}
         </div>
         <div class="form-group">
+            {{ form.gl_code.label }}
+            {{ form.gl_code(class="form-control") }}
+        </div>
+        <div class="form-group">
             {{ form.purchase_gl_code.label }}
             {{ form.purchase_gl_code(class="form-control") }}
         </div>

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -14,6 +14,10 @@
             {{ form.base_unit(class="form-control", value=item.base_unit) }}
         </div>
         <div class="form-group">
+            {{ form.gl_code.label(class="form-label") }}
+            {{ form.gl_code(class="form-control") }}
+        </div>
+        <div class="form-group">
             {{ form.purchase_gl_code.label(class="form-label") }}
             {{ form.purchase_gl_code(class="form-control") }}
         </div>

--- a/tests/test_event_flow.py
+++ b/tests/test_event_flow.py
@@ -48,7 +48,7 @@ def setup_event_env(app):
         )
         db.session.add(
             ProductRecipeItem(
-                product_id=product.id, item_id=item.id, quantity=1, countable=True
+                product_id=product.id, item_id=item.id, unit_id=iu.id, quantity=1, countable=True
             )
         )
         loc.products.append(product)

--- a/tests/test_item_transfer_invoice.py
+++ b/tests/test_item_transfer_invoice.py
@@ -222,7 +222,7 @@ def test_stand_sheet_shows_expected_counts(client, app):
             LocationStandItem(location_id=loc2.id, item_id=item.id, expected_count=0)
         ])
         db.session.add(ProductRecipeItem(product_id=product.id, item_id=item.id,
-                                         quantity=1, countable=True))
+                                         unit_id=unit.id, quantity=1, countable=True))
         loc1.products.append(product)
         loc2.products.append(product)
         db.session.commit()

--- a/tests/test_product_crud_with_recipe.py
+++ b/tests/test_product_crud_with_recipe.py
@@ -11,17 +11,16 @@ def setup_user_and_items(app):
         item2 = Item(name='Sugar', base_unit='gram', quantity=50)
         db.session.add_all([item1, item2])
         db.session.commit()
-        db.session.add_all([
-            ItemUnit(item_id=item1.id, name='gram', factor=1, receiving_default=True, transfer_default=True),
-            ItemUnit(item_id=item2.id, name='gram', factor=1, receiving_default=True, transfer_default=True)
-        ])
+        iu1 = ItemUnit(item_id=item1.id, name='gram', factor=1, receiving_default=True, transfer_default=True)
+        iu2 = ItemUnit(item_id=item2.id, name='gram', factor=1, receiving_default=True, transfer_default=True)
+        db.session.add_all([iu1, iu2])
         db.session.add(user)
         db.session.commit()
-        return user.email, item1.id, item2.id
+        return user.email, item1.id, item2.id, iu1.id, iu2.id
 
 
 def test_create_product_with_recipe_items(client, app):
-    email, item1_id, item2_id = setup_user_and_items(app)
+    email, item1_id, item2_id, unit1_id, unit2_id = setup_user_and_items(app)
     with client:
         login(client, email, 'pass')
         resp = client.post('/products/create', data={
@@ -30,9 +29,11 @@ def test_create_product_with_recipe_items(client, app):
             'cost': 2,
             'gl_code': '4000',
             'items-0-item': item1_id,
+            'items-0-unit': unit1_id,
             'items-0-quantity': 2,
             'items-0-countable': 'y',
             'items-1-item': item2_id,
+            'items-1-unit': unit2_id,
             'items-1-quantity': 1,
             'items-1-countable': ''
         }, follow_redirects=True)
@@ -46,12 +47,12 @@ def test_create_product_with_recipe_items(client, app):
 
 
 def test_edit_product_recipe_on_edit_page(client, app):
-    email, item1_id, item2_id = setup_user_and_items(app)
+    email, item1_id, item2_id, unit1_id, unit2_id = setup_user_and_items(app)
     with app.app_context():
         product = Product(name='Bread', price=3.0, cost=1.0)
         db.session.add(product)
         db.session.commit()
-        db.session.add(ProductRecipeItem(product_id=product.id, item_id=item1_id, quantity=1, countable=True))
+        db.session.add(ProductRecipeItem(product_id=product.id, item_id=item1_id, unit_id=unit1_id, quantity=1, countable=True))
         db.session.commit()
         pid = product.id
     with client:
@@ -62,6 +63,7 @@ def test_edit_product_recipe_on_edit_page(client, app):
             'cost': 1.5,
             'gl_code': '4000',
             'items-0-item': item2_id,
+            'items-0-unit': unit2_id,
             'items-0-quantity': 4,
             'items-0-countable': ''
         }, follow_redirects=True)
@@ -76,7 +78,7 @@ def test_edit_product_recipe_on_edit_page(client, app):
 
 
 def test_recipe_accepts_integer_quantity(client, app):
-    email, item1_id, _ = setup_user_and_items(app)
+    email, item1_id, _, unit1_id, _ = setup_user_and_items(app)
     with client:
         login(client, email, 'pass')
         resp = client.post('/products/create', data={
@@ -85,6 +87,7 @@ def test_recipe_accepts_integer_quantity(client, app):
             'cost': 2,
             'gl_code': '4000',
             'items-0-item': item1_id,
+            'items-0-unit': unit1_id,
             'items-0-quantity': 0,
             'items-0-countable': 'y'
         }, follow_redirects=True)
@@ -96,7 +99,7 @@ def test_recipe_accepts_integer_quantity(client, app):
 
 
 def test_recipe_accepts_decimal_quantity(client, app):
-    email, item1_id, _ = setup_user_and_items(app)
+    email, item1_id, _, unit1_id, _ = setup_user_and_items(app)
     with client:
         login(client, email, 'pass')
         resp = client.post('/products/create', data={
@@ -105,6 +108,7 @@ def test_recipe_accepts_decimal_quantity(client, app):
             'cost': 1,
             'gl_code': '4000',
             'items-0-item': item1_id,
+            'items-0-unit': unit1_id,
             'items-0-quantity': 0.5,
             'items-0-countable': 'y'
         }, follow_redirects=True)

--- a/tests/test_product_recipe.py
+++ b/tests/test_product_recipe.py
@@ -12,17 +12,16 @@ def setup_data(app):
         item2 = Item(name='Sugar', quantity=50, base_unit='gram')
         db.session.add_all([item1, item2])
         db.session.commit()
-        db.session.add_all([
-            ItemUnit(item_id=item1.id, name='gram', factor=1, receiving_default=True, transfer_default=True),
-            ItemUnit(item_id=item2.id, name='gram', factor=1, receiving_default=True, transfer_default=True)
-        ])
+        iu1 = ItemUnit(item_id=item1.id, name='gram', factor=1, receiving_default=True, transfer_default=True)
+        iu2 = ItemUnit(item_id=item2.id, name='gram', factor=1, receiving_default=True, transfer_default=True)
+        db.session.add_all([iu1, iu2])
         db.session.commit()
         product = Product(name='Cake', price=5.0, cost=2.0, quantity=10)
         db.session.add_all([user, customer, product])
         db.session.commit()
         db.session.add_all([
-            ProductRecipeItem(product_id=product.id, item_id=item1.id, quantity=2, countable=True),
-            ProductRecipeItem(product_id=product.id, item_id=item2.id, quantity=1, countable=False)
+            ProductRecipeItem(product_id=product.id, item_id=item1.id, unit_id=iu1.id, quantity=2, countable=True),
+            ProductRecipeItem(product_id=product.id, item_id=item2.id, unit_id=iu2.id, quantity=1, countable=False)
         ])
         db.session.commit()
         return user.email, customer.id, product.name, item1.id, item2.id


### PR DESCRIPTION
## Summary
- show GL code field on item pages
- store unit reference on `ProductRecipeItem`
- allow selecting units when editing product recipes
- adjust inventory and cost calculations for units
- update related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659558d12c8324b0fd5f84e4bc5e87