### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+uploads/
+backups/
+.env
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
-EXPOSE 5000
+ARG PORT=5000
+ENV PORT=${PORT}
+
+EXPOSE ${PORT}
 
 CMD ["python", "run.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+EXPOSE 5000
+
+CMD ["python", "run.py"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ python run.py
 
 The application uses a local SQLite database located at `inventory.db` and creates `uploads` and `backups` directories automatically on startup.
 
+## Docker Setup
+
+The project includes a `Dockerfile` and a `docker-compose.yml` to make running
+the application in a container straightforward on Linux and Windows. Create a
+`.env` file containing the environment variables described above and then start
+the service with:
+
+```bash
+docker compose up --build
+```
+
+The web interface will be available at <http://localhost:5000>. Uploaded files,
+backups and the SQLite database are stored on the host so data persists across
+container restarts.
+
 ## Running Tests
 
 The project includes a suite of `pytest` tests. Execute them with:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The application requires several variables to be present in your environment:
 - `ADMIN_EMAIL` – email address for the initial administrator account.
 - `ADMIN_PASS` – password for the administrator account.
 - `GST` – GST number to display on invoices (optional).
+- `PORT` – port the web server listens on (optional, defaults to 5000).
 
 These can be placed in a `.env` file or exported in your shell before starting the app.
 
@@ -38,20 +39,23 @@ After installing the dependencies and setting the environment variables, start t
 python run.py
 ```
 
+Set `PORT` in your environment to change the port (default `5000`).
+
 The application uses a local SQLite database located at `inventory.db` and creates `uploads` and `backups` directories automatically on startup.
 
 ## Docker Setup
 
 The project includes a `Dockerfile` and a `docker-compose.yml` to make running
 the application in a container straightforward on Linux and Windows. Create a
-`.env` file containing the environment variables described above and then start
-the service with:
+`.env` file containing the environment variables described above. You can also
+specify the port the app will use by adding a `PORT` variable to `.env` (or by
+exporting it in your shell) before starting the service:
 
 ```bash
 docker compose up --build
 ```
 
-The web interface will be available at <http://localhost:5000>. Uploaded files,
+The web interface will be available at `http://localhost:$PORT` (default `5000`). Uploaded files,
 backups and the SQLite database are stored on the host so data persists across
 container restarts.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    container_name: invoice-manager
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./uploads:/app/uploads
+      - ./backups:/app/backups
+      - ./inventory.db:/app/inventory.db
+    env_file:
+      - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,18 @@ version: '3.8'
 
 services:
   web:
-    build: .
+    build:
+      context: .
+      args:
+        PORT: ${PORT:-5000}
     container_name: invoice-manager
     ports:
-      - "5000:5000"
+      - "${PORT:-5000}:${PORT:-5000}"
     volumes:
       - ./uploads:/app/uploads
       - ./backups:/app/backups
       - ./inventory.db:/app/inventory.db
     env_file:
       - .env
+    environment:
+      - PORT=${PORT:-5000}

--- a/run.py
+++ b/run.py
@@ -1,7 +1,9 @@
+import os
 import sys
 from app import create_app
 
 app, socketio = create_app(sys.argv)
 
 if __name__ == "__main__":
-    socketio.run(app, allow_unsafe_werkzeug=True, debug=True)
+    port = int(os.getenv("PORT", "5000"))
+    socketio.run(app, host="0.0.0.0", port=port, allow_unsafe_werkzeug=True, debug=True)


### PR DESCRIPTION
## Summary
- add Dockerfile for Python app
- add docker-compose configuration
- ignore generated files when building Docker images
- document how to run the app with Docker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68660b370f3c8324b9b0165c76348dc8