### PR TITLE
Add configurable time zones

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -27,9 +27,12 @@ from wtforms.validators import (
 )
 from wtforms.widgets import CheckboxInput, ListWidget
 
+from zoneinfo import available_timezones
+
 from app.models import Item, Location, Product, Customer, Vendor, ItemUnit, GLCode
 from wtforms.validators import ValidationError
 
+TIMEZONE_CHOICES = sorted(available_timezones())
 
 class LoginForm(FlaskForm):
     email = StringField("Email", validators=[DataRequired(), Email()])
@@ -486,6 +489,18 @@ class TerminalSalesUploadForm(FlaskForm):
     submit = SubmitField("Upload")
 
 
-class GSTForm(FlaskForm):
+class SettingsForm(FlaskForm):
     gst_number = StringField("GST Number", validators=[Optional(), Length(max=50)])
+    default_timezone = SelectField(
+        "Default Timezone", choices=[(tz, tz) for tz in TIMEZONE_CHOICES]
+    )
     submit = SubmitField("Update")
+
+
+class TimezoneForm(FlaskForm):
+    timezone = SelectField(
+        "Timezone",
+        choices=[("", "Use Default")] + [(tz, tz) for tz in TIMEZONE_CHOICES],
+        validators=[Optional()],
+    )
+    submit = SubmitField("Update Timezone")

--- a/app/models.py
+++ b/app/models.py
@@ -40,6 +40,7 @@ class User(UserMixin, db.Model):
     invoices = db.relationship('Invoice', backref='creator', lazy=True)
     active = db.Column(db.Boolean, default=False, nullable=False)
     favorites = db.Column(db.Text, default='')
+    timezone = db.Column(db.String(50))
 
     def get_favorites(self):
         """Return the user's favourite endpoint names as a list."""

--- a/app/templates/admin/activity_logs.html
+++ b/app/templates/admin/activity_logs.html
@@ -15,7 +15,7 @@
         <tbody>
             {% for log in logs %}
             <tr>
