### PR TITLE
Allow creating spoilage locations

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -62,6 +62,7 @@ class LocationForm(FlaskForm):
         "Location Name", validators=[DataRequired(), Length(min=2, max=100)]
     )
     products = HiddenField("Products")
+    is_spoilage = BooleanField("Spoilage Location")
     submit = SubmitField("Submit")
 
 

--- a/app/routes/location_routes.py
+++ b/app/routes/location_routes.py
@@ -23,7 +23,9 @@ def add_location():
     """Create a new location."""
     form = LocationForm()
     if form.validate_on_submit():
-        new_location = Location(name=form.name.data)
+        new_location = Location(
+            name=form.name.data, is_spoilage=form.is_spoilage.data
+        )
         product_ids = (
             [int(pid) for pid in form.products.data.split(",") if pid]
             if form.products.data
@@ -82,6 +84,7 @@ def edit_location(location_id):
 
     if form.validate_on_submit():
         location.name = form.name.data
+        location.is_spoilage = form.is_spoilage.data
         product_ids = (
             [int(pid) for pid in form.products.data.split(",") if pid]
             if form.products.data

--- a/app/templates/locations/add_location.html
+++ b/app/templates/locations/add_location.html
@@ -9,6 +9,10 @@
             {{ form.name.label(class="form-label") }}
             {{ form.name(class="form-control") }}
         </div>
+        <div class="form-check mb-3">
+            {{ form.is_spoilage(class="form-check-input") }}
+            {{ form.is_spoilage.label(class="form-check-label") }}
+        </div>
         <div class="form-group">
             <label for="productSearch" class="form-label">Select Products</label>
             <input type="text" id="productSearch" class="form-control" placeholder="Enter product name" autocomplete="off">

--- a/app/templates/locations/edit_location.html
+++ b/app/templates/locations/edit_location.html
@@ -9,6 +9,10 @@
             {{ form.name.label(class="form-label") }}
             {{ form.name(class="form-control") }}
         </div>
+        <div class="form-check mb-3">
+            {{ form.is_spoilage(class="form-check-input") }}
+            {{ form.is_spoilage.label(class="form-check-label") }}
+        </div>
         <div class="form-group">
             <label for="productSearch" class="form-label">Select Products</label>
             <input type="text" id="productSearch" class="form-control" placeholder="Enter product name" autocomplete="off">

--- a/tests/test_user_flows.py
+++ b/tests/test_user_flows.py
@@ -84,10 +84,13 @@ def test_add_location(client, app):
     with client:
         login(client, "loc@example.com", "pass")
         response = client.post(
-            "/locations/add", data={"name": "Warehouse"}, follow_redirects=True
+            "/locations/add",
+            data={"name": "Warehouse", "is_spoilage": "y"},
+            follow_redirects=True,
         )
         assert response.status_code == 200
 
     with app.app_context():
         location = Location.query.filter_by(name="Warehouse").first()
         assert location is not None
+        assert location.is_spoilage


### PR DESCRIPTION
## Summary
- add `is_spoilage` checkbox to location form and templates
- persist spoilage flag in add/edit location routes
- test creating a spoilage location

## Testing
- `pytest tests/test_user_flows.py::test_add_location tests/test_spoilage_flow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba699505688324b5b39db448dfd31f