### PR TITLE
Add event types, backup restore shortcut, item location report, and invoice location

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -438,10 +438,23 @@ class GLCodeForm(FlaskForm):
     submit = SubmitField("Submit")
 
 
+EVENT_TYPES = [
+    ("catering", "Catering"),
+    ("hockey", "Hockey"),
+    ("concert", "Concert"),
+    ("RMWF", "RMWF"),
+    ("tournament", "Tournament"),
+    ("curling", "Curling"),
+    ("inventory", "Inventory"),
+    ("other", "Other"),
+]
+
+
 class EventForm(FlaskForm):
     name = StringField("Name", validators=[DataRequired()])
     start_date = DateField("Start Date", validators=[DataRequired()])
     end_date = DateField("End Date", validators=[DataRequired()])
+    event_type = SelectField("Event Type", choices=EVENT_TYPES, validators=[DataRequired()])
     submit = SubmitField("Submit")
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -337,6 +337,7 @@ class Event(db.Model):
     start_date = db.Column(db.Date, nullable=False)
     end_date = db.Column(db.Date, nullable=False)
     closed = db.Column(db.Boolean, default=False, nullable=False, server_default='0')
+    event_type = db.Column(db.String(20), nullable=False, default='other', server_default='other')
 
     locations = relationship('EventLocation', back_populates='event', cascade='all, delete-orphan')
 

--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -63,6 +63,18 @@ def view_items():
     return render_template('items/view_items.html', items=items, form=form)
 
 
+@item.route('/items/<int:item_id>/locations')
+@login_required
+def item_locations(item_id):
+    """Show all locations holding a specific item and their quantities."""
+    item_obj = db.session.get(Item, item_id)
+    if item_obj is None:
+        abort(404)
+    entries = LocationStandItem.query.filter_by(item_id=item_id).all()
+    total = sum(e.expected_count for e in entries)
+    return render_template('items/item_locations.html', item=item_obj, entries=entries, total=total)
+
+
 @item.route('/items/add', methods=['GET', 'POST'])
 @login_required
 def add_item():

--- a/app/templates/admin/backups.html
+++ b/app/templates/admin/backups.html
@@ -23,7 +23,13 @@
         {% for b in backups %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
             {{ b }}
-            <a href="{{ url_for('admin.download_backup', filename=b) }}" class="btn btn-sm btn-secondary">Download</a>
+            <div>
+                <form action="{{ url_for('admin.restore_backup_file', filename=b) }}" method="post" class="d-inline">
+                    {{ restore_form.csrf_token }}
+                    <button type="submit" class="btn btn-sm btn-danger">Restore</button>
+                </form>
+                <a href="{{ url_for('admin.download_backup', filename=b) }}" class="btn btn-sm btn-secondary ms-1">Download</a>
+            </div>
         </li>
         {% else %}
         <li class="list-group-item">No backups found.</li>

--- a/app/templates/events/create_event.html
+++ b/app/templates/events/create_event.html
@@ -6,6 +6,7 @@
     {{ form.name.label }} {{ form.name(class='form-control') }}
     {{ form.start_date.label }} {{ form.start_date(class='form-control') }}
     {{ form.end_date.label }} {{ form.end_date(class='form-control') }}
+    {{ form.event_type.label }} {{ form.event_type(class='form-control') }}
     {{ form.submit(class='btn btn-primary mt-2') }}
 </form>
 {% endblock %}

--- a/app/templates/events/edit_event.html
+++ b/app/templates/events/edit_event.html
@@ -6,6 +6,7 @@
     {{ form.name.label }} {{ form.name(class='form-control') }}
     {{ form.start_date.label }} {{ form.start_date(class='form-control') }}
     {{ form.end_date.label }} {{ form.end_date(class='form-control') }}
+    {{ form.event_type.label }} {{ form.event_type(class='form-control') }}
     {{ form.submit(class='btn btn-primary mt-2') }}
 </form>
 {% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -4,14 +4,16 @@
 <p>Start: {{ event.start_date }} End: {{ event.end_date }}</p>
 <a class="btn btn-secondary" href="{{ url_for('event.add_location', event_id=event.id) }}">Add Location</a>
 <a class="btn btn-secondary" href="{{ url_for('event.bulk_stand_sheets', event_id=event.id) }}">Stand Sheets</a>
+{% if event.event_type == 'inventory' %}
 <a class="btn btn-secondary" href="{{ url_for('event.bulk_count_sheets', event_id=event.id) }}">Count Sheets</a>
+{% endif %}
 <a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
 <ul class="mt-3">
 {% for el in event.locations %}
     <li>{{ el.location.name }} -
         {% if not el.confirmed and not event.closed %}
-            <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a> |
-            <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a> |
+            <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a>
+            {% if event.event_type == 'inventory' %}| <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a>{% endif %} |
             <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> |
             <a href="{{ url_for('event.upload_terminal_sales', event_id=event.id) }}">Upload Sales</a> |
             <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>

--- a/app/templates/events/view_events.html
+++ b/app/templates/events/view_events.html
@@ -2,15 +2,25 @@
 {% block content %}
 <h2>Events</h2>
 <a class="btn btn-primary" href="{{ url_for('event.create_event') }}">Create Event</a>
+<form method="get" class="form-inline mt-2">
+    <select name="type" class="form-control">
+        <option value="">All Types</option>
+        {% for val, label in event_types %}
+            <option value="{{ val }}" {% if event_type == val %}selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+    </select>
+    <button type="submit" class="btn btn-secondary ml-2">Filter</button>
+</form>
 <div class="table-responsive">
 <table class="table mt-3">
     <thead>
-        <tr><th>Name</th><th>Start</th><th>End</th><th>Closed</th><th></th></tr>
+        <tr><th>Name</th><th>Type</th><th>Start</th><th>End</th><th>Closed</th><th></th></tr>
     </thead>
     <tbody>
     {% for e in events %}
         <tr>
             <td>{{ e.name }}</td>
+            <td>{{ type_labels.get(e.event_type, e.event_type) }}</td>
             <td>{{ e.start_date }}</td>
             <td>{{ e.end_date }}</td>
             <td>{{ 'Yes' if e.closed else 'No' }}</td>

--- a/app/templates/items/item_locations.html
+++ b/app/templates/items/item_locations.html
@@ -1,0 +1,20 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ item.name }} Locations</h2>
+<div class="table-responsive">
+<table class="table">
+    <thead>
+        <tr><th>Location</th><th>Quantity</th></tr>
+    </thead>
+    <tbody>
+    {% for e in entries %}
+        <tr><td>{{ e.location.name }}</td><td>{{ e.expected_count }}</td></tr>
+    {% endfor %}
+        <tr>
+            <td><strong>Total</strong></td>
+            <td><strong>{{ total }}</strong></td>
+        </tr>
+    </tbody>
+</table>
+</div>
+{% endblock %}

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -32,6 +32,7 @@
                     <td>{{ item.cost }}</td>
                     <td>
                         <a href="{{ url_for('item.edit_item', item_id=item.id) }}" class="btn btn-secondary">Edit</a>
