### PR TITLE
Add spoilage tracking workflow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -27,6 +27,7 @@ NAV_LINKS = {
     "item.view_items": "Items",
     "locations.view_locations": "Locations",
     "product.view_products": "Products",
+    "spoilage.view_spoilage": "Spoilage",
     "glcode.view_gl_codes": "GL Codes",
     "purchase.view_purchase_orders": "Purchase Orders",
     "purchase.view_purchase_invoices": "Purchase Invoices",
@@ -170,6 +171,7 @@ def create_app(args: list):
         from app.routes.purchase_routes import purchase
         from app.routes.report_routes import report
         from app.routes.transfer_routes import transfer
+        from app.routes.spoilage_routes import spoilage
         from app.routes.vendor_routes import vendor
 
         app.register_blueprint(auth, url_prefix="/auth")
@@ -177,6 +179,7 @@ def create_app(args: list):
         app.register_blueprint(location)
         app.register_blueprint(item)
         app.register_blueprint(transfer)
+        app.register_blueprint(spoilage)
         app.register_blueprint(admin)
         app.register_blueprint(customer)
         app.register_blueprint(invoice)

--- a/app/forms.py
+++ b/app/forms.py
@@ -217,6 +217,27 @@ class DateRangeForm(FlaskForm):
     )
 
 
+class SpoilageFilterForm(FlaskForm):
+    start_date = DateField("Start Date", validators=[Optional()])
+    end_date = DateField("End Date", validators=[Optional()])
+    purchase_gl_code = SelectField(
+        "Purchase GL Code", coerce=int, validators=[Optional()], validate_choice=False
+    )
+    items = SelectMultipleField(
+        "Items", coerce=int, validators=[Optional()], validate_choice=False
+    )
+    submit = SubmitField("Filter")
+
+    def __init__(self, *args, **kwargs):
+        super(SpoilageFilterForm, self).__init__(*args, **kwargs)
+        gl_codes = GLCode.query.filter(GLCode.code.like("5%"))
+        self.purchase_gl_code.choices = [
+            (g.id, f"{g.code} - {g.description}" if g.description else g.code)
+            for g in gl_codes
+        ]
+        self.items.choices = load_item_choices()
+
+
 class CustomerForm(FlaskForm):
     first_name = StringField("First Name", validators=[DataRequired()])
     last_name = StringField("Last Name", validators=[DataRequired()])

--- a/app/models.py
+++ b/app/models.py
@@ -87,6 +87,9 @@ class Location(db.Model):
     archived = db.Column(
         db.Boolean, default=False, nullable=False, server_default="0"
     )
+    is_spoilage = db.Column(
+        db.Boolean, default=False, nullable=False, server_default="0"
+    )
     products = db.relationship(
         "Product", secondary=location_products, backref="locations"
     )

--- a/app/routes/spoilage_routes.py
+++ b/app/routes/spoilage_routes.py
@@ -1,0 +1,59 @@
+"""Routes for handling spoilage tracking."""
+
+# flake8: noqa
+
+from datetime import datetime
+
+from flask import Blueprint, render_template, request
+from flask_login import login_required
+from sqlalchemy import and_
+
+from app import db
+from app.forms import SpoilageFilterForm
+from app.models import GLCode, Item, Location, Transfer, TransferItem
+
+spoilage = Blueprint("spoilage", __name__)
+
+
+@spoilage.route("/spoilage", methods=["GET"])
+@login_required
+def view_spoilage():
+    """Display spoilage items with optional filtering."""
+    form = SpoilageFilterForm(meta={"csrf": False})
+    form.process(request.args)
+
+    # alias for from location
+    from_location = db.aliased(Location)
+
+    query = (
+        db.session.query(TransferItem, Transfer, Item, from_location)
+        .join(Transfer, TransferItem.transfer_id == Transfer.id)
+        .join(Item, TransferItem.item_id == Item.id)
+        .join(from_location, Transfer.from_location_id == from_location.id)
+        .join(Location, Transfer.to_location_id == Location.id)
+        .filter(Transfer.completed.is_(True), Location.is_spoilage.is_(True))
+    )
+
+    start_date_str = request.args.get("start_date")
+    if start_date_str:
+        start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
+        form.start_date.data = start_date
+        query = query.filter(
+            Transfer.date_created >= datetime.combine(start_date, datetime.min.time())
+        )
+    end_date_str = request.args.get("end_date")
+    if end_date_str:
+        end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
+        form.end_date.data = end_date
+        query = query.filter(
+            Transfer.date_created <= datetime.combine(end_date, datetime.max.time())
+        )
+    if form.purchase_gl_code.data:
+        query = query.filter(Item.purchase_gl_code_id == form.purchase_gl_code.data)
+    if form.items.data:
+        query = query.filter(TransferItem.item_id.in_(form.items.data))
+
+    results = query.order_by(Transfer.date_created.desc()).all()
+
+    return render_template("spoilage/view_spoilage.html", form=form, results=results)
+

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -134,6 +134,12 @@
                             </a>
                         </li>
                         <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('spoilage.view_spoilage') }}">Spoilage</a>
