### PR TITLE
Fix ImportForm FileAllowed usage

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -349,7 +349,7 @@ class ImportForm(FlaskForm):
     """Upload a CSV file for bulk imports."""
 
     file = FileField(
-        "CSV File", validators=[FileRequired(), FileAllowed({".csv"}, "CSV only!")]
+        "CSV File", validators=[FileRequired(), FileAllowed({"csv"}, "CSV only!")]
     )
     submit = SubmitField("Import")
 


### PR DESCRIPTION
## Summary
- ensure ImportForm restricts uploads to `.csv` using same pattern as other forms
- verify existing tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68706e69be64832484142ed73102110b