### PR TITLE
Use production WSGI server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,5 @@ ENV DATABASE_PATH=/app/data/inventory.db
 
 EXPOSE ${PORT}
 
-CMD ["sh", "-c", "flask db upgrade && python run.py"]
+CMD ["sh", "-c", "flask db upgrade && gunicorn -k eventlet -w 1 run:app"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ WTForms==3.1.2
 pytest==7.4.0
 Flask-Migrate==4.1.0
 Flask-SocketIO==5.5.1
+eventlet==0.36.1
+gunicorn==21.2.0
 
 email_validator==2.2.0
 openpyxl==3.1.5

--- a/run.py
+++ b/run.py
@@ -4,6 +4,14 @@ from app import create_app
 
 app, socketio = create_app(sys.argv)
 
+# Configure debug mode from environment (default to False)
+debug = os.getenv("DEBUG", "False").lower() in {"1", "true", "t", "yes"}
+app.debug = debug
+
 if __name__ == "__main__":
     port = int(os.getenv("PORT", "5000"))
-    socketio.run(app, host="0.0.0.0", port=port, allow_unsafe_werkzeug=True, debug=True)
+    # Run using eventlet's production WSGI server
+    import eventlet
+    from eventlet import wsgi
+
+    wsgi.server(eventlet.listen(("0.0.0.0", port)), app)


### PR DESCRIPTION
## Summary
- configure Flask debug mode via environment variable
- run app with eventlet WSGI server and gunicorn in Docker
- add gunicorn and eventlet dependencies

## Testing
- `pip install --quiet -r requirements.txt`
- `pytest >/tmp/unit_test.log && tail -n 20 /tmp/unit_test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b8a59f0a44832493bcc2956a38fbd8