### PR TITLE
Fix missing current_app import in data import route

### DIFF
--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -560,6 +560,7 @@ def import_page():
 @login_required
 def import_data(data_type):
     """Import a specific data type from example files."""
+    from flask import current_app
     if not current_user.is_admin:
         abort(403)
     form = ImportForm()


### PR DESCRIPTION
## Summary
- fix NameError when importing data by importing `current_app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659e237c808324a4e8f20fa9702df4