### PR TITLE
Add pagination for product, transfer, and purchase listings

### DIFF
--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -12,7 +12,8 @@ product = Blueprint('product', __name__)
 @login_required
 def view_products():
     """List available products."""
-    products = Product.query.all()
+    page = request.args.get('page', 1, type=int)
+    products = Product.query.paginate(page=page, per_page=20)
     return render_template('products/view_products.html', products=products)
 
 

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -85,7 +85,12 @@ def check_negative_invoice_reverse(invoice_obj):
 @login_required
 def view_purchase_orders():
     """Show outstanding purchase orders."""
-    orders = PurchaseOrder.query.filter_by(received=False).order_by(PurchaseOrder.order_date.desc()).all()
+    page = request.args.get('page', 1, type=int)
+    orders = (
+        PurchaseOrder.query.filter_by(received=False)
+        .order_by(PurchaseOrder.order_date.desc())
+        .paginate(page=page, per_page=20)
+    )
     return render_template('purchase_orders/view_purchase_orders.html', orders=orders)
 
 
@@ -296,7 +301,11 @@ def receive_invoice(po_id):
 @login_required
 def view_purchase_invoices():
     """List all received purchase invoices."""
-    invoices = PurchaseInvoice.query.order_by(PurchaseInvoice.received_date.desc()).all()
+    page = request.args.get('page', 1, type=int)
+    invoices = (
+        PurchaseInvoice.query.order_by(PurchaseInvoice.received_date.desc())
+        .paginate(page=page, per_page=20)
+    )
     return render_template('purchase_invoices/view_purchase_invoices.html', invoices=invoices)
 
 

--- a/app/routes/transfer_routes.py
+++ b/app/routes/transfer_routes.py
@@ -126,6 +126,7 @@ def view_transfers():
     transfer_id = request.args.get('transfer_id', '', type=int)  # Optional: Search by Transfer ID
     from_location_name = request.args.get('from_location', '')  # Optional: Search by From Location
     to_location_name = request.args.get('to_location', '')  # Optional: Search by To Location
+    page = request.args.get('page', 1, type=int)
 
     query = Transfer.query
     if transfer_id != '':
@@ -140,11 +141,11 @@ def view_transfers():
             Location.name.ilike(f"%{to_location_name}%"))
 
     if filter_option == 'completed':
-        transfers = query.filter(Transfer.completed == True).all()
+        query = query.filter(Transfer.completed == True)
     elif filter_option == 'not_completed':
-        transfers = query.filter(Transfer.completed == False).all()
-    else:
-        transfers = query.all()
+        query = query.filter(Transfer.completed == False)
+
+    transfers = query.paginate(page=page, per_page=20)
 
     form = TransferForm()  # Assuming you're using it for something like a filter form on the page
     return render_template('transfers/view_transfers.html', transfers=transfers, form=form)

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -19,7 +19,7 @@
             </tr>
         </thead>
         <tbody>
-            {% for product in products %}
+            {% for product in products.items %}
             <tr>
                 <td>{{ product.name }}</td>
                 <td>{{ product.price }}</td>
@@ -34,5 +34,22 @@
         </tbody>
     </table>
     </div>
+    <nav aria-label="Product pagination">
+        <ul class="pagination">
+            {% if products.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ products.page }} of {{ products.pages }}</span>
+            </li>
+            {% if products.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -17,7 +17,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for inv in invoices %}
+        {% for inv in invoices.items %}
             <tr>
                 <td>{{ inv.id }}</td>
                 <td>{{ inv.purchase_order_id }}</td>
@@ -36,5 +36,22 @@
         </tbody>
     </table>
     </div>
+    <nav aria-label="Purchase invoice pagination">
+        <ul class="pagination">
+            {% if invoices.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('purchase.view_purchase_invoices', page=invoices.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ invoices.page }} of {{ invoices.pages }}</span>
+            </li>
+            {% if invoices.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('purchase.view_purchase_invoices', page=invoices.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -16,7 +16,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for order in orders %}
+        {% for order in orders.items %}
             <tr>
                 <td>{{ order.id }}</td>
                 <td>{{ order.vendor.first_name }} {{ order.vendor.last_name }}</td>
@@ -33,5 +33,22 @@
         </tbody>
     </table>
     </div>
+    <nav aria-label="Purchase order pagination">
+        <ul class="pagination">
+            {% if orders.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ orders.page }} of {{ orders.pages }}</span>
+            </li>
+            {% if orders.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}

--- a/app/templates/transfers/view_transfers.html
+++ b/app/templates/transfers/view_transfers.html
@@ -45,7 +45,8 @@
         </tr>
         </thead>
         <tbody>
-        {% for transfer in transfers %}
+        {% set transfer_items = transfers.items if transfers is defined else [] %}
+        {% for transfer in transfer_items %}
         <tr>
             <th scope="row">{{ transfer.id }}</th>
             <td>{{ transfer.from_location.name }}</td>
@@ -74,6 +75,25 @@
         </tbody>
     </table>
     </div>
+    {% if transfers is defined %}
+    <nav aria-label="Transfer pagination">
+        <ul class="pagination">
+            {% if transfers.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('transfer.view_transfers', page=transfers.prev_num, filter=request.args.get('filter'), transfer_id=request.args.get('transfer_id'), from_location=request.args.get('from_location'), to_location=request.args.get('to_location')) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ transfers.page }} of {{ transfers.pages }}</span>
+            </li>
+            {% if transfers.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('transfer.view_transfers', page=transfers.next_num, filter=request.args.get('filter'), transfer_id=request.args.get('transfer_id'), from_location=request.args.get('from_location'), to_location=request.args.get('to_location')) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
+    {% endif %}
 </div>
 <script>
     var protocol = window.location.protocol;


### PR DESCRIPTION
## Summary
- Paginate product listings and add page controls
- Paginate transfers with filters preserved in navigation
- Paginate purchase order and invoice lists

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8a5c3bf3483249b7f66d133f438da