### PR TITLE
Add unit ratios to quick item form and fix backup permissions

### DIFF
--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -72,8 +72,16 @@
                         <input type="text" id="new-item-receiving-unit" class="form-control">
                     </div>
                     <div class="mb-3">
+                        <label for="new-item-receiving-factor" class="form-label">Receiving Ratio to Base Unit</label>
+                        <input type="number" step="any" id="new-item-receiving-factor" class="form-control" value="1">
+                    </div>
+                    <div class="mb-3">
                         <label for="new-item-transfer-unit" class="form-label">Transfer Unit</label>
                         <input type="text" id="new-item-transfer-unit" class="form-control">
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-item-transfer-factor" class="form-label">Transfer Ratio to Base Unit</label>
+                        <input type="number" step="any" id="new-item-transfer-factor" class="form-control" value="1">
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -86,7 +94,7 @@
 </div>
 
 <script>
-    const itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
+    let itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
 
     function createRow(index) {
@@ -145,13 +153,23 @@
         const glCode = document.getElementById('new-item-gl-code').value;
         const baseUnit = document.getElementById('new-item-base-unit').value;
         const recvUnit = document.getElementById('new-item-receiving-unit').value.trim();
+        const recvFactor = parseFloat(document.getElementById('new-item-receiving-factor').value) || 0;
         const transUnit = document.getElementById('new-item-transfer-unit').value.trim();
+        const transFactor = parseFloat(document.getElementById('new-item-transfer-factor').value) || 0;
         const csrfToken = document.querySelector('input[name="csrf_token"]').value;
-        if (!name || !recvUnit || !transUnit) return;
+        if (!name || !recvUnit || !transUnit || recvFactor <= 0 || transFactor <= 0) return;
         fetch('/items/quick_add', {
             method: 'POST',
             headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
-            body: JSON.stringify({name: name, purchase_gl_code: glCode, base_unit: baseUnit, receiving_unit: recvUnit, transfer_unit: transUnit})
+            body: JSON.stringify({
+                name: name,
+                purchase_gl_code: glCode,
+                base_unit: baseUnit,
+                receiving_unit: recvUnit,
+                receiving_factor: recvFactor,
+                transfer_unit: transUnit,
+                transfer_factor: transFactor
+            })
         }).then(r => r.json()).then(data => {
             if (data.id) {
                 itemOptions += `<option value="${data.id}">${data.name}</option>`;
@@ -160,7 +178,9 @@
                 });
                 document.getElementById('new-item-name').value = '';
                 document.getElementById('new-item-receiving-unit').value = '';
+                document.getElementById('new-item-receiving-factor').value = '1';
                 document.getElementById('new-item-transfer-unit').value = '';
+                document.getElementById('new-item-transfer-factor').value = '1';
                 bootstrap.Modal.getInstance(document.getElementById('newItemModal')).hide();
             }
         });

--- a/app/utils/backup.py
+++ b/app/utils/backup.py
@@ -23,6 +23,10 @@ def create_backup():
     """Create a timestamped copy of the database."""
     backups_dir = current_app.config["BACKUP_FOLDER"]
     os.makedirs(backups_dir, exist_ok=True)
+    try:
+        os.chmod(backups_dir, 0o777)
+    except OSError:
+        pass
     db_path = _get_db_path()
     filename = f"backup_{datetime.utcnow().strftime('%Y%m%d_%H%M%S')}.db"
     backup_path = os.path.join(backups_dir, filename)

--- a/tests/test_quick_item_creation.py
+++ b/tests/test_quick_item_creation.py
@@ -42,7 +42,9 @@ def test_quick_add_item_endpoint(client, app):
                 "purchase_gl_code": gl_id,
                 "base_unit": "each",
                 "receiving_unit": "case",
+                "receiving_factor": 12,
                 "transfer_unit": "each",
+                "transfer_factor": 1,
             },
         )
         assert resp.status_code == 200
@@ -59,4 +61,6 @@ def test_quick_add_item_endpoint(client, app):
         each_unit = next(u for u in units if u.name == "each")
         case_unit = next(u for u in units if u.name == "case")
         assert case_unit.receiving_default is True
+        assert case_unit.factor == 12
         assert each_unit.transfer_default is True
+        assert each_unit.factor == 1

--- a/tests/test_spoilage_flow.py
+++ b/tests/test_spoilage_flow.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import os
 
 from app import db
 from app.models import GLCode, Item, Location, Transfer, TransferItem
@@ -38,7 +39,9 @@ def test_spoilage_page_filters(client, app):
         db.session.add(ti)
         db.session.commit()
 
-    login(client, "admin@example.com", "adminpass")
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    admin_pass = os.getenv("ADMIN_PASS", "adminpass")
+    login(client, admin_email, admin_pass)
 
     # unfiltered should show item
     resp = client.get("/spoilage")


### PR DESCRIPTION
## Summary
- expand quick-add item API to include receiving/transfer unit ratios
- send new fields from purchase order quick item modal and fix const mutation error
- ensure backup directory is writable when creating backups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d603228c832498aace2b62c1f5fe