### PR TITLE
Fix duplicate GL code fields

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -77,8 +77,8 @@ def add_item():
         item = Item(
             name=form.name.data,
             base_unit=form.base_unit.data,
-            gl_code=form.gl_code.data,
-            gl_code_id=form.gl_code_id.data,
+            gl_code=form.gl_code.data if 'gl_code' in request.form else None,
+            gl_code_id=form.gl_code_id.data if 'gl_code_id' in request.form else None,
             purchase_gl_code_id=form.purchase_gl_code.data or None,
         )
         db.session.add(item)
@@ -141,8 +141,10 @@ def edit_item(item_id):
             return render_template('items/edit_item.html', form=form, item=item)
         item.name = form.name.data
         item.base_unit = form.base_unit.data
-        item.gl_code = form.gl_code.data
-        item.gl_code_id = form.gl_code_id.data
+        if 'gl_code' in request.form:
+            item.gl_code = form.gl_code.data
+        if 'gl_code_id' in request.form:
+            item.gl_code_id = form.gl_code_id.data
         item.purchase_gl_code_id = form.purchase_gl_code.data or None
         ItemUnit.query.filter_by(item_id=item.id).delete()
         receiving_set = False

--- a/app/templates/items/add_item.html
+++ b/app/templates/items/add_item.html
@@ -17,10 +17,6 @@
         </div>
         <div class="row">
             <div class="col-md-6 mb-3">
-                {{ form.gl_code.label(class="form-label") }}
-                {{ form.gl_code(class="form-control") }}
-            </div>
-            <div class="col-md-6 mb-3">
                 {{ form.purchase_gl_code.label(class="form-label") }}
                 {{ form.purchase_gl_code(class="form-control") }}
             </div>

--- a/app/templates/items/edit_item.html
+++ b/app/templates/items/edit_item.html
@@ -17,10 +17,6 @@
         </div>
         <div class="row">
             <div class="col-md-6 mb-3">
-                {{ form.gl_code.label(class="form-label") }}
-                {{ form.gl_code(class="form-control") }}
-            </div>
-            <div class="col-md-6 mb-3">
                 {{ form.purchase_gl_code.label(class="form-label") }}
                 {{ form.purchase_gl_code(class="form-control") }}
             </div>


### PR DESCRIPTION
## Summary
- show only one GL code selector when adding or editing items
- keep existing GL code values untouched when the field is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866dd8417648324b9dac466e92b7b78