### PR TITLE
Handle string dates during backup restore

### DIFF
--- a/app/utils/backup.py
+++ b/app/utils/backup.py
@@ -91,7 +91,6 @@ def restore_backup(file_path):
         for row in rows:
             record = {col.name: row[col.name] for col in select_cols}
 
-            # Supply defaults for new columns not in backup
             for col in table.columns:
                 if col.name not in record:
                     default = None
@@ -100,6 +99,18 @@ def restore_backup(file_path):
                         if callable(default):
                             default = default()
                     record[col.name] = default
+                else:
+                    value = record[col.name]
+                    if isinstance(col.type, db.DateTime) and isinstance(value, str):
+                        try:
+                            record[col.name] = datetime.fromisoformat(value)
+                        except ValueError:
+                            pass
+                    elif isinstance(col.type, db.Date) and isinstance(value, str):
+                        try:
+                            record[col.name] = datetime.fromisoformat(value).date()
+                        except ValueError:
+                            pass
 
             insert_rows.append(record)
 

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -14,6 +14,7 @@ from app.models import (
     User,
     PurchaseOrder,
     PurchaseOrderItem,
+    PurchaseOrderItemArchive,
     PurchaseInvoice,
     PurchaseInvoiceItem,
     Event,
@@ -48,6 +49,8 @@ def populate_data():
         quantity=1,
         countable=True,
     )
+    db.session.add_all([product, recipe])
+
     po = PurchaseOrder(
         vendor_id=vendor.id,
         user_id=user.id,
@@ -55,7 +58,16 @@ def populate_data():
         expected_date=date(2023, 1, 2),
         delivery_charge=0,
     )
+    db.session.add(po)
+    db.session.flush()
+
     poi = PurchaseOrderItem(purchase_order=po, item=item, unit=unit, quantity=1)
+    archive = PurchaseOrderItemArchive(
+        purchase_order_id=po.id,
+        item_id=item.id,
+        unit_id=unit.id,
+        quantity=1,
+    )
     invoice = PurchaseInvoice(
         purchase_order=po,
         user_id=user.id,
@@ -81,16 +93,8 @@ def populate_data():
     stand_item = EventStandSheetItem(event_location=event_loc, item=item, opening_count=0, closing_count=0)
 
     db.session.add_all([
-        gl,
-        item,
-        unit,
-        product,
-        recipe,
-        vendor,
-        location,
-        user,
-        po,
         poi,
+        archive,
         invoice,
         pii,
         event,
@@ -111,6 +115,7 @@ def populate_data():
         User,
         PurchaseOrder,
         PurchaseOrderItem,
+        PurchaseOrderItemArchive,
         PurchaseInvoice,
         PurchaseInvoiceItem,
         Event,


### PR DESCRIPTION
## Summary
- ensure restore_backup parses string DateTime and Date values
- extend backup/restore tests to cover purchase order item archive

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7a682cc2c8324bc7a3e7909655ecf