### PR TITLE
Improve count sheet workflow and inventory cleanup

### DIFF
--- a/app/templates/events/bulk_count_sheets.html
+++ b/app/templates/events/bulk_count_sheets.html
@@ -1,7 +1,14 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<h2>Inventory Count Sheets - {{ event.name }}</h2>
+<style>
+    .navbar { display: none; }
+    .page-break { page-break-after: always; }
+    @media print {
+        .no-print { display: none; }
+    }
+</style>
+<h2 class="no-print">Inventory Count Sheets - {{ event.name }}</h2>
 {% for block in data %}
     <h4 class="mt-4">{{ block.location.name }}</h4>
     <div class="table-responsive">
@@ -26,6 +33,6 @@
         </tbody>
     </table>
     </div>
+    {% if not loop.last %}<div class="page-break"></div>{% endif %}
 {% endfor %}
-<button type="button" class="btn btn-secondary" onclick="window.print()">Print</button>
 {% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -2,12 +2,16 @@
 {% block content %}
 <h2>{{ event.name }}</h2>
 <p>Start: {{ event.start_date }} End: {{ event.end_date }}</p>
+{% if not event.closed %}
 <a class="btn btn-secondary" href="{{ url_for('event.add_location', event_id=event.id) }}">Add Location</a>
+{% endif %}
 <a class="btn btn-secondary" href="{{ url_for('event.bulk_stand_sheets', event_id=event.id) }}">Stand Sheets</a>
 {% if event.event_type == 'inventory' %}
 <a class="btn btn-secondary" href="{{ url_for('event.bulk_count_sheets', event_id=event.id) }}">Count Sheets</a>
 {% endif %}
+{% if not event.closed %}
 <a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
+{% endif %}
 <ul class="mt-3">
 {% for el in event.locations %}
     <li>{{ el.location.name }} -

--- a/tests/test_event_flow.py
+++ b/tests/test_event_flow.py
@@ -109,7 +109,7 @@ def test_event_lifecycle(client, app):
 
     with app.app_context():
         lsi = LocationStandItem.query.filter_by(location_id=loc_id).first()
-        assert lsi.expected_count == 10
+        assert lsi is None
         assert TerminalSale.query.filter_by(event_location_id=elid).count() == 0
 
 


### PR DESCRIPTION
## Summary
- hide navigation and print button on bulk count sheets, ensure each location prints on its own page
- return to event location list after saving a count sheet
- prevent location editing when events are closed and remove uncounted items when closing events

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8a296d08c832493b4cb846d12a1ac