### PR TITLE
Add tests for deprecated modules and utilities

### DIFF
--- a/tests/test_deprecated_modules.py
+++ b/tests/test_deprecated_modules.py
@@ -1,0 +1,25 @@
+import importlib
+
+
+def test_activity_logger_reexports(monkeypatch):
+    """Ensure app.activity_logger forwards to app.utils.activity."""
+    called = {}
+    def fake_log_activity(message):
+        called["message"] = message
+    monkeypatch.setattr("app.utils.activity.log_activity", fake_log_activity)
+    module = importlib.reload(importlib.import_module("app.activity_logger"))
+    module.log_activity("hello")
+    assert called["message"] == "hello"
+
+
+def test_backup_utils_reexports(monkeypatch):
+    """Ensure app.backup_utils forwards to app.utils.backup."""
+    create_called = {}
+    restore_called = {}
+    monkeypatch.setattr("app.utils.backup.create_backup", lambda: create_called.setdefault("called", True))
+    monkeypatch.setattr("app.utils.backup.restore_backup", lambda: restore_called.setdefault("called", True))
+    module = importlib.reload(importlib.import_module("app.backup_utils"))
+    module.create_backup()
+    module.restore_backup()
+    assert create_called["called"]
+    assert restore_called["called"]

--- a/tests/test_run_module.py
+++ b/tests/test_run_module.py
@@ -1,0 +1,38 @@
+import importlib
+import runpy
+import sys
+from types import SimpleNamespace
+
+
+def test_run_import_sets_debug(monkeypatch):
+    def fake_create_app(argv):
+        return SimpleNamespace(debug=False), "socket"
+    monkeypatch.setattr("app.create_app", fake_create_app)
+    monkeypatch.setenv("DEBUG", "True")
+    run = importlib.reload(importlib.import_module("run"))
+    try:
+        assert run.app.debug is True
+        assert run.socketio == "socket"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(importlib.import_module("run"))
+
+
+def test_run_main_executes_server(monkeypatch):
+    def fake_create_app(argv):
+        return SimpleNamespace(debug=False), "sock"
+    monkeypatch.setattr("app.create_app", fake_create_app)
+    called = {}
+    def fake_server(listener, app):
+        called["listener"] = listener
+        called["app"] = app
+    monkeypatch.setattr("eventlet.wsgi.server", fake_server)
+    monkeypatch.setattr("eventlet.listen", lambda addr: ("listener", addr))
+    monkeypatch.setenv("PORT", "6000")
+    runpy.run_module("run", run_name="__main__")
+    try:
+        assert called["listener"] == ("listener", ("0.0.0.0", 6000))
+        assert called["app"] is not None
+    finally:
+        monkeypatch.undo()
+        importlib.reload(importlib.import_module("run"))

--- a/tests/test_sms_utils.py
+++ b/tests/test_sms_utils.py
@@ -1,0 +1,33 @@
+import pytest
+
+from types import SimpleNamespace
+
+
+def test_send_sms_missing_settings(monkeypatch):
+    # Ensure environment variables are absent
+    monkeypatch.delenv("TWILIO_ACCOUNT_SID", raising=False)
+    monkeypatch.delenv("TWILIO_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("TWILIO_PHONE_NUMBER", raising=False)
+    from app.utils import sms
+    with pytest.raises(RuntimeError):
+        sms.send_sms("+123", "hi")
+
+
+def test_send_sms_success(monkeypatch):
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "sid")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token")
+    monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+1999")
+
+    calls = []
+
+    class DummyClient:
+        def __init__(self, sid, token):
+            calls.append(("init", sid, token))
+            self.messages = self
+        def create(self, to, from_, body):
+            calls.append(("send", to, from_, body))
+
+    monkeypatch.setattr("app.utils.sms.Client", DummyClient)
+    from app.utils import sms
+    sms.send_sms("+1555", "Hello")
+    assert calls == [("init", "sid", "token"), ("send", "+1555", "+1999", "Hello")]


### PR DESCRIPTION
## Summary
- test deprecated module re-exports for activity and backup helpers
- cover Twilio SMS helper behavior for success and missing settings
- exercise run module import and main-server execution

## Testing
- `pytest --cov=app --cov=run --cov-report=term-missing -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8cd6c5d4c8324b4d5ec7b2301bc10