### PR TITLE
Add simple setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A Flask-based application for managing invoices, products and vendors. The proje
 
 ## Installation
 
+You can perform the steps below manually or run one of the setup scripts provided in the repository. `setup.sh` works on Linux/macOS and `setup.ps1` works on Windows. Each script optionally accepts a repository URL and target directory, clones the project, installs dependencies and prepares a `.env` file.
+
+
 1. **Clone the repository**
    ```bash
    git clone <repo-url>

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,35 @@
+param(
+    [string]$RepoUrl = "https://github.com/yourusername/InvoiceManager.git",
+    [string]$TargetDir = "InvoiceManager"
+)
+
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Error "git is required but not installed. Please install git.";
+    exit 1
+}
+
+if (-not (Test-Path $TargetDir)) {
+    Write-Output "Cloning $RepoUrl into $TargetDir"
+    git clone $RepoUrl $TargetDir
+} else {
+    Write-Output "$TargetDir already exists. Pulling latest changes."
+    git -C $TargetDir pull
+}
+
+Set-Location $TargetDir
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Error "Python 3 is required but not installed.";
+    exit 1
+}
+
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+
+if (-not (Test-Path ".env")) {
+    Copy-Item ".env.example" ".env"
+    Write-Output "Created .env from example. Edit it with your settings."
+}
+
+Write-Output "Setup complete. To start the application run:`n.\venv\Scripts\Activate.ps1; python run.py"

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+REPO_URL=${1:-"https://github.com/yourusername/InvoiceManager.git"}
+TARGET_DIR=${2:-"InvoiceManager"}
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "git is required but not installed. Please install git." >&2
+    exit 1
+fi
+
+if [ ! -d "$TARGET_DIR" ]; then
+    echo "Cloning $REPO_URL into $TARGET_DIR"
+    git clone "$REPO_URL" "$TARGET_DIR"
+else
+    echo "Directory $TARGET_DIR exists. Pulling latest changes."
+    git -C "$TARGET_DIR" pull
+fi
+
+cd "$TARGET_DIR"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required but not installed. Please install Python 3." >&2
+    exit 1
+fi
+
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+
+if [ ! -f .env ]; then
+    cp .env.example .env
+    echo "Created .env from example. Edit it with your settings."
+fi
+
+echo "Setup complete. To start the application run:\nsource venv/bin/activate && python run.py"


### PR DESCRIPTION
## Summary
- add cross-platform setup scripts `setup.sh` and `setup.ps1`
- document the scripts in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866265c076c8324af263f6419178268