+                        <a href="{{ url_for('item.item_locations', item_id=item.id) }}" class="btn btn-info ms-1">Locations</a>
                     </td>
                 </tr>
                 {% endfor %}

--- a/app/templates/purchase_invoices/view_purchase_invoice.html
+++ b/app/templates/purchase_invoices/view_purchase_invoice.html
@@ -4,6 +4,7 @@
     <h2>Invoice {{ invoice.id }}</h2>
     <p>Purchase Order: {{ invoice.purchase_order_id }}</p>
     <p>Vendor: {{ invoice.purchase_order.vendor.first_name }} {{ invoice.purchase_order.vendor.last_name }}</p>
+    <p>Location: {{ invoice.location_name }}</p>
     <p>Invoice Number: {{ invoice.invoice_number }}</p>
     <p>Received: {{ invoice.received_date }}</p>
     <div class="table-responsive">

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -9,6 +9,7 @@
                 <th>ID</th>
                 <th>PO</th>
                 <th>Vendor</th>
+                <th>Location</th>
                 <th>Date</th>
                 <th>Invoice #</th>
                 <th>Total</th>
@@ -21,6 +22,7 @@
                 <td>{{ inv.id }}</td>
                 <td>{{ inv.purchase_order_id }}</td>
                 <td>{{ inv.purchase_order.vendor.first_name }} {{ inv.purchase_order.vendor.last_name }}</td>
+                <td>{{ inv.location_name }}</td>
                 <td>{{ inv.received_date }}</td>
                 <td>{{ inv.invoice_number or '' }}</td>
                 <td>{{ '%.2f'|format(inv.total) }}</td>

--- a/tests/test_event_flow.py
+++ b/tests/test_event_flow.py
@@ -66,6 +66,7 @@ def test_event_lifecycle(client, app):
                 "name": "Test Event",
                 "start_date": "2023-01-01",
                 "end_date": "2023-01-02",
+                "event_type": "inventory",
             },
             follow_redirects=True,
         )