+                            <a href="{{ url_for('auth.toggle_favorite', link='spoilage.view_spoilage') }}" class="ms-1">
+                                {% if 'spoilage.view_spoilage' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{% endif %}
+                            </a>
+                        </li>
+                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('item.view_items') }}">Items</a>
                             <a href="{{ url_for('auth.toggle_favorite', link='item.view_items') }}" class="ms-1">
                                 {% if 'item.view_items' in current_user.get_favorites() %}&#9733;{% else %}&#9734;{%

--- a/app/templates/spoilage/view_spoilage.html
+++ b/app/templates/spoilage/view_spoilage.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-5">
+    <h2>Spoilage</h2>
+    <form method="get" class="row g-3 mb-4">
+        <div class="col-auto">
+            {{ form.start_date.label }}
+            {{ form.start_date(class='form-control') }}
+        </div>
+        <div class="col-auto">
+            {{ form.end_date.label }}
+            {{ form.end_date(class='form-control') }}
+        </div>
+        <div class="col-auto">
+            {{ form.purchase_gl_code.label }}
+            {{ form.purchase_gl_code(class='form-select') }}
+        </div>
+        <div class="col-auto">
+            {{ form.items.label }}
+            {{ form.items(class='form-select', multiple=True) }}
+        </div>
+        <div class="col-auto align-self-end">
+            <button type="submit" class="btn btn-primary">Filter</button>
+        </div>
+    </form>
+    {% if results %}
+    <div class="mb-3">
+        <button onclick="window.print()" class="btn btn-secondary">Print</button>
+    </div>
+    <div class="table-responsive">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>From Location</th>
+                <th>Item</th>
+                <th>Quantity</th>
+                <th>Purchase GL Code</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for ti, tr, item, from_loc in results %}
+            <tr>
+                <td>{{ tr.date_created.date() }}</td>
+                <td>{{ from_loc.name }}</td>
+                <td>{{ item.name }}</td>
+                <td>{{ ti.quantity }}</td>
+                <td>{{ item.purchase_gl_code.code if item.purchase_gl_code else '' }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% else %}
+    <p>No spoilage records found.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_spoilage_flow.py
+++ b/tests/test_spoilage_flow.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta
+
+from app import db
+from app.models import GLCode, Item, Location, Transfer, TransferItem
+from tests.utils import login
+
+
+def test_spoilage_page_filters(client, app):
+    with app.app_context():
+        # set up locations
+        loc = Location(name="Main")
+        spoilage_loc = Location(name="Spoilage", is_spoilage=True)
+        db.session.add_all([loc, spoilage_loc])
+        db.session.commit()
+
+        # item with purchase gl code
+        gl = GLCode.query.filter_by(code="5000").first()
+        gl_id = gl.id
+        item = Item(name="Milk", base_unit="each", purchase_gl_code_id=gl_id)
+        db.session.add(item)
+        db.session.commit()
+
+        # transfer to spoilage
+        transfer = Transfer(
+            from_location_id=loc.id,
+            to_location_id=spoilage_loc.id,
+            user_id=1,
+            completed=True,
+        )
+        db.session.add(transfer)
+        db.session.flush()
+        ti = TransferItem(
+            transfer_id=transfer.id,
+            item_id=item.id,
+            quantity=2,
+            item_name=item.name,
+        )
+        db.session.add(ti)
+        db.session.commit()
+
+    login(client, "admin@example.com", "adminpass")
+
+    # unfiltered should show item
+    resp = client.get("/spoilage")
+    assert b"Milk" in resp.data
+
+    # filter by purchase gl code
+    resp = client.get(f"/spoilage?purchase_gl_code={gl_id}")
+    assert b"Milk" in resp.data
+


### PR DESCRIPTION
## Summary
- allow locations to be flagged as spoilage
- add spoilage report page with filters for GL code, items, and date range
- expose spoilage link in navigation and register blueprint
- test spoilage transfer and filtering by purchase GL code

## Testing
- `python3 -m pytest tests/test_spoilage_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9c6b536b48324b7643f803627d9d7