### PR TITLE
Add pre-commit configuration and formatting workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,17 @@
+name: Code style
+
+on:
+  pull_request:
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -91,6 +91,27 @@ pytest
 
 The tests automatically set the necessary environment variables, so no additional setup is required.
 
+## Code Style
+
+This project uses [pre-commit](https://pre-commit.com/) to run formatting and
+linting via **Black**, **isort**, and **Flake8**.
+
+Install the development dependencies and set up the hooks:
+
+```bash
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+Run all checks against the entire codebase with:
+
+```bash
+pre-commit run --all-files
+```
+
+A GitHub Actions workflow (`.github/workflows/format.yml`) executes these checks
+for every pull request.
+
 ## Features
 - Manage items, products, and invoices.
 - User authentication and admin features.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pre-commit
+black
+isort
+flake8


### PR DESCRIPTION
## Summary
- add pre-commit configuration using Black, isort, and Flake8
- add development requirements and GitHub Actions workflow for formatting checks
- document code style and pre-commit usage in README

## Testing
- `python -m pre_commit run --files README.md .pre-commit-config.yaml .github/workflows/format.yml requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8b685ed0c832494531376914bd7ed