### PR TITLE
Create missing database and directories at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ python run.py
 
 Set `PORT` in your environment to change the port (default `5000`).
 
-The application uses a local SQLite database located at `inventory.db` and creates `uploads` and `backups` directories automatically on startup.
+The application uses a local SQLite database located at `inventory.db`. If the
+database file is missing, it and the `uploads`, `backups`, and `import_files`
+directories are created automatically on startup.
 
 ## Docker Setup
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -90,12 +90,20 @@ def create_app(args: list):
 
     base_dir = os.getcwd()
     db_path = os.path.join(base_dir, 'inventory.db')
+    if os.path.isdir(db_path):
+        db_path = os.path.join(db_path, 'inventory.db')
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    if not os.path.exists(db_path):
+        open(db_path, 'a').close()
+
     app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
     app.config['UPLOAD_FOLDER'] = os.path.join(base_dir, 'uploads')
     app.config['BACKUP_FOLDER'] = os.path.join(base_dir, 'backups')
+    app.config['IMPORT_FOLDER'] = os.path.join(base_dir, 'import_files')
 
     os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
     os.makedirs(app.config['BACKUP_FOLDER'], exist_ok=True)
+    os.makedirs(app.config['IMPORT_FOLDER'], exist_ok=True)
 
     if '--demo' in args:
         app.config['DEMO'] = True

--- a/tests/test_path_creation.py
+++ b/tests/test_path_creation.py
@@ -1,0 +1,5 @@
+def test_creates_paths(app, tmp_path):
+    assert (tmp_path / 'inventory.db').exists()
+    assert (tmp_path / 'uploads').is_dir()
+    assert (tmp_path / 'backups').is_dir()
+    assert (tmp_path / 'import_files').is_dir()


### PR DESCRIPTION
## Summary
- Ensure the app creates `inventory.db` if missing
- Auto-create `uploads`, `backups`, and `import_files` folders
- Add test covering automatic path creation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b76f6d6754832489b5ce4d35169dc2