### PR TITLE
Add right-aligned admin favorites

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -66,7 +66,15 @@
         <a class="navbar-brand" href="#">AssetFlow</a>
         {% if current_user.is_authenticated %}
         <ul class="navbar-nav flex-row me-auto ms-2">
-            {% for fav in current_user.get_favorites() %}
+            {% for fav in current_user.get_favorites() if not fav.startswith('admin.') %}
+            {% set label = NAV_LINKS.get(fav, fav.split('.')[-1].replace('_', ' ').title()) %}
+            <li class="nav-item">
+                <a class="nav-link" href="{{ url_for(fav) }}">{{ label }}</a>
+            </li>
+            {% endfor %}
+        </ul>
+        <ul class="navbar-nav flex-row ms-auto">
+            {% for fav in current_user.get_favorites() if fav.startswith('admin.') %}
             {% set label = NAV_LINKS.get(fav, fav.split('.')[-1].replace('_', ' ').title()) %}
             <li class="nav-item">
                 <a class="nav-link" href="{{ url_for(fav) }}">{{ label }}</a>

--- a/tests/test_navbar_favorites.py
+++ b/tests/test_navbar_favorites.py
@@ -1,0 +1,16 @@
+import os
+from app import db
+from app.models import User
+from tests.utils import login
+
+
+def test_navbar_has_separate_admin_section(client, app):
+    admin_email = os.getenv('ADMIN_EMAIL', 'admin@example.com')
+    admin_pass = os.getenv('ADMIN_PASS', 'adminpass')
+    with client:
+        login(client, admin_email, admin_pass)
+        resp = client.get('/')
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert '<ul class="navbar-nav flex-row me-auto ms-2">' in html
+        assert '<ul class="navbar-nav flex-row ms-auto">' in html


### PR DESCRIPTION
## Summary
- split favourite links in the navbar so admin links are aligned right
- add regression test for navbar layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d91b1bcc8324af7e7f969055949c