### PR TITLE
Add dependencies badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Invoice Manager
 
+[![Dependencies](https://img.shields.io/librariesio/github/0xCarti/InvoiceManager)](https://libraries.io/github/0xCarti/InvoiceManager)
+
 A Flask-based application for managing invoices, products and vendors. The project comes with a comprehensive test suite using `pytest`.
 
 ## Installation


### PR DESCRIPTION
## Summary
- add Libraries.io dependency badge to README

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: IndentationError in purchase_routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b8acbbc0488324ba965bbd7e10c704