### PR TITLE
Improve purchase order item creation and navigation

### DIFF
--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -197,8 +197,12 @@ def edit_purchase_order(po_id):
             form.items[i].unit.data = poi.unit_id
             form.items[i].quantity.data = poi.quantity
 
+    codes = GLCode.query.filter(GLCode.code.like("5%"))
     return render_template(
-        "purchase_orders/edit_purchase_order.html", form=form, po=po
+        "purchase_orders/edit_purchase_order.html",
+        form=form,
+        po=po,
+        gl_codes=codes,
     )
 
 

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -176,6 +176,14 @@
                 document.querySelectorAll('.item-select').forEach(sel => {
                     sel.insertAdjacentHTML('beforeend', `<option value="${data.id}">${data.name}</option>`);
                 });
+
+                const row = createRow(itemIndex);
+                document.getElementById('items').appendChild(row);
+                const newSelect = row.querySelector('.item-select');
+                newSelect.value = data.id;
+                fetchUnits(newSelect);
+                itemIndex++;
+
                 document.getElementById('new-item-name').value = '';
                 document.getElementById('new-item-receiving-unit').value = '';
                 document.getElementById('new-item-receiving-factor').value = '1';

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -21,6 +21,7 @@
             {{ form.delivery_charge(class="form-control narrow-field") }}
         </div>
         <h4>Items</h4>
+        <button id="quick-add-item" type="button" class="btn btn-link p-0">Create New Item</button>
         <div id="items">
         {% for item in form.items %}
         <div class="row g-2 mt-2 item-row align-items-center">
@@ -36,10 +37,64 @@
         <button id="add-item" type="button" class="btn btn-secondary mt-3">Add Item</button>
         <button type="submit" class="btn btn-primary mt-3">Submit</button>
     </form>
+
+    <div class="modal fade" id="newItemModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Create Item</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="new-item-name" class="form-label">Name</label>
+                        <input type="text" id="new-item-name" class="form-control">
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-item-gl-code" class="form-label">Purchase GL Code</label>
+                        <select id="new-item-gl-code" class="form-select">
+                            {% for code in gl_codes %}
+                                <option value="{{ code.id }}">{{ code.code }}{% if code.description %} - {{ code.description }}{% endif %}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-item-base-unit" class="form-label">Base Unit</label>
+                        <select id="new-item-base-unit" class="form-select">
+                            <option value="ounce">Ounce</option>
+                            <option value="gram">Gram</option>
+                            <option value="each" selected>Each</option>
+                            <option value="millilitre">Millilitre</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-item-receiving-unit" class="form-label">Receiving Unit</label>
+                        <input type="text" id="new-item-receiving-unit" class="form-control">
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-item-receiving-factor" class="form-label">Receiving Ratio to Base Unit</label>
+                        <input type="number" step="any" id="new-item-receiving-factor" class="form-control" value="1">
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-item-transfer-unit" class="form-label">Transfer Unit</label>
+                        <input type="text" id="new-item-transfer-unit" class="form-control">
+                    </div>
+                    <div class="mb-3">
+                        <label for="new-item-transfer-factor" class="form-label">Transfer Ratio to Base Unit</label>
+                        <input type="number" step="any" id="new-item-transfer-factor" class="form-control" value="1">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" id="save-new-item" class="btn btn-primary">Save Item</button>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script>
-    const itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
+    let itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
 
     function createRow(index) {
@@ -87,6 +142,56 @@
         if (e.target && e.target.classList.contains('item-select')) {
             fetchUnits(e.target);
         }
+    });
+
+    document.getElementById('quick-add-item').addEventListener('click', function() {
+        new bootstrap.Modal(document.getElementById('newItemModal')).show();
+    });
+
+    document.getElementById('save-new-item').addEventListener('click', function() {
+        const name = document.getElementById('new-item-name').value.trim();
+        const glCode = document.getElementById('new-item-gl-code').value;
+        const baseUnit = document.getElementById('new-item-base-unit').value;
+        const recvUnit = document.getElementById('new-item-receiving-unit').value.trim();
+        const recvFactor = parseFloat(document.getElementById('new-item-receiving-factor').value) || 0;
+        const transUnit = document.getElementById('new-item-transfer-unit').value.trim();
+        const transFactor = parseFloat(document.getElementById('new-item-transfer-factor').value) || 0;
+        const csrfToken = document.querySelector('input[name="csrf_token"]').value;
+        if (!name || !recvUnit || !transUnit || recvFactor <= 0 || transFactor <= 0) return;
+        fetch('/items/quick_add', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
+            body: JSON.stringify({
+                name: name,
+                purchase_gl_code: glCode,
+                base_unit: baseUnit,
+                receiving_unit: recvUnit,
+                receiving_factor: recvFactor,
+                transfer_unit: transUnit,
+                transfer_factor: transFactor
+            })
+        }).then(r => r.json()).then(data => {
+            if (data.id) {
+                itemOptions += `<option value="${data.id}">${data.name}</option>`;
+                document.querySelectorAll('.item-select').forEach(sel => {
+                    sel.insertAdjacentHTML('beforeend', `<option value="${data.id}">${data.name}</option>`);
+                });
+
+                const row = createRow(itemIndex);
+                document.getElementById('items').appendChild(row);
+                const newSelect = row.querySelector('.item-select');
+                newSelect.value = data.id;
+                fetchUnits(newSelect);
+                itemIndex++;
+
+                document.getElementById('new-item-name').value = '';
+                document.getElementById('new-item-receiving-unit').value = '';
+                document.getElementById('new-item-receiving-factor').value = '1';
+                document.getElementById('new-item-transfer-unit').value = '';
+                document.getElementById('new-item-transfer-factor').value = '1';
+                bootstrap.Modal.getInstance(document.getElementById('newItemModal')).hide();
+            }
+        });
     });
 
     document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -158,6 +158,21 @@
         }
     });
 
+    document.getElementById('items').addEventListener('keydown', function(e) {
+        if (
+            e.target &&
+            e.target.classList.contains('cost') &&
+            e.key === 'Tab' &&
+            !e.shiftKey
+        ) {
+            const nextRow = e.target.closest('.item-row').nextElementSibling;
+            if (nextRow && nextRow.querySelector('.cost')) {
+                e.preventDefault();
+                nextRow.querySelector('.cost').focus();
+            }
+        }
+    });
+
     document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
     document.getElementById('gst').addEventListener('input', updateTotals);
     document.getElementById('pst').addEventListener('input', updateTotals);


### PR DESCRIPTION
## Summary
- Allow quick-creating items when editing purchase orders and auto-insert them
- Auto-insert newly quick-created items on create purchase order page
- Pass GL codes to edit purchase order template and add tab navigation for cost fields on receiving page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9e3aa7e008324ab1a36ecd4ae1146