### PR TITLE
Add vendor invoice number field

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -306,6 +306,7 @@ class InvoiceItemReceiveForm(FlaskForm):
 
 
 class ReceiveInvoiceForm(FlaskForm):
+    invoice_number = StringField('Invoice Number', validators=[Optional()])
     received_date = DateField('Received Date', validators=[DataRequired()])
     location_id = SelectField('Location', coerce=int, validators=[DataRequired()])
     gst = DecimalField('GST Amount', validators=[Optional()], default=0)

--- a/app/models.py
+++ b/app/models.py
@@ -246,6 +246,7 @@ class PurchaseInvoice(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     location_id = db.Column(db.Integer, db.ForeignKey('location.id'), nullable=False)
     received_date = db.Column(db.Date, nullable=False)
+    invoice_number = db.Column(db.String(50), nullable=True)
     gst = db.Column(db.Float, nullable=False, default=0.0)
     pst = db.Column(db.Float, nullable=False, default=0.0)
     delivery_charge = db.Column(db.Float, nullable=False, default=0.0)

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -223,6 +223,7 @@ def receive_invoice(po_id):
             user_id=current_user.id,
             location_id=form.location_id.data,
             received_date=form.received_date.data,
+            invoice_number=form.invoice_number.data,
             gst=form.gst.data or 0.0,
             pst=form.pst.data or 0.0,
             delivery_charge=form.delivery_charge.data or 0.0,

--- a/app/templates/purchase_invoices/invoice_gl_report.html
+++ b/app/templates/purchase_invoices/invoice_gl_report.html
@@ -2,6 +2,7 @@
 {% block content %}
 <div class="container mt-4">
     <h2>GL Report for Invoice {{ invoice.id }}</h2>
+    <p>Invoice Number: {{ invoice.invoice_number }}</p>
     <table class="table">
         <thead>
             <tr>

--- a/app/templates/purchase_invoices/view_purchase_invoice.html
+++ b/app/templates/purchase_invoices/view_purchase_invoice.html
@@ -4,6 +4,7 @@
     <h2>Invoice {{ invoice.id }}</h2>
     <p>Purchase Order: {{ invoice.purchase_order_id }}</p>
     <p>Vendor: {{ invoice.purchase_order.vendor.first_name }} {{ invoice.purchase_order.vendor.last_name }}</p>
+    <p>Invoice Number: {{ invoice.invoice_number }}</p>
     <p>Received: {{ invoice.received_date }}</p>
     <table class="table">
         <thead>

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -9,6 +9,7 @@
                 <th>PO</th>
                 <th>Vendor</th>
                 <th>Date</th>
+                <th>Invoice #</th>
                 <th>Total</th>
                 <th>Actions</th>
             </tr>
@@ -20,6 +21,7 @@
                 <td>{{ inv.purchase_order_id }}</td>
                 <td>{{ inv.purchase_order.vendor.first_name }} {{ inv.purchase_order.vendor.last_name }}</td>
                 <td>{{ inv.received_date }}</td>
+                <td>{{ inv.invoice_number or '' }}</td>
                 <td>{{ '%.2f'|format(inv.total) }}</td>
                 <td>
                     <a href="{{ url_for('purchase.view_purchase_invoice', invoice_id=inv.id) }}" class="btn btn-sm btn-primary">View</a>

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -24,6 +24,10 @@
             {{ form.delivery_charge.label(class="form-label") }}
             {{ form.delivery_charge(class="form-control narrow-field") }}
         </div>
+        <div class="form-group">
+            {{ form.invoice_number.label(class="form-label") }}
+            {{ form.invoice_number(class="form-control narrow-field") }}
+        </div>
         <h4>Items</h4>
         <div id="items">
         {% for item in form.items %}


### PR DESCRIPTION
## Summary
- track vendor invoice number on purchase invoices
- allow entering invoice number when receiving an invoice
- show invoice numbers in purchase invoice list and details
- display invoice number on purchase invoice GL report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866083d96b4832497b8f60d5668a2b1