### PR TITLE
Enhance purchase workflows for returns and navigation

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -489,7 +489,7 @@ class PurchaseInvoiceItem(db.Model):
 
     @property
     def line_total(self):
-        return self.quantity * self.cost
+        return self.quantity * abs(self.cost)
 
 
 class PurchaseOrderItemArchive(db.Model):

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -299,9 +299,10 @@ def receive_invoice(po_id):
                 request.form.get(f"items-{index}-return_item") is not None
             )
             if item_id and quantity is not None and cost is not None:
+                quantity = abs(quantity)
+                cost = abs(cost)
                 if is_return:
-                    quantity = -abs(quantity)
-                    cost = -abs(cost)
+                    quantity = -quantity
 
                 item_obj = db.session.get(Item, item_id)
                 unit_obj = (
@@ -328,7 +329,7 @@ def receive_invoice(po_id):
                         item_obj.quantity or 0
                     ) + quantity * factor
                     # store cost per base unit (always positive)
-                    item_obj.cost = abs(cost) / factor if factor else abs(cost)
+                    item_obj.cost = cost / factor if factor else cost
                     record = LocationStandItem.query.filter_by(
                         location_id=invoice.location_id, item_id=item_obj.id
                     ).first()
@@ -368,7 +369,7 @@ def view_purchase_invoices():
     """List all received purchase invoices."""
     page = request.args.get("page", 1, type=int)
     invoices = PurchaseInvoice.query.order_by(
-        PurchaseInvoice.received_date.desc()
+        PurchaseInvoice.received_date.desc(), PurchaseInvoice.id.desc()
     ).paginate(page=page, per_page=20)
     return render_template(
         "purchase_invoices/view_purchase_invoices.html", invoices=invoices

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -27,7 +27,7 @@
         <div class="row g-2 mt-2 item-row align-items-center">
             <div class="col">{{ item.item(class="form-control item-select") }}</div>
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
-            <div class="col">{{ item.quantity(class="form-control") }}</div>
+            <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col-auto">
                 <button type="button" class="btn btn-danger remove-item">Remove</button>
             </div>
@@ -103,7 +103,7 @@
         row.innerHTML = `
             <div class="col"><select name="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
             <div class="col"><select name="items-${index}-unit" class="form-control unit-select"></select></div>
-            <div class="col"><input type="number" step="any" name="items-${index}-quantity" class="form-control"></div>
+            <div class="col"><input type="number" step="any" name="items-${index}-quantity" class="form-control quantity"></div>
             <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
         `;
         return row;
@@ -141,6 +141,21 @@
     document.getElementById('items').addEventListener('change', function(e) {
         if (e.target && e.target.classList.contains('item-select')) {
             fetchUnits(e.target);
+        }
+    });
+
+    document.getElementById('items').addEventListener('keydown', function(e) {
+        if (
+            e.target &&
+            e.target.classList.contains('quantity') &&
+            e.key === 'Tab' &&
+            !e.shiftKey
+        ) {
+            const nextRow = e.target.closest('.item-row').nextElementSibling;
+            if (nextRow && nextRow.querySelector('.quantity')) {
+                e.preventDefault();
+                nextRow.querySelector('.quantity').focus();
+            }
         }
     });
 

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -168,7 +168,9 @@
             const nextRow = e.target.closest('.item-row').nextElementSibling;
             if (nextRow && nextRow.querySelector('.cost')) {
                 e.preventDefault();
-                nextRow.querySelector('.cost').focus();
+                const nextCost = nextRow.querySelector('.cost');
+                nextCost.focus();
+                nextCost.select();
             }
         }
     });

--- a/tests/test_purchase_flow.py
+++ b/tests/test_purchase_flow.py
@@ -287,9 +287,10 @@ def test_receive_prefills_items_and_return(client, app):
 
     with app.app_context():
         inv_item = PurchaseInvoiceItem.query.first()
-        assert inv_item.cost == -1.5
+        assert inv_item.cost == 1.5
         assert inv_item.quantity == -3
         assert inv_item.unit_id == unit_id
+        assert inv_item.line_total == -4.5
 
 
 def test_edit_purchase_order_updates(client, app):


### PR DESCRIPTION
## Summary
- Enable tabbing between quantity inputs when creating purchase orders
- Auto-select next cost field on tab in invoice receiving
- Treat returned invoice items as negative and sort purchase invoices by newest

## Testing
- `pre-commit run --files app/models.py app/routes/purchase_routes.py app/templates/purchase_orders/create_purchase_order.html app/templates/purchase_orders/receive_invoice.html tests/test_purchase_flow.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba01adb9408324a6e950ba06ba293e