@@ -133,6 +134,7 @@ def test_bulk_stand_sheet(client, app):
                 "name": "BulkEvent",
                 "start_date": "2023-02-01",
                 "end_date": "2023-02-02",
+                "event_type": "inventory",
             },
             follow_redirects=True,
         )
@@ -172,6 +174,7 @@ def test_no_sales_after_confirmation(client, app):
                 "name": "ConfirmEvent",
                 "start_date": "2023-03-01",
                 "end_date": "2023-03-02",
+                "event_type": "inventory",
             },
             follow_redirects=True,
         )
@@ -212,7 +215,8 @@ def test_save_stand_sheet(client, app):
         client.post('/events/create', data={
             'name': 'SheetEvent',
             'start_date': '2023-03-01',
-            'end_date': '2023-03-02'
+            'end_date': '2023-03-02',
+            'event_type': 'inventory'
         }, follow_redirects=True)
 
     with app.app_context():
@@ -253,7 +257,8 @@ def test_terminal_sales_prefill(client, app):
         client.post('/events/create', data={
             'name': 'PrefillEvent',
             'start_date': '2023-04-01',
-            'end_date': '2023-04-02'
+            'end_date': '2023-04-02',
+            'event_type': 'inventory'
         }, follow_redirects=True)
 
     with app.app_context():
@@ -287,7 +292,8 @@ def test_upload_sales_xls(client, app):
         client.post('/events/create', data={
             'name': 'UploadXLS',
             'start_date': '2025-06-20',
-            'end_date': '2025-06-21'
+            'end_date': '2025-06-21',
+            'event_type': 'inventory'
         }, follow_redirects=True)
 
     with app.app_context():
@@ -341,7 +347,8 @@ def test_upload_sales_pdf(client, app):
         client.post('/events/create', data={
             'name': 'UploadPDF',
             'start_date': '2025-06-20',
-            'end_date': '2025-06-21'
+            'end_date': '2025-06-21',
+            'event_type': 'inventory'
         }, follow_redirects=True)
 
     with app.app_context():

--- a/tests/test_inventory_report.py
+++ b/tests/test_inventory_report.py
@@ -62,6 +62,7 @@ def test_inventory_report_variance(client, app):
                 "name": "InvEvent",
                 "start_date": "2023-01-01",
                 "end_date": "2023-01-02",
+                "event_type": "inventory",
             },
             follow_redirects=True,
         )
@@ -140,6 +141,7 @@ def test_inventory_close_updates_counts(client, app):
                 "name": "CloseEvent",
                 "start_date": "2023-02-01",
                 "end_date": "2023-02-02",
+                "event_type": "inventory",
             },
             follow_redirects=True,
         )

--- a/tests/test_item_location_report.py
+++ b/tests/test_item_location_report.py
@@ -1,0 +1,27 @@
+from werkzeug.security import generate_password_hash
+from app import db
+from app.models import User, Location, Item, LocationStandItem
+from tests.utils import login
+
+
+def test_item_location_report(client, app):
+    with app.app_context():
+        user = User(email='locreport@example.com', password=generate_password_hash('pass'), active=True)
+        item = Item(name='ReportItem', base_unit='each')
+        loc1 = Location(name='Loc1')
+        loc2 = Location(name='Loc2')
+        db.session.add_all([user, item, loc1, loc2])
+        db.session.commit()
+        db.session.add_all([
+            LocationStandItem(location_id=loc1.id, item_id=item.id, expected_count=5),
+            LocationStandItem(location_id=loc2.id, item_id=item.id, expected_count=3),
+        ])
+        db.session.commit()
+        item_id = item.id
+    with client:
+        login(client, 'locreport@example.com', 'pass')
+        resp = client.get(f'/items/{item_id}/locations')
+        assert resp.status_code == 200
+        assert b'Loc1' in resp.data
+        assert b'Loc2' in resp.data
+        assert b'8' in resp.data

--- a/tests/test_purchase_flow.py
+++ b/tests/test_purchase_flow.py
@@ -290,6 +290,7 @@ def test_invoice_moves_and_reverse(client, app):
         assert f'>{po_id}<'.encode() not in resp.data
         resp = client.get('/purchase_invoices')
         assert str(inv_id).encode() in resp.data
+        assert b'Main' in resp.data
 
     with client:
         login(client, email, 'pass')


### PR DESCRIPTION
## Summary
- allow selecting an event type when creating or editing events and filter events by type; hide count sheet buttons for non-inventory events
- add restore action to backup listing for one-click database restores
- show locations stocking an item with totals and expose invoice locations on purchase invoices
- validate backup restore filenames to prevent restoring arbitrary files

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b88c718e3c8324a155ee1ffce578ab