### PR TITLE
Adjust form widths

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -50,6 +50,10 @@
             width: auto;
         }
         .navbar-nav.flex-row .nav-item { margin-right: 0.5rem; }
+
+        .narrow-field {
+            max-width: 300px;
+        }
     </style>
 </head>
 <body>

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -6,19 +6,19 @@
         {{ form.hidden_tag() }}
         <div class="form-group">
             {{ form.vendor.label(class="form-label") }}
-            {{ form.vendor(class="form-control") }}
+            {{ form.vendor(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.order_date.label(class="form-label") }}
-            {{ form.order_date(class="form-control") }}
+            {{ form.order_date(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.expected_date.label(class="form-label") }}
-            {{ form.expected_date(class="form-control") }}
+            {{ form.expected_date(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.delivery_charge.label(class="form-label") }}
-            {{ form.delivery_charge(class="form-control") }}
+            {{ form.delivery_charge(class="form-control narrow-field") }}
         </div>
         <h4>Items</h4>
         <div id="items">

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -6,19 +6,19 @@
         {{ form.hidden_tag() }}
         <div class="form-group">
             {{ form.vendor.label(class="form-label") }}
-            {{ form.vendor(class="form-control") }}
+            {{ form.vendor(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.order_date.label(class="form-label") }}
-            {{ form.order_date(class="form-control") }}
+            {{ form.order_date(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.expected_date.label(class="form-label") }}
-            {{ form.expected_date(class="form-control") }}
+            {{ form.expected_date(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.delivery_charge.label(class="form-label") }}
-            {{ form.delivery_charge(class="form-control") }}
+            {{ form.delivery_charge(class="form-control narrow-field") }}
         </div>
         <h4>Items</h4>
         <div id="items">

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -6,23 +6,23 @@
         {{ form.hidden_tag() }}
         <div class="form-group">
             {{ form.received_date.label(class="form-label") }}
-            {{ form.received_date(class="form-control") }}
+            {{ form.received_date(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.gst.label(class="form-label") }}
-            {{ form.gst(class="form-control") }}
+            {{ form.gst(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.location_id.label(class="form-label") }}
-            {{ form.location_id(class="form-control") }}
+            {{ form.location_id(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.pst.label(class="form-label") }}
-            {{ form.pst(class="form-control") }}
+            {{ form.pst(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
             {{ form.delivery_charge.label(class="form-label") }}
-            {{ form.delivery_charge(class="form-control") }}
+            {{ form.delivery_charge(class="form-control narrow-field") }}
         </div>
         <h4>Items</h4>
         <div id="items">

--- a/app/templates/transfers/add_transfer.html
+++ b/app/templates/transfers/add_transfer.html
@@ -7,7 +7,7 @@
         {{ form.hidden_tag() }}
         <div class="form-group">
             {{ form.from_location_id.label(class="form-label") }}
-            {{ form.from_location_id(class="form-control") }}
+            {{ form.from_location_id(class="form-control narrow-field") }}
             {% if form.from_location_id.errors %}
             {% for error in form.from_location_id.errors %}
             <div class="alert alert-danger">{{ error }}</div>
@@ -16,7 +16,7 @@
         </div>
         <div class="form-group">
             {{ form.to_location_id.label(class="form-label") }}
-            {{ form.to_location_id(class="form-control") }}
+            {{ form.to_location_id(class="form-control narrow-field") }}
             {% if form.to_location_id.errors %}
             {% for error in form.to_location_id.errors %}
             <div class="alert alert-danger">{{ error }}</div>
@@ -26,7 +26,7 @@
         <h3>Add Items</h3>
         <div class="form-group">
             <label for="item-name" class="form-label">Item Name</label>
-            <input type="text" id="item-name" class="form-control" name="item-name" autocomplete="off">
+            <input type="text" id="item-name" class="form-control narrow-field" name="item-name" autocomplete="off">
             <div id="suggestions"></div>
         </div>
         <div id="item-list" class="mb-3">

--- a/app/templates/transfers/edit_transfer.html
+++ b/app/templates/transfers/edit_transfer.html
@@ -7,7 +7,7 @@
         {{ form.hidden_tag() }}
         <div class="form-group">
             {{ form.from_location_id.label(class="form-label") }}
-            {{ form.from_location_id(class="form-control") }}
+            {{ form.from_location_id(class="form-control narrow-field") }}
             {% if form.from_location_id.errors %}
             {% for error in form.from_location_id.errors %}
             <div class="alert alert-danger">{{ error }}</div>
@@ -16,7 +16,7 @@
         </div>
         <div class="form-group">
             {{ form.to_location_id.label(class="form-label") }}
-            {{ form.to_location_id(class="form-control") }}
+            {{ form.to_location_id(class="form-control narrow-field") }}
             {% if form.to_location_id.errors %}
             {% for error in form.to_location_id.errors %}
             <div class="alert alert-danger">{{ error }}</div>
@@ -26,7 +26,7 @@
         <h3>Add Items</h3>
         <div class="form-group">
             <label for="item-name" class="form-label">Item Name</label>
-            <input type="text" id="item-name" class="form-control" name="item-name" autocomplete="off">
+            <input type="text" id="item-name" class="form-control narrow-field" name="item-name" autocomplete="off">
             <div id="suggestions"></div>
         </div>
         <div id="item-list" class="mb-3">


### PR DESCRIPTION
## Summary
- tweak base template with `.narrow-field` helper class
- reduce form width on transfer add/edit pages
- reduce form width on purchase order and receive invoice forms

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b6cb4fd48324b0101e46e95d718b