### PR TITLE
Fix row layout for units and recipe items

### DIFF
--- a/app/templates/create_product.html
+++ b/app/templates/create_product.html
@@ -54,7 +54,7 @@
 
         <div id="item-list">
             {% for item in form.items %}
-            <div class="form-row mb-2 align-items-center">
+            <div class="row mb-2 align-items-center">
                 <div class="col">{{ item.item(class="form-control") }}</div>
                 <div class="col">{{ item.unit(class="form-control") }}</div>
                 <div class="col">{{ item.quantity(class="form-control") }}</div>
@@ -87,13 +87,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const countableLabel = "{{ form.items[0].countable.label.text }}";
     let itemIndex = {{ form.items|length }};
 
-    document.getElementById('add-item').addEventListener('click', function(e) {
-        e.preventDefault();
-        const row = document.createElement('div');
-        row.classList.add('form-row', 'mb-2', 'align-items-center');
-        row.innerHTML = `
-            <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
-            <div class="col"><select name="items-${itemIndex}-unit" class="form-control">${unitOptions}</select></div>
+        document.getElementById('add-item').addEventListener('click', function(e) {
+            e.preventDefault();
+            const row = document.createElement('div');
+            row.classList.add('row', 'mb-2', 'align-items-center');
+            row.innerHTML = `
+                <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
+                <div class="col"><select name="items-${itemIndex}-unit" class="form-control">${unitOptions}</select></div>
             <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
             <div class="col-auto form-check d-flex align-items-center">
                 <input type="checkbox" name="items-${itemIndex}-countable" class="form-check-input" id="items-${itemIndex}-countable">
@@ -105,11 +105,11 @@ document.addEventListener('DOMContentLoaded', function() {
         itemIndex++;
     });
 
-    document.getElementById('item-list').addEventListener('click', function(e) {
-        if (e.target && e.target.classList.contains('remove-item')) {
-            e.target.closest('.form-row').remove();
-        }
-    });
+        document.getElementById('item-list').addEventListener('click', function(e) {
+            if (e.target && e.target.classList.contains('remove-item')) {
+                e.target.closest('.row').remove();
+            }
+        });
 });
 </script>
 {% endblock %}

--- a/app/templates/edit_product.html
+++ b/app/templates/edit_product.html
@@ -54,7 +54,7 @@
 
         <div id="item-list">
             {% for item in form.items %}
-            <div class="form-row mb-2 align-items-center">
+            <div class="row mb-2 align-items-center">
                 <div class="col">{{ item.item(class="form-control") }}</div>
                 <div class="col">{{ item.unit(class="form-control") }}</div>
                 <div class="col">{{ item.quantity(class="form-control") }}</div>
