### PR TITLE
Fix layout of item and product forms

### DIFF
--- a/app/templates/create_product.html
+++ b/app/templates/create_product.html
@@ -8,44 +8,48 @@
     <form method="POST">
         {{ form.hidden_tag() }}
 
-        <div class="form-group">
-            {{ form.name.label(class="form-label") }}
-            {{ form.name(class="form-control") }}
-            {% if form.name.errors %}
-                <div class="invalid-feedback">
-                    {{ form.name.errors[0] }}
-                </div>
-            {% endif %}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.name.label(class="form-label") }}
+                {{ form.name(class="form-control") }}
+                {% if form.name.errors %}
+                    <div class="invalid-feedback">
+                        {{ form.name.errors[0] }}
+                    </div>
+                {% endif %}
+            </div>
+
+            <div class="col-md-6 mb-3">
+                {{ form.price.label(class="form-label") }}
+                {{ form.price(class="form-control") }}
+                {% if form.price.errors %}
+                    <div class="invalid-feedback">
+                        {{ form.price.errors[0] }}
+                    </div>
+                {% endif %}
+            </div>
         </div>
 
-        <div class="form-group">
-            {{ form.price.label(class="form-label") }}
-            {{ form.price(class="form-control") }}
-            {% if form.price.errors %}
-                <div class="invalid-feedback">
-                    {{ form.price.errors[0] }}
-                </div>
-        {% endif %}
-    </div>
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.cost.label(class="form-label") }}
+                {{ form.cost(class="form-control", id="cost") }}
+                {% if form.cost.errors %}
+                    <div class="invalid-feedback">
+                        {{ form.cost.errors[0] }}
+                    </div>
+                {% endif %}
+            </div>
 
-    <div class="form-group">
-        {{ form.cost.label(class="form-label") }}
-        {{ form.cost(class="form-control", id="cost") }}
-        {% if form.cost.errors %}
-            <div class="invalid-feedback">
-                {{ form.cost.errors[0] }}
-                </div>
-            {% endif %}
-        </div>
-
-        <div class="form-group">
-            {{ form.gl_code_id.label(class="form-label") }}
-            {{ form.gl_code_id(class="form-control") }}
-            {% if form.gl_code_id.errors %}
-                <div class="invalid-feedback">
-                    {{ form.gl_code_id.errors[0] }}
-                </div>
-            {% endif %}
+            <div class="col-md-6 mb-3">
+                {{ form.gl_code_id.label(class="form-label") }}
+                {{ form.gl_code_id(class="form-control") }}
+                {% if form.gl_code_id.errors %}
+                    <div class="invalid-feedback">
+                        {{ form.gl_code_id.errors[0] }}
+                    </div>
+                {% endif %}
+            </div>
         </div>
 
         <div id="item-list">

--- a/app/templates/edit_product.html
+++ b/app/templates/edit_product.html
@@ -8,44 +8,48 @@
     <form method="POST">
         {{ form.hidden_tag() }}
 
-        <div class="form-group">
-            {{ form.name.label(class="form-label") }}
-            {{ form.name(class="form-control" + (" is-invalid" if form.name.errors else "")) }}
-            {% for error in form.name.errors %}
-                <div class="invalid-feedback d-block">
-                    {{ error }}
-                </div>
-            {% endfor %}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.name.label(class="form-label") }}
+                {{ form.name(class="form-control" + (" is-invalid" if form.name.errors else "")) }}
+                {% for error in form.name.errors %}
+                    <div class="invalid-feedback d-block">
+                        {{ error }}
+                    </div>
+                {% endfor %}
+            </div>
+
+            <div class="col-md-6 mb-3">
+                {{ form.price.label(class="form-label") }}
+                {{ form.price(class="form-control" + (" is-invalid" if form.price.errors else "")) }}
+                {% for error in form.price.errors %}
+                    <div class="invalid-feedback d-block">
+                        {{ error }}
+                    </div>
+                {% endfor %}
+            </div>
         </div>
 
-        <div class="form-group">
-            {{ form.price.label(class="form-label") }}
-            {{ form.price(class="form-control" + (" is-invalid" if form.price.errors else "")) }}
-            {% for error in form.price.errors %}
-                <div class="invalid-feedback d-block">
-                    {{ error }}
-                </div>
-            {% endfor %}
-        </div>
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.cost.label(class="form-label") }}
+                {{ form.cost(class="form-control" + (" is-invalid" if form.cost.errors else ""), id="cost") }}
+                {% for error in form.cost.errors %}
+                    <div class="invalid-feedback d-block">
+                        {{ error }}
+                    </div>
+                {% endfor %}
+            </div>
 
