### PR TITLE
Fix GL code import validation

### DIFF
--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -392,7 +392,7 @@ def import_data(data_type):
     from flask import current_app
     if not current_user.is_admin:
         abort(403)
-    form = ImportForm()
+    form = ImportForm(prefix=data_type)
     if not form.validate_on_submit() or data_type not in IMPORT_FILES:
         abort(400)
 

--- a/tests/test_admin_imports.py
+++ b/tests/test_admin_imports.py
@@ -1,0 +1,26 @@
+import os
+from io import BytesIO
+
+from app import db
+from app.models import GLCode
+from tests.utils import login
+
+
+def test_admin_can_import_gl_codes(client, app):
+    admin_email = os.getenv('ADMIN_EMAIL', 'admin@example.com')
+    admin_pass = os.getenv('ADMIN_PASS', 'adminpass')
+    data = {
+        'gl_codes-file': (BytesIO(b'code,description\n7000,Test Code\n'), 'gl_codes.csv')
+    }
+    with client:
+        login(client, admin_email, admin_pass)
+        resp = client.post(
+            '/controlpanel/import/gl_codes',
+            data=data,
+            content_type='multipart/form-data',
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert b'Imported 1 gl codes.' in resp.data
+    with app.app_context():
+        assert GLCode.query.filter_by(code='7000').first() is not None


### PR DESCRIPTION
## Summary
- ensure `ImportForm` uses the proper prefix when uploading
- add regression test for uploading GL codes via admin interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707051df2083248dc9f6d3364d68ff