### PR TITLE
Add downloadable example files for data imports

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -97,6 +97,7 @@ def create_app(args: list):
     # always point to the intended location.
 
     base_dir = os.getcwd()
+    repo_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     # Allow overriding the database location via the DATABASE_PATH environment
     # variable.  This is useful for container deployments where the database
     # may reside in a mounted volume.  If the provided path is a directory,
@@ -110,9 +111,11 @@ def create_app(args: list):
     app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{db_path}"
     app.config["UPLOAD_FOLDER"] = os.path.join(base_dir, "uploads")
     app.config["BACKUP_FOLDER"] = os.path.join(base_dir, "backups")
+    app.config["IMPORT_FILES_FOLDER"] = os.path.join(repo_dir, "import_files")
 
     os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
     os.makedirs(app.config["BACKUP_FOLDER"], exist_ok=True)
+    os.makedirs(app.config["IMPORT_FILES_FOLDER"], exist_ok=True)
 
     if "--demo" in args:
         app.config["DEMO"] = True

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -535,6 +535,22 @@ def import_page():
     return render_template("admin/imports.html", forms=forms, labels=labels)
 
 
+@admin.route("/controlpanel/import/<string:data_type>/example", methods=["GET"])
+@login_required
+def download_example(data_type):
+    """Download an example CSV file for the given data type."""
+    from flask import current_app, send_from_directory
+
+    if not current_user.is_admin:
+        abort(403)
+    if data_type not in IMPORT_FILES:
+        abort(404)
+    directory = current_app.config["IMPORT_FILES_FOLDER"]
+    filename = IMPORT_FILES[data_type]
+    log_activity(f"Downloaded example import file for {data_type}")
+    return send_from_directory(directory, filename, as_attachment=True)
+
+
 @admin.route("/controlpanel/import/<string:data_type>", methods=["POST"])
 @login_required
 def import_data(data_type):

--- a/app/templates/admin/imports.html
+++ b/app/templates/admin/imports.html
@@ -9,6 +9,7 @@
         <div class="mb-2">
             {{ forms[key].file(class="form-control") }}
         </div>
+        <a href="{{ url_for('admin.download_example', data_type=key) }}" class="btn btn-secondary me-2">Download Example</a>
         <button type="submit" class="btn btn-primary">{{ label }}</button>
     </form>
     {% endfor %}

--- a/tests/test_admin_imports.py
+++ b/tests/test_admin_imports.py
@@ -27,3 +27,19 @@ def test_admin_can_import_gl_codes(client, app):
         assert b"Imported 1 gl codes." in resp.data
     with app.app_context():
         assert GLCode.query.filter_by(code="7000").first() is not None
+
+
+def test_admin_can_download_example_import_file(client, app):
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    admin_pass = os.getenv("ADMIN_PASS", "adminpass")
+    with client:
+        login(client, admin_email, admin_pass)
+        resp = client.get("/controlpanel/import/locations/example")
+        assert resp.status_code == 200
+        with app.app_context():
+            path = os.path.join(
+                app.config["IMPORT_FILES_FOLDER"], "example_locations.csv"
+            )
+            with open(path, "rb") as fh:
+                expected = fh.read()
+        assert resp.data == expected


### PR DESCRIPTION
## Summary
- Allow admins to download example CSV files for each import type
- Configure app with static `IMPORT_FILES_FOLDER`
- Expose download links on import page and test example file downloads

## Testing
- `pytest tests/test_admin_imports.py::test_admin_can_download_example_import_file -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba69b2ab708324a9567b600ade0329