### PR TITLE
Add inventory variance report

### DIFF
--- a/app/templates/events/bulk_count_sheets.html
+++ b/app/templates/events/bulk_count_sheets.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Inventory Count Sheets - {{ event.name }}</h2>
+{% for block in data %}
+    <h4 class="mt-4">{{ block.location.name }}</h4>
+    <div class="table-responsive">
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Item</th>
+                <th>Receiving Quantity</th>
+                <th>Transfer Quantity</th>
+                <th>Base Quantity</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in block.stand_items %}
+            <tr>
+                <td>{{ entry.item.name }}</td>
+                <td>{% if entry.recv_unit %} _____ {{ entry.recv_unit.name }} of {{ entry.recv_unit.factor }} {{ entry.item.base_unit }}{% endif %}</td>
+                <td>{% if entry.trans_unit %} _____ {{ entry.trans_unit.name }} of {{ entry.trans_unit.factor }} {{ entry.item.base_unit }}{% endif %}</td>
+                <td>_____ {{ entry.item.base_unit }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+{% endfor %}
+<button type="button" class="btn btn-secondary" onclick="window.print()">Print</button>
+{% endblock %}

--- a/app/templates/events/count_sheet.html
+++ b/app/templates/events/count_sheet.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Inventory Count Sheet - {{ location.name }}</h2>
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <div class="table-responsive">
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Item</th>
+                    <th>Receiving Quantity</th>
+                    <th>Transfer Quantity</th>
+                    <th>Base Quantity</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for entry in stand_items %}
+                <tr>
+                    <td>{{ entry.item.name }}</td>
+                    <td>
+                        <input type="number" class="form-control" name="recv_{{ entry.item.id }}" value="{{ entry.sheet.opening_count if entry.sheet else '' }}">
+                        {% if entry.recv_unit %} {{ entry.recv_unit.name }} of {{ entry.recv_unit.factor }} {{ entry.item.base_unit }}{% endif %}
+                    </td>
+                    <td>
+                        <input type="number" class="form-control" name="trans_{{ entry.item.id }}" value="{{ entry.sheet.transferred_in if entry.sheet else '' }}">
+                        {% if entry.trans_unit %} {{ entry.trans_unit.name }} of {{ entry.trans_unit.factor }} {{ entry.item.base_unit }}{% endif %}
+                    </td>
+                    <td>
+                        <input type="number" class="form-control" name="base_{{ entry.item.id }}" value="{{ entry.sheet.transferred_out if entry.sheet else '' }}">
+                        {{ entry.item.base_unit }}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+        <button type="button" class="btn btn-secondary" onclick="window.print()">Print</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/events/inventory_report.html
+++ b/app/templates/events/inventory_report.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Inventory Report - {{ event.name }}</h1>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Location</th>
+      <th>Item</th>
+      <th>Expected</th>
+      <th>Actual</th>
+      <th>Variance</th>
+      <th>GL Code</th>
+      <th>Cost</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in rows %}
+    <tr>
+      <td>{{ row.location.name }}</td>
+      <td>{{ row.item.name }}</td>
+      <td>{{ row.expected }}</td>
+      <td>{{ row.actual }}</td>
+      <td>{{ row.variance }}</td>
+      <td>{{ row.gl_code }}</td>
+      <td>{{ '%.2f'|format(row.cost_total) }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<h2>Totals by GL Code</h2>
+<table class="table table-striped">
+  <thead>
+    <tr><th>GL Code</th><th>Total Cost</th></tr>
+  </thead>
+  <tbody>
+    {% for code, total in gl_totals.items() %}
+    <tr><td>{{ code }}</td><td>{{ '%.2f'|format(total) }}</td></tr>
+    {% endfor %}
+    <tr><th>Grand Total</th><th>{{ '%.2f'|format(grand_total) }}</th></tr>
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -4,12 +4,14 @@
 <p>Start: {{ event.start_date }} End: {{ event.end_date }}</p>
 <a class="btn btn-secondary" href="{{ url_for('event.add_location', event_id=event.id) }}">Add Location</a>
 <a class="btn btn-secondary" href="{{ url_for('event.bulk_stand_sheets', event_id=event.id) }}">Stand Sheets</a>
+<a class="btn btn-secondary" href="{{ url_for('event.bulk_count_sheets', event_id=event.id) }}">Count Sheets</a>
 <a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
 <ul class="mt-3">
 {% for el in event.locations %}
     <li>{{ el.location.name }} -
         {% if not el.confirmed and not event.closed %}
             <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a> |
+            <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a> |
             <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> |
             <a href="{{ url_for('event.upload_terminal_sales', event_id=event.id) }}">Upload Sales</a> |
             <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>

--- a/tests/test_event_flow.py
+++ b/tests/test_event_flow.py
@@ -108,7 +108,7 @@ def test_event_lifecycle(client, app):
 
     with app.app_context():
         lsi = LocationStandItem.query.filter_by(location_id=loc_id).first()
-        assert lsi.expected_count == 0
+        assert lsi.expected_count == 10
         assert TerminalSale.query.filter_by(event_location_id=elid).count() == 0
 
 

--- a/tests/test_inventory_report.py
+++ b/tests/test_inventory_report.py
@@ -1,0 +1,172 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import (
+    User,
+    Location,
+    Item,
+    ItemUnit,
+    Product,
+    ProductRecipeItem,
+    LocationStandItem,
+    GLCode,
+    Event,
+)
+from tests.utils import login
+
+
+def test_inventory_report_variance(client, app):
+    with app.app_context():
+        user = User(
+            email="inv@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        loc = Location(name="InvLoc")
+        gl = GLCode(code="7000", description="Beverage")
+        db.session.add_all([user, loc, gl])
+        db.session.commit()
+        item = Item(name="Pepsi", base_unit="each", cost=1.0, gl_code_id=gl.id)
+        product = Product(name="Pepsi Product", price=1.0, cost=1.0)
+        db.session.add_all([item, product])
+        db.session.commit()
+        iu = ItemUnit(
+            item_id=item.id,
+            name="each",
+            factor=1,
+            receiving_default=True,
+            transfer_default=True,
+        )
+        pri = ProductRecipeItem(
+            product_id=product.id,
+            item_id=item.id,
+            unit_id=iu.id,
+            quantity=1,
+            countable=True,
+        )
+        lsi = LocationStandItem(
+            location_id=loc.id, item_id=item.id, expected_count=5
+        )
+        loc.products.append(product)
+        db.session.add_all([iu, pri, lsi])
+        db.session.commit()
+        loc_id = loc.id
+        item_id = item.id
+
+
+    with client:
+        login(client, "inv@example.com", "pass")
+        client.post(
+            "/events/create",
+            data={
+                "name": "InvEvent",
+                "start_date": "2023-01-01",
+                "end_date": "2023-01-02",
+            },
+            follow_redirects=True,
+        )
+
+    with app.app_context():
+        ev = Event.query.filter_by(name="InvEvent").first()
+        eid = ev.id
+
+    with client:
+        login(client, "inv@example.com", "pass")
+        client.post(
+            f"/events/{eid}/add_location",
+            data={"location_id": loc_id},
+            follow_redirects=True,
+        )
+        client.post(
+            f"/events/{eid}/count_sheet/{loc_id}",
+            data={
+                f"recv_{item_id}": 0,
+                f"trans_{item_id}": 4,
+                f"base_{item_id}": 0,
+            },
+            follow_redirects=True,
+        )
+        resp = client.get(f"/events/{eid}/inventory_report")
+        assert resp.status_code == 200
+        assert b"-1" in resp.data
+        assert b"7000" in resp.data
+
+
+def test_inventory_close_updates_counts(client, app):
+    with app.app_context():
+        user = User(
+            email="close@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        loc = Location(name="CloseLoc")
+        item = Item(name="Coffee", base_unit="each", cost=1.0)
+        product = Product(name="Coffee Product", price=1.0, cost=1.0)
+        db.session.add_all([user, loc, item, product])
+        db.session.commit()
+        recv_unit = ItemUnit(
+            item_id=item.id,
+            name="case",
+            factor=24,
+            receiving_default=True,
+        )
+        trans_unit = ItemUnit(
+            item_id=item.id,
+            name="each",
+            factor=1,
+            transfer_default=True,
+        )
+        pri = ProductRecipeItem(
+            product_id=product.id,
+            item_id=item.id,
+            unit_id=trans_unit.id,
+            quantity=1,
+            countable=True,
+        )
+        lsi = LocationStandItem(
+            location_id=loc.id, item_id=item.id, expected_count=5
+        )
+        loc.products.append(product)
+        db.session.add_all([recv_unit, trans_unit, pri, lsi])
+        db.session.commit()
+        loc_id = loc.id
+        item_id = item.id
+
+    with client:
+        login(client, "close@example.com", "pass")
+        client.post(
+            "/events/create",
+            data={
+                "name": "CloseEvent",
+                "start_date": "2023-02-01",
+                "end_date": "2023-02-02",
+            },
+            follow_redirects=True,
+        )
+
+    with app.app_context():
+        ev = Event.query.filter_by(name="CloseEvent").first()
+        eid = ev.id
+
+    with client:
+        login(client, "close@example.com", "pass")
+        client.post(
+            f"/events/{eid}/add_location",
+            data={"location_id": loc_id},
+            follow_redirects=True,
+        )
+        client.post(
+            f"/events/{eid}/count_sheet/{loc_id}",
+            data={
+                f"recv_{item_id}": 0,
+                f"trans_{item_id}": 7,
+                f"base_{item_id}": 0,
+            },
+            follow_redirects=True,
+        )
+        client.get(f"/events/{eid}/close", follow_redirects=True)
+
+    with app.app_context():
+        lsi = LocationStandItem.query.filter_by(location_id=loc_id, item_id=item_id).first()
+        assert lsi.expected_count == 7
+


### PR DESCRIPTION
## Summary
- add `/events/<id>/inventory_report` to summarize expected vs actual counts and GL-code costs
- include template for displaying inventory totals and variances
- cover report with automated tests
- implement full inventory counting workflow with per-location count sheets and closing updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b868448a90832492c59e5491d52c2a