@@ -92,13 +92,13 @@ document.addEventListener('DOMContentLoaded', function() {
     const countableLabel = "{{ form.items[0].countable.label.text }}";
     let itemIndex = {{ form.items|length }};
 
-    document.getElementById('add-item').addEventListener('click', function(e) {
-        e.preventDefault();
-        const row = document.createElement('div');
-        row.classList.add('form-row', 'mb-2', 'align-items-center');
-        row.innerHTML = `
-            <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
-            <div class="col"><select name="items-${itemIndex}-unit" class="form-control">${unitOptions}</select></div>
+        document.getElementById('add-item').addEventListener('click', function(e) {
+            e.preventDefault();
+            const row = document.createElement('div');
+            row.classList.add('row', 'mb-2', 'align-items-center');
+            row.innerHTML = `
+                <div class="col"><select name="items-${itemIndex}-item" class="form-control">${itemOptions}</select></div>
+                <div class="col"><select name="items-${itemIndex}-unit" class="form-control">${unitOptions}</select></div>
             <div class="col"><input type="number" step="any" name="items-${itemIndex}-quantity" class="form-control"></div>
             <div class="col-auto form-check d-flex align-items-center">
                 <input type="checkbox" name="items-${itemIndex}-countable" class="form-check-input" id="items-${itemIndex}-countable">
@@ -110,11 +110,11 @@ document.addEventListener('DOMContentLoaded', function() {
         itemIndex++;
     });
 
-    document.getElementById('item-list').addEventListener('click', function(e) {
-        if (e.target && e.target.classList.contains('remove-item')) {
-            e.target.closest('.form-row').remove();
-        }
-    });
+        document.getElementById('item-list').addEventListener('click', function(e) {
+            if (e.target && e.target.classList.contains('remove-item')) {
+                e.target.closest('.row').remove();
+            }
+        });
 });
 </script>
 {% endblock %}

--- a/app/templates/items/add_item.html
+++ b/app/templates/items/add_item.html
@@ -28,7 +28,7 @@
         <h4>Units</h4>
         <div id="units-container">
         {% for unit in form.units %}
-        <div class="form-row mb-2">
+        <div class="row mb-2">
             <div class="col">{{ unit.form.name(class="form-control", placeholder="Name") }}</div>
             <div class="col">{{ unit.form.factor(class="form-control", placeholder="Factor") }}</div>
             <div class="col-auto">{{ unit.form.receiving_default() }} {{ unit.form.receiving_default.label }}</div>
@@ -42,24 +42,24 @@
     </form>
 </div>
 <script>
-    let unitIndex = {{ form.units|length }};
-    document.getElementById('add-unit').addEventListener('click', function() {
-        const container = document.getElementById('units-container');
-        const row = document.createElement('div');
-        row.classList.add('form-row', 'mb-2');
-        row.innerHTML = `
-            <div class="col"><input type="text" name="units-${unitIndex}-name" class="form-control" placeholder="Name"></div>
-            <div class="col"><input type="number" step="any" name="units-${unitIndex}-factor" class="form-control" placeholder="Factor"></div>
+        let unitIndex = {{ form.units|length }};
+        document.getElementById('add-unit').addEventListener('click', function() {
+            const container = document.getElementById('units-container');
+            const row = document.createElement('div');
+            row.classList.add('row', 'mb-2');
+            row.innerHTML = `
+                <div class="col"><input type="text" name="units-${unitIndex}-name" class="form-control" placeholder="Name"></div>
+                <div class="col"><input type="number" step="any" name="units-${unitIndex}-factor" class="form-control" placeholder="Factor"></div>
             <div class="col-auto"><input type="checkbox" name="units-${unitIndex}-receiving_default"> Receiving Default</div>
             <div class="col-auto"><input type="checkbox" name="units-${unitIndex}-transfer_default"> Transfer Default</div>
             <button type="button" class="btn btn-danger btn-sm remove-unit ml-2">Delete</button>`;
         container.appendChild(row);
         unitIndex++;
     });
-    document.getElementById('units-container').addEventListener('click', function(e){
-        if(e.target && e.target.classList.contains('remove-unit')){
-            e.target.closest('.form-row').remove();
-        }
-    });
+        document.getElementById('units-container').addEventListener('click', function(e){
+            if(e.target && e.target.classList.contains('remove-unit')){
+                e.target.closest('.row').remove();
+            }
+        });
 </script>
 {% endblock %}

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -32,7 +32,7 @@
         <h4>Units</h4>
         <div id="units-container">
         {% for unit in form.units %}
-        <div class="form-row mb-2">
+        <div class="row mb-2">
             <div class="col">{{ unit.form.name(class="form-control") }}</div>
             <div class="col">{{ unit.form.factor(class="form-control") }}</div>
             <div class="col-auto">{{ unit.form.receiving_default() }} {{ unit.form.receiving_default.label }}</div>
@@ -46,24 +46,24 @@
     </form>
 </div>
 <script>
-    let unitIndex = {{ form.units|length }};
-    document.getElementById('add-unit').addEventListener('click', function() {
-        const container = document.getElementById('units-container');
-        const row = document.createElement('div');
-        row.classList.add('form-row', 'mb-2');
-        row.innerHTML = `
-            <div class="col"><input type="text" name="units-${unitIndex}-name" class="form-control" placeholder="Name"></div>
-            <div class="col"><input type="number" step="any" name="units-${unitIndex}-factor" class="form-control" placeholder="Factor"></div>
+        let unitIndex = {{ form.units|length }};
+        document.getElementById('add-unit').addEventListener('click', function() {
+            const container = document.getElementById('units-container');
+            const row = document.createElement('div');
+            row.classList.add('row', 'mb-2');
+            row.innerHTML = `
+                <div class="col"><input type="text" name="units-${unitIndex}-name" class="form-control" placeholder="Name"></div>
+                <div class="col"><input type="number" step="any" name="units-${unitIndex}-factor" class="form-control" placeholder="Factor"></div>
             <div class="col-auto"><input type="checkbox" name="units-${unitIndex}-receiving_default"> Receiving Default</div>
             <div class="col-auto"><input type="checkbox" name="units-${unitIndex}-transfer_default"> Transfer Default</div>
             <button type="button" class="btn btn-danger btn-sm remove-unit ml-2">Delete</button>`;
         container.appendChild(row);
         unitIndex++;
     });
-    document.getElementById('units-container').addEventListener('click', function(e){
-        if(e.target && e.target.classList.contains('remove-unit')){
-            e.target.closest('.form-row').remove();
-        }
-    });
+        document.getElementById('units-container').addEventListener('click', function(e){
+            if(e.target && e.target.classList.contains('remove-unit')){
+                e.target.closest('.row').remove();
+            }
+        });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure recipe item fields in create/edit product forms use Bootstrap row classes
- ensure unit of measure inputs in create/edit item forms are displayed in rows

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a6c4bd40832488549154793fba73