### PR TITLE
Fix indentation error in purchase routes

### DIFF
--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -85,7 +85,7 @@ def check_negative_invoice_reverse(invoice_obj):
 def view_purchase_orders():
     """Show outstanding purchase orders."""
     delete_form = DeleteForm()
-     page = request.args.get('page', 1, type=int)
+    page = request.args.get('page', 1, type=int)
     orders = (
         PurchaseOrder.query.filter_by(received=False)
         .order_by(PurchaseOrder.order_date.desc())


### PR DESCRIPTION
## Summary
- fix indentation in `view_purchase_orders` to prevent app startup crash

## Testing
- `python -m py_compile app/routes/purchase_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8b4d901c083248253ca04888fb03e