### PR TITLE
Fix form layouts on transfer and purchase order pages

### DIFF
--- a/app/templates/edit_product_recipe.html
+++ b/app/templates/edit_product_recipe.html
@@ -6,7 +6,7 @@
         {{ form.hidden_tag() }}
         <div id="item-list">
             {% for item in form.items %}
-            <div class="form-row mb-2 align-items-center">
+            <div class="row g-2 mb-2 align-items-center">
                 <div class="col">{{ item.item(class="form-control") }}</div>
                 <div class="col">{{ item.quantity(class="form-control") }}</div>
                 <div class="col-auto form-check d-flex align-items-center">

--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -17,7 +17,7 @@
 
     <form method="GET" class="mb-4">
         {{ form.hidden_tag() }}
-        <div class="form-row">
+        <div class="row g-2">
             <div class="col-md-2">{{ form.invoice_id.label }} {{ form.invoice_id(class="form-control") }}</div>
             <div class="col-md-3">{{ form.customer_id.label }} {{ form.customer_id(class="form-control") }}</div>
             <div class="col-md-2">{{ form.start_date.label }} {{ form.start_date(class="form-control") }}</div>

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -23,7 +23,7 @@
         <h4>Items</h4>
         <div id="items">
         {% for item in form.items %}
-        <div class="form-row mt-2 item-row align-items-center">
+        <div class="row g-2 mt-2 item-row align-items-center">
             <div class="col">{{ item.item(class="form-control item-select") }}</div>
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
             <div class="col">{{ item.quantity(class="form-control") }}</div>
