### PR TITLE
Avoid duplicate render_as_batch during Alembic migrations

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -100,10 +100,10 @@ def run_migrations_online():
 
     with connectable.connect() as connection:
         render_as_batch = connection.dialect.name == "sqlite"
+        conf_args.setdefault("render_as_batch", render_as_batch)
         context.configure(
             connection=connection,
             target_metadata=get_metadata(),
-            render_as_batch=render_as_batch,
             **conf_args,
         )
 


### PR DESCRIPTION
## Summary
- ensure `render_as_batch` isn't passed twice when configuring Alembic

## Testing
- `pre-commit run --files migrations/env.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba0e60ac20832481a7eec8d739dabd