### PR TITLE
Improve transfer workflow and login UX

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -311,16 +311,19 @@ def item_units(item_id):
     item = db.session.get(Item, item_id)
     if item is None:
         abort(404)
-    data = [
-        {
-            "id": u.id,
-            "name": u.name,
-            "factor": u.factor,
-            "receiving_default": u.receiving_default,
-            "transfer_default": u.transfer_default,
-        }
-        for u in item.units
-    ]
+    data = {
+        "base_unit": item.base_unit,
+        "units": [
+            {
+                "id": u.id,
+                "name": u.name,
+                "factor": u.factor,
+                "receiving_default": u.receiving_default,
+                "transfer_default": u.transfer_default,
+            }
+            for u in item.units
+        ],
+    }
     return jsonify(data)
 
 

--- a/app/routes/transfer_routes.py
+++ b/app/routes/transfer_routes.py
@@ -432,7 +432,14 @@ def generate_report():
                 Transfer.date_created >= start_datetime,
                 Transfer.date_created <= end_datetime,
             )
-            .group_by(from_location.name, to_location.name, Item.name)
+            .group_by(
+                from_location.id,
+                to_location.id,
+                Item.id,
+                from_location.name,
+                to_location.name,
+                Item.name,
+            )
             .order_by(from_location.name, to_location.name, Item.name)
             .all()
         )

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -12,7 +12,10 @@
             </div>
             <div class="form-group">
                 {{ form.password.label(class_="form-label") }}
-                {{ form.password(class_="form-control") }}
+                <div class="input-group">
+                    {{ form.password(class_="form-control", id="password-field") }}
+                    <button class="btn btn-outline-secondary" type="button" id="toggle-password">Show</button>
+                </div>
             </div>
             <button type="submit" class="btn btn-primary mt-2">Login</button>
         </form>
@@ -25,4 +28,16 @@
         {% endif %}
     </div>
 </div>
+<script>
+document.getElementById('toggle-password').addEventListener('click', function() {
+    var pwd = document.getElementById('password-field');
+    if (pwd.type === 'password') {
+        pwd.type = 'text';
+        this.textContent = 'Hide';
+    } else {
+        pwd.type = 'password';
+        this.textContent = 'Show';
+    }
+});
+</script>
 {% endblock %}

--- a/app/templates/transfers/add_transfer.html
+++ b/app/templates/transfers/add_transfer.html
@@ -5,34 +5,33 @@
     <h2>Add New Transfer</h2>
     <form method="POST">
         {{ form.hidden_tag() }}
-        <div class="form-group">
-            {{ form.from_location_id.label(class="form-label") }}
-            {{ form.from_location_id(class="form-control narrow-field") }}
-            {% if form.from_location_id.errors %}
-            {% for error in form.from_location_id.errors %}
-            <div class="alert alert-danger">{{ error }}</div>
-            {% endfor %}
-            {% endif %}
-        </div>
-        <div class="form-group">
-            {{ form.to_location_id.label(class="form-label") }}
-            {{ form.to_location_id(class="form-control narrow-field") }}
-            {% if form.to_location_id.errors %}
-            {% for error in form.to_location_id.errors %}
-            <div class="alert alert-danger">{{ error }}</div>
-            {% endfor %}
-            {% endif %}
+        <div class="row">
+            <div class="col-md-6">
+                <div class="form-group">
+                    {{ form.from_location_id.label(class="form-label") }}
+                    {{ form.from_location_id(class="form-control") }}
+                    {% for error in form.from_location_id.errors %}
+                    <div class="alert alert-danger">{{ error }}</div>
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="form-group">
+                    {{ form.to_location_id.label(class="form-label") }}
+                    {{ form.to_location_id(class="form-control") }}
+                    {% for error in form.to_location_id.errors %}
+                    <div class="alert alert-danger">{{ error }}</div>
+                    {% endfor %}
+                </div>
+            </div>
         </div>
         <h3>Add Items</h3>
         <div class="form-group">
             <label for="item-name" class="form-label">Item Name</label>
-            <input type="text" id="item-name" class="form-control narrow-field" name="item-name" autocomplete="off">
+            <input type="text" id="item-name" class="form-control" name="item-name" autocomplete="off">
             <div id="suggestions"></div>
         </div>