@@ -44,7 +44,7 @@
 
     function createRow(index) {
         const row = document.createElement('div');
-        row.classList.add('form-row','mt-2','item-row','align-items-center');
+        row.classList.add('row','g-2','mt-2','item-row','align-items-center');
         row.innerHTML = `
             <div class="col"><select name="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
             <div class="col"><select name="items-${index}-unit" class="form-control unit-select"></select></div>
@@ -79,7 +79,7 @@
 
     document.getElementById('items').addEventListener('click', function(e) {
         if (e.target && e.target.classList.contains('remove-item')) {
-            e.target.closest('.form-row').remove();
+            e.target.closest('.row').remove();
         }
     });
 

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -23,7 +23,7 @@
         <h4>Items</h4>
         <div id="items">
         {% for item in form.items %}
-        <div class="form-row mt-2 item-row align-items-center">
+        <div class="row g-2 mt-2 item-row align-items-center">
             <div class="col">{{ item.item(class="form-control item-select") }}</div>
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
             <div class="col">{{ item.quantity(class="form-control") }}</div>
@@ -44,7 +44,7 @@
 
     function createRow(index) {
         const row = document.createElement('div');
-        row.classList.add('form-row','mt-2','item-row','align-items-center');
+        row.classList.add('row','g-2','mt-2','item-row','align-items-center');
         row.innerHTML = `
             <div class="col"><select name="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
             <div class="col"><select name="items-${index}-unit" class="form-control unit-select"></select></div>
@@ -79,7 +79,7 @@
 
     document.getElementById('items').addEventListener('click', function(e) {
         if (e.target && e.target.classList.contains('remove-item')) {
-            e.target.closest('.form-row').remove();
+            e.target.closest('.row').remove();
         }
     });
 

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -27,7 +27,7 @@
         <h4>Items</h4>
         <div id="items">
         {% for item in form.items %}
-        <div class="form-row item-row mb-2 align-items-center">
+        <div class="row g-2 item-row mb-2 align-items-center">
             <div class="col">{{ item.item(class="form-control item-select") }}</div>
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
@@ -56,7 +56,7 @@
 
     function createRow(index) {
         const row = document.createElement('div');
-        row.classList.add('form-row','mb-2','item-row','align-items-center');
+        row.classList.add('row','g-2','mb-2','item-row','align-items-center');
         row.innerHTML = `
             <div class="col"><select name="items-${index}-item" id="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
             <div class="col"><select name="items-${index}-unit" id="items-${index}-unit" class="form-control unit-select"></select></div>

--- a/app/templates/transfers/add_transfer.html
+++ b/app/templates/transfers/add_transfer.html
@@ -84,7 +84,7 @@
                 <div style="padding-left: 15px; font-weight: bold;">${item.name}</div>
                 <div class="d-flex align-items-center">
                     <input type="hidden" name="items-${itemIndex}-item" value="${item.id}">
-                    <select name="items-${itemIndex}-unit" class="form-control mr-2" style="max-width: 120px;">${options}</select>
+                    <select name="items-${itemIndex}-unit" class="form-control me-2" style="max-width: 120px;">${options}</select>
                     <input type="number" step="any" class="form-control quantity" name="items-${itemIndex}-quantity" placeholder="Qty" style="max-width: 120px;">
                     <button type="button" class="btn btn-danger delete-item ml-2">Delete</button>
                 </div>

--- a/app/templates/transfers/edit_transfer.html
+++ b/app/templates/transfers/edit_transfer.html
@@ -88,7 +88,7 @@ function addItemToList(item, index) {
             <div style="padding-left: 15px; font-weight: bold;">${item.name}</div>
             <div class="d-flex align-items-center">
                 <input type="hidden" name="items-${index}-item" value="${item.id}">
-                <select name="items-${index}-unit" class="form-control mr-2" style="max-width: 120px;">${options}</select>
+                <select name="items-${index}-unit" class="form-control me-2" style="max-width: 120px;">${options}</select>
                 <input type="number" step="any" class="form-control quantity" name="items-${index}-quantity" value="${item.quantity}" placeholder="Qty" style="max-width: 120px;">
                 <button type="button" class="btn btn-danger delete-item ml-2">Delete</button>
             </div>

--- a/app/templates/transfers/view_transfers.html
+++ b/app/templates/transfers/view_transfers.html
@@ -5,30 +5,30 @@
     <h2>Transfers List</h2>
     <div class="row mb-3 align-items-center">
         <div class="col-12 col-lg-auto mb-2 mb-lg-0 d-flex align-items-center">
-            <a href="{{ url_for('transfer.add_transfer') }}" class="btn btn-primary mr-2">Add New Transfer</a>
-            <button id="new-transfer-alert" class="btn btn-warning mr-2" onclick="window.location.reload();"
+            <a href="{{ url_for('transfer.add_transfer') }}" class="btn btn-primary me-2">Add New Transfer</a>
+            <button id="new-transfer-alert" class="btn btn-warning me-2" onclick="window.location.reload();"
                     style="display: none;">
                 <img src="{{ url_for('static', filename='img/alert_icon.png') }}" alt="Reload"
                      style="width: 20px; height: 20px;"/>
             </button>
-            <a href="{{ url_for('transfer.generate_report') }}" class="btn btn-info mr-2">Generate Report</a>
+            <a href="{{ url_for('transfer.generate_report') }}" class="btn btn-info me-2">Generate Report</a>
         </div>
     </div>
     <div class="row mb-3 align-items-center">
         <div class="col-12 col-lg d-flex">
-            <form action="" method="get" class="form-inline flex-grow-1">
-                <select name="filter" class="form-control mr-2" onchange="this.form.submit()">
+            <form action="" method="get" class="d-flex flex-wrap align-items-end flex-grow-1">
+                <select name="filter" class="form-control me-2" onchange="this.form.submit()">
                     <option value="not_completed">Not Completed</option>
                     <option value="completed" {% if request.args.get(
                     'filter') == 'completed' %}selected{% endif %}>Completed</option>
                     <option value="all" {% if request.args.get(
                     'filter') == 'all' %}selected{% endif %}>All Transfers</option>
                 </select>
-                <input type="text" name="transfer_id" class="form-control mr-2" placeholder="Transfer ID"
+                <input type="text" name="transfer_id" class="form-control me-2" placeholder="Transfer ID"
                        value="{{ request.args.get('transfer_id', '') }}">
-                <input type="text" name="from_location" class="form-control mr-2" placeholder="From Location"
+                <input type="text" name="from_location" class="form-control me-2" placeholder="From Location"
                        value="{{ request.args.get('from_location', '') }}">
-                <input type="text" name="to_location" class="form-control mr-2" placeholder="To Location"
+                <input type="text" name="to_location" class="form-control me-2" placeholder="To Location"
                        value="{{ request.args.get('to_location', '') }}">
                 <button type="submit" class="btn btn-info">Search</button>
             </form>


### PR DESCRIPTION
## Summary
- align filter inputs on Transfers page using flexbox and update spacing
- ensure purchase order item rows use Bootstrap row classes
- adjust related templates to remove deprecated form-row classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bb26c03c8324be926f22aa12b870