### PR TITLE
Implement favourite navigation links

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,6 +15,23 @@ login_manager = LoginManager()
 login_manager.login_view = 'auth.login'
 socketio = None
 GST = 0
+NAV_LINKS = {
+    'transfer.view_transfers': 'Transfers',
+    'item.view_items': 'Items',
+    'locations.view_locations': 'Locations',
+    'product.view_products': 'Products',
+    'glcode.view_gl_codes': 'GL Codes',
+    'purchase.view_purchase_orders': 'Purchase Orders',
+    'purchase.view_purchase_invoices': 'Purchase Invoices',
+    'customer.view_customers': 'Customers',
+    'vendor.view_vendors': 'Vendors',
+    'invoice.view_invoices': 'Invoices',
+    'event.view_events': 'Events',
+    'admin.users': 'Control Panel',
+    'admin.backups': 'Backups',
+    'admin.import_page': 'Data Imports',
+    'admin.activity_logs': 'Activity Logs',
+}
 
 
 @login_manager.user_loader
@@ -91,6 +108,11 @@ def create_app(args: list):
     def inject_gst():
         """Inject the GST constant into all templates."""
         return dict(GST=GST)
+
+    @app.context_processor
+    def inject_nav_links():
+        """Provide navigation labels to templates."""
+        return dict(NAV_LINKS=NAV_LINKS)
 
     with app.app_context():
         from app.routes import auth_routes

--- a/app/models.py
+++ b/app/models.py
@@ -39,6 +39,20 @@ class User(UserMixin, db.Model):
     transfers = db.relationship('Transfer', backref='creator', lazy=True)
     invoices = db.relationship('Invoice', backref='creator', lazy=True)
     active = db.Column(db.Boolean, default=False, nullable=False)
+    favorites = db.Column(db.Text, default='')
+
+    def get_favorites(self):
+        """Return the user's favourite endpoint names as a list."""
+        return [f for f in (self.favorites or '').split(',') if f]
+
+    def toggle_favorite(self, endpoint: str):
+        """Add or remove an endpoint from the favourites list."""
+        favs = set(self.get_favorites())
+        if endpoint in favs:
+            favs.remove(endpoint)
+        else:
+            favs.add(endpoint)
+        self.favorites = ','.join(sorted(favs))
 
 
 class Location(db.Model):

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -103,6 +103,15 @@ def profile():
     return render_template('profile.html', user=current_user, form=form, transfers=transfers, invoices=invoices)
 
 
+@auth.route('/favorite/<path:link>')
+@login_required
+def toggle_favorite(link):
+    """Toggle a navigation link as favourite for the current user."""
+    current_user.toggle_favorite(link)
+    db.session.commit()
+    return redirect(request.referrer or url_for('main.home'))
+
+
 @admin.route('/user_profile/<int:user_id>', methods=['GET', 'POST'])
 @login_required
 def user_profile(user_id):

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -46,6 +46,16 @@
 <nav class="navbar navbar-light bg-light">
     <div class="container-fluid">
         <a class="navbar-brand" href="#">AssetFlow</a>
+        {% if current_user.is_authenticated %}
+        <ul class="navbar-nav me-auto ms-2">
+            {% for fav in current_user.get_favorites() %}
+            {% set label = NAV_LINKS.get(fav, fav.split('.')[-1].replace('_', ' ').title()) %}
+            <li class="nav-item">
+                <a class="nav-link" href="{{ url_for(fav) }}">{{ label }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+        {% endif %}
         <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
@@ -60,36 +70,69 @@
             {% if current_user.is_authenticated %}
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('transfer.view_transfers') }}">Transfers</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='transfer.view_transfers') }}" class="ms-1">
+                    {% if 'transfer.view_transfers' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('item.view_items') }}">Items</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='item.view_items') }}" class="ms-1">
+                    {% if 'item.view_items' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('locations.view_locations') }}">Locations</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='locations.view_locations') }}" class="ms-1">
+                    {% if 'locations.view_locations' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('product.view_products') }}">Products</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='product.view_products') }}" class="ms-1">
+                    {% if 'product.view_products' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('glcode.view_gl_codes') }}">GL Codes</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='glcode.view_gl_codes') }}" class="ms-1">
+                    {% if 'glcode.view_gl_codes' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('purchase.view_purchase_orders') }}">Purchase Orders</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='purchase.view_purchase_orders') }}" class="ms-1">
+                    {% if 'purchase.view_purchase_orders' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('purchase.view_purchase_invoices') }}">Purchase Invoices</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='purchase.view_purchase_invoices') }}" class="ms-1">
+                    {% if 'purchase.view_purchase_invoices' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('customer.view_customers') }}">Customers</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='customer.view_customers') }}" class="ms-1">
+                    {% if 'customer.view_customers' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('vendor.view_vendors') }}">Vendors</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='vendor.view_vendors') }}" class="ms-1">
+                    {% if 'vendor.view_vendors' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('invoice.view_invoices') }}">Invoices</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='invoice.view_invoices') }}" class="ms-1">
+                    {% if 'invoice.view_invoices' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('event.view_events') }}">Events</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='event.view_events') }}" class="ms-1">
+                    {% if 'event.view_events' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             {% endif %}
         </ul>
@@ -105,19 +148,34 @@
             {% if current_user.is_admin %}
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('admin.users') }}">Control Panel</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='admin.users') }}" class="ms-1">
+                    {% if 'admin.users' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('admin.backups') }}">Backups</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='admin.backups') }}" class="ms-1">
+                    {% if 'admin.backups' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('admin.import_page') }}">Data Imports</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='admin.import_page') }}" class="ms-1">
+                    {% if 'admin.import_page' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('admin.activity_logs') }}">Activity Logs</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='admin.activity_logs') }}" class="ms-1">
+                    {% if 'admin.activity_logs' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             {% endif %}
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('auth.profile') }}">Profile</a>
+                <a href="{{ url_for('auth.toggle_favorite', link='auth.profile') }}" class="ms-1">
+                    {% if 'auth.profile' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>


### PR DESCRIPTION
## Summary
- allow users to mark navigation links as favourites
- show favourite links in the top bar for quick access
- persist favourites on the user model
- add toggle route for favourites

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a93881808324a71eeffac6d9f5f5