### PR TITLE
docs: add build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Invoice Manager
+[![Build status](https://github.com/0xCarti/InvoiceManager/actions/workflows/build-main.yml/badge.svg?branch=main)](https://github.com/0xCarti/InvoiceManager/actions/workflows/build-main.yml)
 
 A Flask-based application for managing invoices, products and vendors. The project comes with a comprehensive test suite using `pytest`.
 


### PR DESCRIPTION
## Summary
- add GitHub Actions build badge to README

## Testing
- `pytest` *(fails: ModuleNotFoundError and subsequent errors as per log)*

------
https://chatgpt.com/codex/tasks/task_e_68b8acb646c08324af8ce16f21b9e600