### PR TITLE
Add admin system information page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -7,7 +7,7 @@ from flask_login import LoginManager
 from flask_bootstrap import Bootstrap
 from flask_wtf import CSRFProtect
 from werkzeug.security import generate_password_hash
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 load_dotenv()
 db = SQLAlchemy()
@@ -32,6 +32,7 @@ NAV_LINKS = {
     'admin.settings': 'Settings',
     'admin.import_page': 'Data Imports',
     'admin.activity_logs': 'Activity Logs',
+    'admin.system_info': 'System Info',
 }
 
 
@@ -78,6 +79,7 @@ def create_app(args: list):
         SESSION_COOKIE_SAMESITE='Lax',
         PERMANENT_SESSION_LIFETIME=timedelta(minutes=30)
     )
+    app.config['START_TIME'] = datetime.utcnow()
     # Use absolute paths so that changing the working directory after app
     # creation does not break file references. This occurs in the test suite
     # which creates the app in a temporary directory and then changes back to

--- a/app/templates/admin/system_info.html
+++ b/app/templates/admin/system_info.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>System Information</h2>
+    <table class="table">
+        <tbody>
+            <tr><th>Platform</th><td>{{ info.platform }}</td></tr>
+            <tr><th>Python Version</th><td>{{ info.python_version }}</td></tr>
+            <tr><th>Flask Version</th><td>{{ info.flask_version }}</td></tr>
+            <tr><th>Application Version</th><td>{{ info.version }}</td></tr>
+            <tr><th>Start Time</th><td>{{ info.started_at }}</td></tr>
+            <tr><th>Uptime</th><td>{{ info.uptime }}</td></tr>
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -263,6 +263,12 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('admin.system_info') }}">System Info</a>
+                            <a href="{{ url_for('auth.toggle_favorite', link='admin.system_info') }}" class="ms-1">
+                                {% if 'admin.system_info' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <hr class="dropdown-divider">
                         </li>
                         {% endif %}

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,0 +1,31 @@
+import os
+from flask import url_for
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import User
+from tests.utils import login
+
+
+def test_admin_can_view_system_info(client, app):
+    with app.app_context():
+        with app.test_request_context():
+            expected = url_for('admin.system_info')
+    admin_email = os.getenv('ADMIN_EMAIL', 'admin@example.com')
+    admin_pass = os.getenv('ADMIN_PASS', 'adminpass')
+    with client:
+        login(client, admin_email, admin_pass)
+        resp = client.get(expected, follow_redirects=True)
+        assert resp.status_code == 200
+        assert b'System Information' in resp.data
+
+
+def test_non_admin_forbidden_from_system_info(client, app):
+    with app.app_context():
+        user = User(email='normal@example.com', password=generate_password_hash('pass'), active=True)
+        db.session.add(user)
+        db.session.commit()
+    with client:
+        login(client, 'normal@example.com', 'pass')
+        resp = client.get('/controlpanel/system')
+        assert resp.status_code == 403


### PR DESCRIPTION
## Summary
- Add admin-only system information view with platform, versions, and uptime
- Record app start time and expose in navigation
- Include tests ensuring only admins can access system info

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a6910e0488324baedc8aa3bca07ff