### PR TITLE
Remove nav brand and tweak favorites layout

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -86,8 +86,7 @@
 <body>
     <nav class="navbar navbar-light bg-light">
         <div class="container-fluid">
-            <a class="navbar-brand" href="#">AssetFlow</a>
-            <button class="navbar-toggler ms-2 me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarNav"
+            <button class="navbar-toggler me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#navbarNav"
                 aria-controls="navbarNav" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -97,7 +96,7 @@
             </button>
             {% if current_user.is_authenticated %}
             <div class="d-none d-md-block">
-            <ul class="navbar-nav flex-row me-auto ms-2">
+            <ul class="navbar-nav flex-row me-auto">
                 {% for fav in current_user.get_favorites() if not fav.startswith('admin.') %}
                 {% set label = NAV_LINKS.get(fav, fav.split('.')[-1].replace('_', ' ').title()) %}
                 <li class="nav-item">

--- a/tests/test_navbar_favorites.py
+++ b/tests/test_navbar_favorites.py
@@ -12,5 +12,5 @@ def test_navbar_has_separate_admin_section(client, app):
         resp = client.get('/')
         assert resp.status_code == 200
         html = resp.data.decode()
-        assert '<ul class="navbar-nav flex-row me-auto ms-2">' in html
+        assert '<ul class="navbar-nav flex-row me-auto">' in html
         assert '<ul class="navbar-nav flex-row ms-auto">' in html


### PR DESCRIPTION
## Summary
- remove brand link from navigation bar
- left-align user favorites and right-align admin favorites
- update navbar favorites test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68704c2b235c8324ae0b3130cc732b72