### PR TITLE
Add food cost percentage to product page

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -170,6 +170,13 @@ class Product(db.Model):
     gl_code_rel = relationship('GLCode', foreign_keys=[gl_code_id], backref='products')
     terminal_sales = relationship('TerminalSale', back_populates='product', cascade='all, delete-orphan')
 
+    @property
+    def food_cost_percentage(self) -> float:
+        """Return the food cost as a percentage of the price before tax."""
+        if self.price:
+            return (self.cost / self.price) * 100
+        return 0.0
+
 
 class Invoice(db.Model):
     id = db.Column(db.String(10), primary_key=True)  # Adjust length based on your requirements

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -14,6 +14,7 @@
                 <th>Name</th>
                 <th>Price</th>
                 <th>Cost</th> <!-- New column -->
+                <th>Food Cost %</th>
                 <th>Action</th>
             </tr>
         </thead>
@@ -23,6 +24,7 @@
                 <td>{{ product.name }}</td>
                 <td>{{ product.price }}</td>
                 <td>{{ product.cost }}</td> <!-- Display cost -->
+                <td>{{ '{:.2f}%'.format(product.food_cost_percentage) }}</td>
                 <td>
                     <a href="{{ url_for('product.edit_product', product_id=product.id) }}" class="btn btn-primary mr-2">Edit</a>
                     <a href="{{ url_for('product.delete_product', product_id=product.id) }}" class="btn btn-danger">Delete</a>

--- a/tests/test_product_food_cost_percentage.py
+++ b/tests/test_product_food_cost_percentage.py
@@ -1,0 +1,18 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import User, Product
+from tests.utils import login
+
+
+def test_food_cost_percentage_display(client, app):
+    """Product list displays calculated food cost percentage."""
+    with app.app_context():
+        user = User(email='foodcost@example.com', password=generate_password_hash('pass'), active=True)
+        product = Product(name='Sandwich', price=10.0, cost=4.0)
+        db.session.add_all([user, product])
+        db.session.commit()
+    with client:
+        login(client, 'foodcost@example.com', 'pass')
+        resp = client.get('/products')
+        assert resp.status_code == 200
+        assert b'40.00%' in resp.data


### PR DESCRIPTION
## Summary
- compute food cost percentage for each product
- display food cost percentage on product list
- test product list shows computed percentage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a6cec3a0083248151ed9de870ad07