### PR TITLE
Disable buildx provenance for GHCR

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -27,3 +27,5 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/${{ env.OWNER_LC }}/invoice-manager:dev
+          provenance: false
+          sbom: false

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -27,3 +27,5 @@ jobs:
           context: .
           push: true
           tags: ghcr.io/${{ env.OWNER_LC }}/invoice-manager:latest
+          provenance: false
+          sbom: false


### PR DESCRIPTION
## Summary
- avoid buildx `unknown blob` errors in CI by disabling provenance and SBOM when pushing to GHCR

## Testing
- `pre-commit run --files .github/workflows/build-main.yml .github/workflows/build-dev.yml`
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8cbbc4b1083249b4872b1ef474aa7