### PR TITLE
Enable batch mode for SQLite migrations

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -99,8 +99,12 @@ def run_migrations_online():
     connectable = get_engine()
 
     with connectable.connect() as connection:
+        render_as_batch = connection.dialect.name == "sqlite"
         context.configure(
-            connection=connection, target_metadata=get_metadata(), **conf_args
+            connection=connection,
+            target_metadata=get_metadata(),
+            render_as_batch=render_as_batch,
+            **conf_args,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
## Summary
- configure Alembic to use SQLite batch mode when running migrations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba09a38a4c83249d884dcb97524862