### PR TITLE
Fix tax toggle semantics

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -160,8 +160,11 @@ class DateRangeForm(FlaskForm):
 class CustomerForm(FlaskForm):
     first_name = StringField('First Name', validators=[DataRequired()])
     last_name = StringField('Last Name', validators=[DataRequired()])
-    gst_exempt = BooleanField('GST Exempt')
-    pst_exempt = BooleanField('PST Exempt')
+    # These checkboxes represent whether GST/PST should be charged. The
+    # underlying model stores exemption flags, so we invert these values in
+    # the routes when saving/loading data.
+    gst_exempt = BooleanField('Charge GST')
+    pst_exempt = BooleanField('Charge PST')
     submit = SubmitField('Submit')
 
 

--- a/app/routes/customer_routes.py
+++ b/app/routes/customer_routes.py
@@ -66,8 +66,9 @@ def create_customer():
         customer = Customer(
             first_name=form.first_name.data,
             last_name=form.last_name.data,
-            gst_exempt=form.gst_exempt.data,
-            pst_exempt=form.pst_exempt.data
+            # Checkbox checked means charge tax, so exemption is the inverse
+            gst_exempt=not form.gst_exempt.data,
+            pst_exempt=not form.pst_exempt.data
         )
         db.session.add(customer)
         db.session.commit()
@@ -89,8 +90,9 @@ def edit_customer(customer_id):
     if form.validate_on_submit():
         customer.first_name = form.first_name.data
         customer.last_name = form.last_name.data
-        customer.gst_exempt = form.gst_exempt.data
-        customer.pst_exempt = form.pst_exempt.data
+        # Store exemptions as the inverse of the checkbox state
+        customer.gst_exempt = not form.gst_exempt.data
+        customer.pst_exempt = not form.pst_exempt.data
         db.session.commit()
         log_activity(f'Edited customer {customer.id}')
         flash('Customer updated successfully!', 'success')
@@ -99,8 +101,9 @@ def edit_customer(customer_id):
     elif request.method == 'GET':
         form.first_name.data = customer.first_name
         form.last_name.data = customer.last_name
-        form.gst_exempt.data = customer.gst_exempt
-        form.pst_exempt.data = customer.pst_exempt
+        # Invert stored values so the checkbox represents charging tax
+        form.gst_exempt.data = not customer.gst_exempt
+        form.pst_exempt.data = not customer.pst_exempt
 
     return render_template('edit_customer.html', form=form)
 

--- a/app/routes/vendor_routes.py
+++ b/app/routes/vendor_routes.py
@@ -67,8 +67,9 @@ def create_vendor():
         vendor = Vendor(
             first_name=form.first_name.data,
             last_name=form.last_name.data,
-            gst_exempt=form.gst_exempt.data,
-            pst_exempt=form.pst_exempt.data
+            # Checkbox checked means charge tax, so exemption is the inverse
+            gst_exempt=not form.gst_exempt.data,
+            pst_exempt=not form.pst_exempt.data
         )
         db.session.add(vendor)
         db.session.commit()
@@ -90,8 +91,9 @@ def edit_vendor(vendor_id):
     if form.validate_on_submit():
         vendor.first_name = form.first_name.data
         vendor.last_name = form.last_name.data
-        vendor.gst_exempt = form.gst_exempt.data
-        vendor.pst_exempt = form.pst_exempt.data
+        # Store exemptions as the inverse of the checkbox state
+        vendor.gst_exempt = not form.gst_exempt.data
+        vendor.pst_exempt = not form.pst_exempt.data
         db.session.commit()
         log_activity(f'Edited vendor {vendor.id}')
         flash('Vendor updated successfully!', 'success')
@@ -100,8 +102,9 @@ def edit_vendor(vendor_id):
     elif request.method == 'GET':
         form.first_name.data = vendor.first_name
         form.last_name.data = vendor.last_name
-        form.gst_exempt.data = vendor.gst_exempt
-        form.pst_exempt.data = vendor.pst_exempt
+        # Invert stored values so the checkbox represents charging tax
+        form.gst_exempt.data = not vendor.gst_exempt
+        form.pst_exempt.data = not vendor.pst_exempt
 
     return render_template('edit_vendor.html', form=form)
 

--- a/tests/test_vendor_crud.py
+++ b/tests/test_vendor_crud.py
@@ -20,6 +20,7 @@ def test_vendor_crud_flow(client, app):
         resp = client.post('/vendors/create', data={
             'first_name': 'Vend',
             'last_name': 'Or',
+            # Checked means charge tax. Leave PST unchecked to mark exempt.
             'gst_exempt': 'y',
             'pst_exempt': ''
         }, follow_redirects=True)
@@ -35,6 +36,7 @@ def test_vendor_crud_flow(client, app):
         resp = client.post(f'/vendors/{vid}/edit', data={
             'first_name': 'New',
             'last_name': 'Vendor',
+            # Unchecked = GST exempt, checked = charge PST
             'gst_exempt': '',
             'pst_exempt': 'y'
         }, follow_redirects=True)
@@ -43,7 +45,8 @@ def test_vendor_crud_flow(client, app):
     with app.app_context():
         vendor = db.session.get(Vendor, vid)
         assert vendor.first_name == 'New'
-        assert vendor.pst_exempt
+        # PST checkbox was checked so vendor should not be PST exempt
+        assert not vendor.pst_exempt
 
     with client:
         login(client, email, 'pass')


### PR DESCRIPTION
## Summary
- show `Charge GST` and `Charge PST` checkboxes on customer/vendor forms
- invert checkbox values when saving and loading vendor/customer records
- update vendor CRUD tests for new tax logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e6d00eb88324bbb40eab37e1e5cb