### PR TITLE
Allow creating items during purchase order creation

### DIFF
--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -21,6 +21,7 @@
             {{ form.delivery_charge(class="form-control narrow-field") }}
         </div>
         <h4>Items</h4>
+        <button id="quick-add-item" type="button" class="btn btn-link p-0">Create New Item</button>
         <div id="items">
         {% for item in form.items %}
         <div class="row g-2 mt-2 item-row align-items-center">
@@ -36,6 +37,36 @@
         <button id="add-item" type="button" class="btn btn-secondary mt-3">Add Item</button>
         <button type="submit" class="btn btn-primary mt-3">Submit</button>
     </form>
+
+    <div class="modal fade" id="newItemModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Create Item</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="new-item-name" class="form-label">Name</label>
+                        <input type="text" id="new-item-name" class="form-control">
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-item-base-unit" class="form-label">Base Unit</label>
+                        <select id="new-item-base-unit" class="form-select">
+                            <option value="ounce">Ounce</option>
+                            <option value="gram">Gram</option>
+                            <option value="each" selected>Each</option>
+                            <option value="millilitre">Millilitre</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" id="save-new-item" class="btn btn-primary">Save Item</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script>
@@ -89,7 +120,30 @@
         }
     });
 
+    document.getElementById('quick-add-item').addEventListener('click', function() {
+        new bootstrap.Modal(document.getElementById('newItemModal')).show();
+    });
+
+    document.getElementById('save-new-item').addEventListener('click', function() {
+        const name = document.getElementById('new-item-name').value.trim();
+        const baseUnit = document.getElementById('new-item-base-unit').value;
+        if (!name) return;
+        fetch('/items/quick_add', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({name: name, base_unit: baseUnit})
+        }).then(r => r.json()).then(data => {
+            if (data.id) {
+                itemOptions += `<option value="${data.id}">${data.name}</option>`;
+                document.querySelectorAll('.item-select').forEach(sel => {
+                    sel.insertAdjacentHTML('beforeend', `<option value="${data.id}">${data.name}</option>`);
+                });
+                document.getElementById('new-item-name').value = '';
+                bootstrap.Modal.getInstance(document.getElementById('newItemModal')).hide();
+            }
+        });
+    });
+
     document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
 </script>
-</div>
 {% endblock %}

--- a/tests/test_quick_item_creation.py
+++ b/tests/test_quick_item_creation.py
@@ -1,0 +1,38 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import User, Vendor, Item, ItemUnit
+from tests.utils import login
+
+
+def test_purchase_order_page_has_quick_add(client, app):
+    with app.app_context():
+        user = User(email='poquick@example.com', password=generate_password_hash('pass'), active=True)
+        vendor = Vendor(first_name='Quick', last_name='Vendor')
+        db.session.add_all([user, vendor])
+        db.session.commit()
+    with client:
+        login(client, 'poquick@example.com', 'pass')
+        resp = client.get('/purchase_orders/create')
+        assert resp.status_code == 200
+        assert b'id="quick-add-item"' in resp.data
+
+
+def test_quick_add_item_endpoint(client, app):
+    with app.app_context():
+        user = User(email='apiquick@example.com', password=generate_password_hash('pass'), active=True)
+        db.session.add(user)
+        db.session.commit()
+    with client:
+        login(client, 'apiquick@example.com', 'pass')
+        resp = client.post('/items/quick_add', json={'name': 'FastItem', 'base_unit': 'each'})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['name'] == 'FastItem'
+        item_id = data['id']
+    with app.app_context():
+        item = db.session.get(Item, item_id)
+        assert item is not None
+        assert item.base_unit == 'each'
+        unit = ItemUnit.query.filter_by(item_id=item_id).first()
+        assert unit is not None
+        assert unit.name == 'each'


### PR DESCRIPTION
## Summary
- add `/items/quick_add` API for lightweight item creation
- enable creating items directly on purchase order page via modal
- test quick-add endpoint and page integration

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689a6d410ad88324a6a603c10b6605d5