### PR TITLE
Add test coverage workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Test Coverage
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest --cov=app --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Invoice Manager
+[![Coverage](https://codecov.io/gh/<OWNER>/InvoiceManager/branch/main/graph/badge.svg)](https://codecov.io/gh/<OWNER>/InvoiceManager)
 
 A Flask-based application for managing invoices, products and vendors. The project comes with a comprehensive test suite using `pytest`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ SQLAlchemy==2.0.27
 Werkzeug==3.1.3
 WTForms==3.1.2
 pytest==7.4.0
+pytest-cov==4.1.0
 Flask-Migrate==4.1.0
 Flask-SocketIO==5.5.1
 gunicorn==23.0.0


### PR DESCRIPTION
## Summary
- measure test coverage with `pytest-cov`
- run coverage in CI and upload to Codecov
- display Codecov coverage badge in README

## Testing
- `pytest --cov=app --cov-report=xml` *(failed: couldn't parse app/routes/purchase_routes.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b8acb656488324865fd1b224ee72e5