### PR TITLE
Pin Python 3.12 in CI workflows

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install dependencies
         run: pip install pre-commit
       - name: Run pre-commit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- avoid building unsupported deps on Python 3.13 by explicitly using Python 3.12 in CI
- run pre-commit using Python 3.12 to match test environment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8c54fb6008324898153f3ec529808