### PR TITLE
Add purchase invoice GL report

### DIFF
--- a/app/templates/purchase_invoices/invoice_gl_report.html
+++ b/app/templates/purchase_invoices/invoice_gl_report.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+    <h2>GL Report for Invoice {{ invoice.id }}</h2>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>GL Code</th>
+                <th>Total</th>
+            </tr>
+        </thead>
+        <tbody>
+        {% for code, total in report %}
+            <tr>
+                <td>{{ code }}</td>
+                <td>{{ '%.2f'|format(total) }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -23,6 +23,7 @@
                 <td>{{ '%.2f'|format(inv.total) }}</td>
                 <td>
                     <a href="{{ url_for('purchase.view_purchase_invoice', invoice_id=inv.id) }}" class="btn btn-sm btn-primary">View</a>
+                    <a href="{{ url_for('purchase.purchase_invoice_report', invoice_id=inv.id) }}" class="btn btn-sm btn-secondary">Report</a>
                     <a href="{{ url_for('purchase.reverse_purchase_invoice', invoice_id=inv.id) }}" class="btn btn-sm btn-danger">Reverse</a>
                 </td>
             </tr>

--- a/tests/test_purchase_flow.py
+++ b/tests/test_purchase_flow.py
@@ -1,8 +1,19 @@
 from werkzeug.security import generate_password_hash
 from app import db
-from app.models import (User, Vendor, Item, ItemUnit, Location, PurchaseOrder,
-                        PurchaseOrderItem, PurchaseInvoice, PurchaseInvoiceItem,
-                        LocationStandItem, PurchaseOrderItemArchive)
+from app.models import (
+    User,
+    Vendor,
+    Item,
+    ItemUnit,
+    Location,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    PurchaseInvoice,
+    PurchaseInvoiceItem,
+    LocationStandItem,
+    PurchaseOrderItemArchive,
+    GLCode,
+)
 from tests.test_user_flows import login
 
 
@@ -412,3 +423,79 @@ def test_invoice_retains_item_and_unit_names_after_unit_removed(client, app):
         assert inv_item.unit is None
         assert inv_item.item_name == 'Part'
         assert inv_item.unit_name == 'each'
+
+
+def test_purchase_invoice_gl_report(client, app):
+    """Report should summarize totals per GL code including taxes and delivery."""
+    with app.app_context():
+        user = User(email='glrep@example.com', password=generate_password_hash('pass'), active=True)
+        vendor = Vendor(first_name='Vend', last_name='Or')
+        gl1 = GLCode(code='5100')
+        gl2 = GLCode(code='5200')
+        item1 = Item(name='PartA', base_unit='each', purchase_gl_code=gl1)
+        item2 = Item(name='PartB', base_unit='each', purchase_gl_code=gl2)
+        unit1 = ItemUnit(item=item1, name='each', factor=1, receiving_default=True, transfer_default=True)
+        unit2 = ItemUnit(item=item2, name='each', factor=1, receiving_default=True, transfer_default=True)
+        loc = Location(name='Main')
+        db.session.add_all([user, vendor, gl1, gl2, item1, item2, unit1, unit2, loc])
+        db.session.commit()
+        db.session.add_all([
+            LocationStandItem(location_id=loc.id, item_id=item1.id, expected_count=0),
+            LocationStandItem(location_id=loc.id, item_id=item2.id, expected_count=0),
+        ])
+        db.session.commit()
+        user_email = user.email
+        vendor_id = vendor.id
+        item1_id = item1.id
+        item2_id = item2.id
+        unit1_id = unit1.id
+        unit2_id = unit2.id
+        location_id = loc.id
+
+    with client:
+        login(client, user_email, 'pass')
+        client.post('/purchase_orders/create', data={
+            'vendor': vendor_id,
+            'order_date': '2023-10-01',
+            'expected_date': '2023-10-05',
+            'items-0-item': item1_id,
+            'items-0-unit': unit1_id,
+            'items-0-quantity': 1,
+            'items-1-item': item2_id,
+            'items-1-unit': unit2_id,
+            'items-1-quantity': 1,
+        }, follow_redirects=True)
+
+    with app.app_context():
+        po_id = PurchaseOrder.query.first().id
+
+    with client:
+        login(client, user_email, 'pass')
+        client.post(f'/purchase_orders/{po_id}/receive', data={
+            'received_date': '2023-10-06',
+            'location_id': location_id,
+            'gst': 1,
+            'pst': 2,
+            'delivery_charge': 3,
+            'items-0-item': item1_id,
+            'items-0-unit': unit1_id,
+            'items-0-quantity': 1,
+            'items-0-cost': 2,
+            'items-1-item': item2_id,
+            'items-1-unit': unit2_id,
+            'items-1-quantity': 1,
+            'items-1-cost': 3,
+        }, follow_redirects=True)
+
+    with app.app_context():
+        inv_id = PurchaseInvoice.query.first().id
+
+    with client:
+        login(client, user_email, 'pass')
+        resp = client.get(f'/purchase_invoices/{inv_id}/report')
+        assert resp.status_code == 200
+        assert b'5100' in resp.data
+        assert b'5200' in resp.data
+        assert b'102702' in resp.data
+        assert b'4.00' in resp.data
+        assert b'6.00' in resp.data


### PR DESCRIPTION
## Summary
- add report route to summarize purchase invoice totals by GL code
- link to report from purchase invoices list
- create GL report template
- test purchase invoice GL reporting logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866048f9d2c832487388c6b3a211f82