### PR TITLE
Allow item name reuse

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -68,7 +68,7 @@ class Location(db.Model):
 
 class Item(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100), unique=True, nullable=False)
+    name = db.Column(db.String(100), nullable=False)
     base_unit = db.Column(db.String(20), nullable=False)
     gl_code = db.Column(db.String(10), nullable=True)
     gl_code_id = db.Column(db.Integer, db.ForeignKey('gl_code.id'), nullable=True)
@@ -81,6 +81,11 @@ class Item(db.Model):
     units = relationship("ItemUnit", back_populates="item", cascade="all, delete-orphan")
     gl_code_rel = relationship('GLCode', foreign_keys=[gl_code_id], backref='items')
     archived = db.Column(db.Boolean, default=False, nullable=False, server_default='0')
+
+    __table_args__ = (
+        db.Index('uix_item_name_active', 'name', unique=True,
+                 sqlite_where=db.text('archived = 0')),
+    )
 
 
 class ItemUnit(db.Model):

--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -261,8 +261,8 @@ def import_items():
             for line in file:
                 item_name = line.strip()
                 if item_name:
-                    # Check if item already exists to avoid duplicates
-                    existing_item = Item.query.filter_by(name=item_name).first()
+                    # Check if an active item already exists to avoid duplicates
+                    existing_item = Item.query.filter_by(name=item_name, archived=False).first()
                     if not existing_item:
                         # Create a new item instance and add it to the database
                         new_item = Item(name=item_name)

--- a/app/utils/imports.py
+++ b/app/utils/imports.py
@@ -59,7 +59,7 @@ def _import_items(path):
             reader = csv.DictReader(csvfile)
             for row in reader:
                 name = row.get('name', '').strip()
-                if not name or Item.query.filter_by(name=name).first():
+                if not name or Item.query.filter_by(name=name, archived=False).first():
                     continue
                 base_unit = row.get('base_unit', 'each').strip().lower() or 'each'
                 cost = float(row.get('cost') or 0)
@@ -113,7 +113,7 @@ def _import_items(path):
         with open(path, encoding='utf-8-sig') as f:
             for line in f:
                 name = line.strip()
-                if name and not Item.query.filter_by(name=name).first():
+                if name and not Item.query.filter_by(name=name, archived=False).first():
                     item = Item(name=name, base_unit='each')
                     db.session.add(item)
                     db.session.flush()

--- a/tests/test_item_name_reuse.py
+++ b/tests/test_item_name_reuse.py
@@ -1,0 +1,57 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import User, Item, ItemUnit
+from tests.utils import login
+
+
+def create_user(app, email='reuse@example.com'):
+    with app.app_context():
+        user = User(email=email, password=generate_password_hash('pass'), active=True)
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+def test_item_name_reuse_after_delete(client, app):
+    create_user(app, 'reuse@example.com')
+    with client:
+        login(client, 'reuse@example.com', 'pass')
+        resp = client.post('/items/add', data={
+            'name': 'Reusable',
+            'base_unit': 'each',
+            'gl_code': '5000',
+            'units-0-name': 'each',
+            'units-0-factor': 1,
+            'units-0-receiving_default': 'y',
+            'units-0-transfer_default': 'y'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    with app.app_context():
+        item = Item.query.filter_by(name='Reusable', archived=False).first()
+        assert item is not None
+        item_id = item.id
+
+    with client:
+        login(client, 'reuse@example.com', 'pass')
+        resp = client.post(f'/items/delete/{item_id}', follow_redirects=True)
+        assert resp.status_code == 200
+
+    with client:
+        login(client, 'reuse@example.com', 'pass')
+        resp = client.post('/items/add', data={
+            'name': 'Reusable',
+            'base_unit': 'each',
+            'gl_code': '5000',
+            'units-0-name': 'each',
+            'units-0-factor': 1,
+            'units-0-receiving_default': 'y',
+            'units-0-transfer_default': 'y'
+        }, follow_redirects=True)
+        assert resp.status_code == 200
+
+    with app.app_context():
+        items = Item.query.filter_by(name='Reusable').all()
+        assert len(items) == 2
+        active = [i for i in items if not i.archived]
+        assert len(active) == 1


### PR DESCRIPTION
## Summary
- allow creating an item with the same name when an older item is archived
- skip archived items when importing items
- avoid duplicates when importing plain text items
- test item name reuse after deletion

## Testing
- `pytest -q tests/test_item_name_reuse.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870844b5c2c8324a315f3222fdd4df6