### PR TITLE
Support units and GL codes in import examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ or modify the provided examples:
   separated by semicolons. The import will fail if any product name cannot be
   matched exactly.
 - `example_products.csv` – may include a `recipe` column listing item names with
-  quantities separated by semicolons (e.g. `Buns:2;Patties:1`). The import will
-  fail if any item name cannot be matched exactly.
-- `example_items.csv` – includes optional `cost`, `base_unit` and `units`
+  quantities and units separated by semicolons (e.g. `Buns:2:each;Patties:1:each`). The import will
+  fail if any item name or unit cannot be matched exactly.
+- `example_items.csv` – includes optional `cost`, `base_unit`, `gl_code` and `units`
   columns. The `units` column lists unit name and factor pairs separated by
   semicolons (e.g. `each:1;case:12`). The first unit becomes the receiving and
-  transfer default.
+  transfer default. The `gl_code` column should reference an existing GL code.
 - `example_customers.csv`
 - `example_vendors.csv`
 - `example_users.csv`

--- a/import_files/example_items.csv
+++ b/import_files/example_items.csv
@@ -1,4 +1,4 @@
-name,base_unit,cost,units
-Buns,each,0.2,"each:1;case:12"
-Patties,each,0.5,"each:1;case:24"
-Ketchup,gram,0.05,"gram:1;bottle:1000"
+name,base_unit,gl_code,cost,units
+Buns,each,5000,0.2,"each:1;case:12"
+Patties,each,5000,0.5,"each:1;case:24"
+Ketchup,gram,5000,0.05,"gram:1;bottle:1000"

--- a/import_files/example_products.csv
+++ b/import_files/example_products.csv
@@ -1,3 +1,3 @@
 name,price,cost,gl_code,recipe
-Burger,5.99,3.00,4000,"Buns:1;Patties:1"
-Fries,2.50,1.00,4000,"Ketchup:0.1"
+Burger,5.99,3.00,4000,"Buns:1:each;Patties:1:each"
+Fries,2.50,1.00,4000,"Ketchup:0.1:gram"

--- a/tests/test_item_import.py
+++ b/tests/test_item_import.py
@@ -1,18 +1,20 @@
-from app.models import Item, ItemUnit
+from app.models import Item, ItemUnit, GLCode
 from app.routes.auth_routes import _import_items
 
 
 def test_import_items_with_cost_and_units(tmp_path, app):
     csv_path = tmp_path / "items.csv"
-    csv_path.write_text("name,base_unit,cost,units\nBuns,each,0.25,\"each:1;case:12\"\n")
+    csv_path.write_text("name,base_unit,gl_code,cost,units\nBuns,each,5000,0.25,\"each:1;case:12\"\n")
 
     with app.app_context():
         count = _import_items(str(csv_path))
         assert count == 1
         item = Item.query.filter_by(name="Buns").first()
+        gl = GLCode.query.filter_by(code="5000").first()
         assert item is not None
         assert item.base_unit == "each"
         assert item.cost == 0.25
+        assert item.gl_code_id == gl.id
         assert len(item.units) == 2
         names = {u.name for u in item.units}
         assert names == {"each", "case"}


### PR DESCRIPTION
## Summary
- support unit names in product import recipes
- allow specifying GL codes when importing items
- update example CSV files and README
- adjust tests for product and item import parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686599ddc1d48324a76a6bd11b5cab42