-                <td>{{ log.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                <td>{{ log.timestamp|format_datetime('%Y-%m-%d %H:%M:%S') }}</td>
                 <td>{{ log.user.email if log.user else 'System' }}</td>
                 <td>{{ log.activity }}</td>
             </tr>

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -9,6 +9,10 @@
             {{ form.gst_number.label }}
             {{ form.gst_number(class='form-control') }}
         </div>
+        <div class="form-group mt-2">
+            {{ form.default_timezone.label }}
+            {{ form.default_timezone(class='form-control') }}
+        </div>
         {{ form.submit(class='btn btn-primary') }}
     </form>
 </div>

--- a/app/templates/invoices/view_invoice.html
+++ b/app/templates/invoices/view_invoice.html
@@ -16,7 +16,7 @@
     <div class="row">
         <div class="col">
             <p><strong>Invoice Number:</strong> {{ invoice.id }}</p>
-            <p><strong>Date Created:</strong> {{ invoice.date_created.strftime('%Y-%m-%d') }}</p>
+            <p><strong>Date Created:</strong> {{ invoice.date_created|format_datetime('%Y-%m-%d') }}</p>
             <h2>Products:</h2>
             <div class="table-responsive">
             <table class="table">

--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -39,7 +39,7 @@
             {% for invoice in invoices %}
             <tr>
                 <td>{{ invoice.id }}</td>
-                <td>{{ invoice.date_created.strftime('%Y-%m-%d') }}</td>
+                <td>{{ invoice.date_created|format_datetime('%Y-%m-%d') }}</td>
                 <td>{{ invoice.customer.first_name }} {{ invoice.customer.last_name }}</td>
                 <td>
                     <a href="{{ url_for('invoice.view_invoice', invoice_id=invoice.id) }}"

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -20,6 +20,14 @@
     </div>
     <button type="submit" class="btn btn-primary mt-2">{{ form.submit.label.text }}</button>
 </form>
+<form method="post" class="mt-3">
+    {{ tz_form.hidden_tag() }}
+    <div class="form-group">
+        {{ tz_form.timezone.label(class_='form-label') }}
+        {{ tz_form.timezone(class_='form-control') }}
+    </div>
+    <button type="submit" class="btn btn-primary mt-2">{{ tz_form.submit.label.text }}</button>
+</form>
 <hr>
 <h3>Transfers</h3>
 <ul>

--- a/app/templates/report_vendor_invoice_results.html
+++ b/app/templates/report_vendor_invoice_results.html
@@ -34,7 +34,7 @@
             {% set ns.grand_total = ns.grand_total + invoice.total %}
             <tr>
                 <td>{{ invoice.invoice.id }}</td>
-                <td>{{ invoice.invoice.date_created.strftime('%Y-%m-%d') }}</td>
+                <td>{{ invoice.invoice.date_created|format_datetime('%Y-%m-%d') }}</td>
                 <td>${{ "%.2f"|format(invoice.total) }}</td>
             </tr>
             {% endfor %}

--- a/app/templates/report_vendor_invoices.html
+++ b/app/templates/report_vendor_invoices.html
@@ -33,7 +33,7 @@
             {% for invoice in invoices %}
             <tr>
                 <td>{{ invoice.id }}</td>
-                <td>{{ invoice.date_created.strftime('%Y-%m-%d') }}</td>
+                <td>{{ invoice.date_created|format_datetime('%Y-%m-%d') }}</td>
                 <td>${{ "%.2f"|format(invoice.total) }}</td>
             </tr>
             {% endfor %}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,7 +5,7 @@ from app.models import User, Setting
 from tests.utils import login
 
 
-def test_admin_can_update_gst_number(client, app):
+def test_admin_can_update_settings(client, app):
     admin_email = os.getenv('ADMIN_EMAIL', 'admin@example.com')
     admin_pass = os.getenv('ADMIN_PASS', 'adminpass')
     with app.app_context():
@@ -16,10 +16,18 @@ def test_admin_can_update_gst_number(client, app):
         db.session.commit()
     with client:
         login(client, admin_email, admin_pass)
-        resp = client.post('/controlpanel/settings', data={'gst_number': '987654321'}, follow_redirects=True)
+        resp = client.post(
+            '/controlpanel/settings',
+            data={'gst_number': '987654321', 'default_timezone': 'US/Eastern'},
+            follow_redirects=True,
+        )
         assert resp.status_code == 200
     with app.app_context():
         setting = Setting.query.filter_by(name='GST').first()
         assert setting.value == '987654321'
         from app import GST
         assert GST == '987654321'
+        tz_setting = Setting.query.filter_by(name='DEFAULT_TIMEZONE').first()
+        assert tz_setting.value == 'US/Eastern'
+        from app import DEFAULT_TIMEZONE
+        assert DEFAULT_TIMEZONE == 'US/Eastern'

--- a/tests/test_timezone_filter.py
+++ b/tests/test_timezone_filter.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timezone
+from flask_login import login_user, logout_user
+from app import db
+from app.models import User, Setting
+import app as app_module
+
+
+def test_format_datetime_uses_user_and_default_timezone(app):
+    with app.app_context():
+        setting = Setting.query.filter_by(name='DEFAULT_TIMEZONE').first()
+        setting.value = 'UTC'
+        db.session.commit()
+        app_module.DEFAULT_TIMEZONE = 'UTC'
+
+        user = User(email='tzf@example.com', password='pass', active=True, timezone='US/Eastern')
+        db.session.add(user)
+        db.session.commit()
+        fmt = app.jinja_env.filters['format_datetime']
+        dt = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        with app.test_request_context():
+            login_user(user)
+            assert fmt(dt, '%Y-%m-%d %H:%M') == '2022-12-31 19:00'
+            logout_user()
+
+        user.timezone = None
+        db.session.commit()
+        setting.value = 'US/Central'
+        db.session.commit()
+        app_module.DEFAULT_TIMEZONE = 'US/Central'
+        with app.test_request_context():
+            login_user(user)
+            assert fmt(dt, '%Y-%m-%d %H:%M') == '2022-12-31 18:00'
+            logout_user()
+

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -84,3 +84,16 @@ def test_admin_users_page_links_to_profile(client, app):
         assert resp.status_code == 200
         assert profile_url.encode() in resp.data
 
+
+def test_user_can_set_timezone(client, app):
+    create_user(app, 'tz@example.com')
+    with client:
+        login(client, 'tz@example.com', 'oldpass')
+        resp = client.post(
+            '/auth/profile', data={'timezone': 'US/Eastern'}, follow_redirects=True
+        )
+        assert resp.status_code == 200
+    with app.app_context():
+        user = User.query.filter_by(email='tz@example.com').first()
+        assert user.timezone == 'US/Eastern'
+


### PR DESCRIPTION
## Summary
- allow admins to define a default timezone
- let users set their own timezone which overrides the default
- ensure date displays honour the selected timezone

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a70f1f4f4832493f3af6ce70c32d4