### PR TITLE
docs: add MIT license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Invoice Manager
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A Flask-based application for managing invoices, products and vendors. The project comes with a comprehensive test suite using `pytest`.
 
 ## Installation


### PR DESCRIPTION
## Summary
- add MIT license badge to README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_limiter')*

------
https://chatgpt.com/codex/tasks/task_e_68b8acbc8b008324a0f947c2f6fd3b09