### PR TITLE
Optimize form data loading for large selections

### DIFF
--- a/app/templates/report_product_recipe.html
+++ b/app/templates/report_product_recipe.html
@@ -2,6 +2,12 @@
 {% block content %}
 <div class="container mt-5">
     <h2>Product Recipe Report</h2>
+    <form method="GET" class="mb-3">
+        <div class="input-group">
+            <input type="text" class="form-control" name="search" placeholder="Search products" value="{{ search or '' }}">
+            <button type="submit" class="btn btn-secondary">Search</button>
+        </div>
+    </form>
     <form method="POST" class="mb-4">
         {{ form.hidden_tag() }}
         <div class="form-check mb-2">


### PR DESCRIPTION
## Summary
- Cache item choices per request and reuse location queries in transfer form
- Lazy-load product choices with search for recipe reports
- Add search UI for recipe report product selection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb2c9aab048324b71f5ec9a2295797