### PR TITLE
Add UTF-8 BOM support in import utilities

### DIFF
--- a/app/utils/imports.py
+++ b/app/utils/imports.py
@@ -23,7 +23,7 @@ def _import_csv(path, model, mappings):
     created = 0
     if not os.path.exists(path):
         return 0
-    with open(path, newline='') as csvfile:
+    with open(path, newline='', encoding='utf-8-sig') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             obj_kwargs = {
@@ -55,7 +55,7 @@ def _import_items(path):
     created = 0
     ext = os.path.splitext(path)[1].lower()
     if ext == '.csv':
-        with open(path, newline='') as csvfile:
+        with open(path, newline='', encoding='utf-8-sig') as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
                 name = row.get('name', '').strip()
@@ -110,7 +110,7 @@ def _import_items(path):
                 db.session.add_all(units)
                 created += 1
     else:
-        with open(path) as f:
+        with open(path, encoding='utf-8-sig') as f:
             for line in f:
                 name = line.strip()
                 if name and not Item.query.filter_by(name=name).first():
@@ -137,7 +137,7 @@ def _import_locations(path):
         return 0
 
     pending = []
-    with open(path, newline='') as csvfile:
+    with open(path, newline='', encoding='utf-8-sig') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             name = row.get('name', '').strip()
@@ -176,7 +176,7 @@ def _import_products(path):
         return 0
 
     pending = []
-    with open(path, newline='') as csvfile:
+    with open(path, newline='', encoding='utf-8-sig') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
             name = row.get('name', '').strip()

--- a/tests/test_item_import.py
+++ b/tests/test_item_import.py
@@ -36,3 +36,16 @@ def test_import_items_txt(tmp_path, app):
         assert len(item.units) == 1
         assert item.units[0].name == "each"
 
+
+def test_import_items_csv_with_bom(tmp_path, app):
+    csv_path = tmp_path / "items_bom.csv"
+    csv_content = "\ufeffname,base_unit,cost\nWidget,each,0.5\n"
+    csv_path.write_bytes(csv_content.encode("utf-8"))
+
+    with app.app_context():
+        count = _import_items(str(csv_path))
+        assert count == 1
+        item = Item.query.filter_by(name="Widget").first()
+        assert item is not None
+        assert item.base_unit == "each"
+


### PR DESCRIPTION
## Summary
- ensure import helpers read files using `encoding='utf-8-sig'`
- test importing items from a CSV that starts with a UTF‑8 BOM

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707f4ea47c83248970ac5408386809