-        <div id="item-list" class="mb-3">
-            <!-- Item list will be dynamically populated -->
-        </div>
-        <br>
+        <div id="item-list" class="mb-3"></div>
         {{ form.submit(class="btn btn-success") }}
     </form>
 </div>
@@ -73,10 +72,13 @@
     });
 
     function addItemToList(item) {
-        fetch(`/items/${item.id}/units`).then(r => r.json()).then(units => {
+        fetch(`/items/${item.id}/units`).then(r => r.json()).then(data => {
+            const base = data.base_unit;
+            const units = data.units;
             var options = '';
             units.forEach(u => {
-                options += `<option value="${u.id}">${u.name}</option>`;
+                const label = `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
+                options += `<option value="${u.id}" data-factor="${u.factor}" ${u.transfer_default ? 'selected' : ''}>${label}</option>`;
             });
             var listItem = document.createElement('div');
             listItem.classList.add('item-container', 'd-flex', 'justify-content-between', 'align-items-center', 'mb-2');
@@ -84,11 +86,22 @@
                 <div style="padding-left: 15px; font-weight: bold;">${item.name}</div>
                 <div class="d-flex align-items-center">
                     <input type="hidden" name="items-${itemIndex}-item" value="${item.id}">
-                    <select name="items-${itemIndex}-unit" class="form-control me-2" style="max-width: 120px;">${options}</select>
-                    <input type="number" step="any" class="form-control quantity" name="items-${itemIndex}-quantity" placeholder="Qty" style="max-width: 120px;">
+                    <select name="items-${itemIndex}-unit" class="form-control me-2" style="max-width: 160px;">${options}</select>
+                    <input type="number" step="any" class="form-control quantity" name="items-${itemIndex}-quantity" placeholder="Qty" style="max-width: 120px;" data-base-qty="0">
                     <button type="button" class="btn btn-danger delete-item ml-2">Delete</button>
                 </div>
             `;
+            const qtyInput = listItem.querySelector('.quantity');
+            const unitSelect = listItem.querySelector('select');
+            qtyInput.addEventListener('input', function(){
+                const factor = parseFloat(unitSelect.selectedOptions[0].dataset.factor);
+                this.dataset.baseQty = (parseFloat(this.value) || 0) * factor;
+            });
+            unitSelect.addEventListener('change', function(){
+                const factor = parseFloat(this.selectedOptions[0].dataset.factor);
+                const qty = listItem.querySelector('.quantity');
+                qty.value = (parseFloat(qty.dataset.baseQty) || 0) / factor;
+            });
             document.getElementById('item-list').appendChild(listItem);
             document.getElementById('suggestions').innerHTML = '';
             document.getElementById('item-name').value = '';

--- a/app/templates/transfers/edit_transfer.html
+++ b/app/templates/transfers/edit_transfer.html
@@ -2,46 +2,47 @@
 
 {% block content %}
 <div class="container mt-4">
-    <h2>Add New Transfer</h2>
+    <h2>Edit Transfer</h2>
     <form method="POST">
         {{ form.hidden_tag() }}
-        <div class="form-group">
-            {{ form.from_location_id.label(class="form-label") }}
-            {{ form.from_location_id(class="form-control narrow-field") }}
-            {% if form.from_location_id.errors %}
-            {% for error in form.from_location_id.errors %}
-            <div class="alert alert-danger">{{ error }}</div>
-            {% endfor %}
-            {% endif %}
-        </div>
-        <div class="form-group">
-            {{ form.to_location_id.label(class="form-label") }}
-            {{ form.to_location_id(class="form-control narrow-field") }}
-            {% if form.to_location_id.errors %}
-            {% for error in form.to_location_id.errors %}
-            <div class="alert alert-danger">{{ error }}</div>
-            {% endfor %}
-            {% endif %}
+        <div class="row">
+            <div class="col-md-6">
+                <div class="form-group">
+                    {{ form.from_location_id.label(class="form-label") }}
+                    {{ form.from_location_id(class="form-control") }}
+                    {% for error in form.from_location_id.errors %}
+                    <div class="alert alert-danger">{{ error }}</div>
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="form-group">
+                    {{ form.to_location_id.label(class="form-label") }}
+                    {{ form.to_location_id(class="form-control") }}
+                    {% for error in form.to_location_id.errors %}
+                    <div class="alert alert-danger">{{ error }}</div>
+                    {% endfor %}
+                </div>
+            </div>
         </div>
         <h3>Add Items</h3>
         <div class="form-group">
             <label for="item-name" class="form-label">Item Name</label>
-            <input type="text" id="item-name" class="form-control narrow-field" name="item-name" autocomplete="off">
+            <input type="text" id="item-name" class="form-control" name="item-name" autocomplete="off">
             <div id="suggestions"></div>
         </div>
-        <div id="item-list" class="mb-3">
-            <!-- Item list will be dynamically populated -->
-        </div>
-        <br>
+        <div id="item-list" class="mb-3"></div>
         {{ form.submit(class="btn btn-success") }}
     </form>
 </div>
 <script>
+    let itemIndex = 0;
     window.addEventListener('DOMContentLoaded', (event) => {
     const existingItems = {{ items | tojson | safe }};
     existingItems.forEach((item, index) => {
-        addItemToList(item, index); // Pass both item and its index
+        addItemToList(item, index);
     });
+    itemIndex = existingItems.length;
 });
 
 
@@ -74,25 +75,45 @@ document.addEventListener('click', function(event) {
     if (event.target && event.target.classList.contains('suggestion')) {
         var itemName = event.target.textContent; // Get the item name from textContent
         var itemId = event.target.dataset.id; // Get the item ID from data attribute
-        addItemToList({id: itemId, name: itemName}); // Pass an object with both id and name
+        addItemToList({id: itemId, name: itemName}, itemIndex);
+        itemIndex++;
     }
 });
 
 function addItemToList(item, index) {
-    fetch(`/items/${item.id}/units`).then(r => r.json()).then(units => {
+    fetch(`/items/${item.id}/units`).then(r => r.json()).then(data => {
+        const base = data.base_unit;
+        const units = data.units;
         var options = '';
-        units.forEach(u => { options += `<option value="${u.id}">${u.name}</option>`; });
+        let defaultUnit = units.find(u => u.transfer_default) || units[0];
+        units.forEach(u => {
+            const label = `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
+            const selected = u.id === defaultUnit.id ? 'selected' : '';
+            options += `<option value="${u.id}" data-factor="${u.factor}" ${selected}>${label}</option>`;
+        });
         var listItem = document.createElement('div');
         listItem.classList.add('item-container', 'd-flex', 'justify-content-between', 'align-items-center', 'mb-2');
+        const displayQty = item.quantity ? item.quantity / defaultUnit.factor : 0;
         listItem.innerHTML = `
             <div style="padding-left: 15px; font-weight: bold;">${item.name}</div>
             <div class="d-flex align-items-center">
                 <input type="hidden" name="items-${index}-item" value="${item.id}">
-                <select name="items-${index}-unit" class="form-control me-2" style="max-width: 120px;">${options}</select>
-                <input type="number" step="any" class="form-control quantity" name="items-${index}-quantity" value="${item.quantity}" placeholder="Qty" style="max-width: 120px;">
+                <select name="items-${index}-unit" class="form-control me-2" style="max-width: 160px;">${options}</select>
+                <input type="number" step="any" class="form-control quantity" name="items-${index}-quantity" value="${displayQty}" placeholder="Qty" style="max-width: 120px;" data-base-qty="${item.quantity}">
                 <button type="button" class="btn btn-danger delete-item mx-2">Delete</button>
             </div>
         `;
+        const qtyInput = listItem.querySelector('.quantity');
+        const unitSelect = listItem.querySelector('select');
+        qtyInput.addEventListener('input', function(){
+            const factor = parseFloat(unitSelect.selectedOptions[0].dataset.factor);
+            this.dataset.baseQty = (parseFloat(this.value) || 0) * factor;
+        });
+        unitSelect.addEventListener('change', function(){
+            const factor = parseFloat(this.selectedOptions[0].dataset.factor);
+            const qty = listItem.querySelector('.quantity');
+            qty.value = (parseFloat(qty.dataset.baseQty) || 0) / factor;
+        });
         document.getElementById('item-list').appendChild(listItem);
     });
 }


### PR DESCRIPTION
## Summary
- Add password visibility toggle on login screen
- Show unit ratios and better layout on transfer create/edit pages
- Preserve base quantities when editing transfers
- Aggregate transfer report by from/to locations and items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba550baac08324a8906e2623c474b6