-        <div class="form-group">
-            {{ form.cost.label(class="form-label") }}
-            {{ form.cost(class="form-control" + (" is-invalid" if form.cost.errors else ""), id="cost") }}
-            {% for error in form.cost.errors %}
-                <div class="invalid-feedback d-block">
-                    {{ error }}
-                </div>
-            {% endfor %}
-        </div>
-
-        <div class="form-group">
-            {{ form.gl_code_id.label(class="form-label") }}
-            {{ form.gl_code_id(class="form-control" + (" is-invalid" if form.gl_code_id.errors else "")) }}
-            {% for error in form.gl_code_id.errors %}
-                <div class="invalid-feedback d-block">
-                    {{ error }}
-                </div>
-            {% endfor %}
+            <div class="col-md-6 mb-3">
+                {{ form.gl_code_id.label(class="form-label") }}
+                {{ form.gl_code_id(class="form-control" + (" is-invalid" if form.gl_code_id.errors else "")) }}
+                {% for error in form.gl_code_id.errors %}
+                    <div class="invalid-feedback d-block">
+                        {{ error }}
+                    </div>
+                {% endfor %}
+            </div>
         </div>
 
         <div id="item-list">

--- a/app/templates/items/add_item.html
+++ b/app/templates/items/add_item.html
@@ -5,21 +5,25 @@
     <h2>Add Item</h2>
     <form method="POST">
         {{ form.hidden_tag() }}
-        <div class="form-group">
-            {{ form.name.label }}
-            {{ form.name(class="form-control") }}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.name.label(class="form-label") }}
+                {{ form.name(class="form-control") }}
+            </div>
+            <div class="col-md-6 mb-3">
+                {{ form.base_unit.label(class="form-label") }}
+                {{ form.base_unit(class="form-control") }}
+            </div>
         </div>
-        <div class="form-group">
-            {{ form.base_unit.label }}
-            {{ form.base_unit(class="form-control") }}
-        </div>
-        <div class="form-group">
-            {{ form.gl_code.label }}
-            {{ form.gl_code(class="form-control") }}
-        </div>
-        <div class="form-group">
-            {{ form.purchase_gl_code.label }}
-            {{ form.purchase_gl_code(class="form-control") }}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.gl_code.label(class="form-label") }}
+                {{ form.gl_code(class="form-control") }}
+            </div>
+            <div class="col-md-6 mb-3">
+                {{ form.purchase_gl_code.label(class="form-label") }}
+                {{ form.purchase_gl_code(class="form-control") }}
+            </div>
         </div>
         <h4>Units</h4>
         <div id="units-container">

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -5,21 +5,25 @@
     <h2>Edit Item</h2>
     <form method="POST">
         {{ form.hidden_tag() }}
-        <div class="form-group">
-            {{ form.name.label(class="form-label") }}
-            {{ form.name(class="form-control", value=item.name) }}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.name.label(class="form-label") }}
+                {{ form.name(class="form-control", value=item.name) }}
+            </div>
+            <div class="col-md-6 mb-3">
+                {{ form.base_unit.label(class="form-label") }}
+                {{ form.base_unit(class="form-control", value=item.base_unit) }}
+            </div>
         </div>
-        <div class="form-group">
-            {{ form.base_unit.label(class="form-label") }}
-            {{ form.base_unit(class="form-control", value=item.base_unit) }}
-        </div>
-        <div class="form-group">
-            {{ form.gl_code.label(class="form-label") }}
-            {{ form.gl_code(class="form-control") }}
-        </div>
-        <div class="form-group">
-            {{ form.purchase_gl_code.label(class="form-label") }}
-            {{ form.purchase_gl_code(class="form-control") }}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.gl_code.label(class="form-label") }}
+                {{ form.gl_code(class="form-control") }}
+            </div>
+            <div class="col-md-6 mb-3">
+                {{ form.purchase_gl_code.label(class="form-label") }}
+                {{ form.purchase_gl_code(class="form-control") }}
+            </div>
         </div>
         <div class="form-group">
             <label class="form-label">Cost</label>


### PR DESCRIPTION
## Summary
- arrange item fields in rows on add/edit pages
- arrange product fields in rows on create/edit pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a5126a1083249824e739fe5bf8bf