### PR TITLE
Auto seed admin user during container startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,23 @@ set -e
 
 flask db upgrade
 
+# Ensure the database has the initial admin user and settings
+python <<'PYTHON'
+from seed_data import seed_initial_data
+from app import create_app
+from app.models import User, Setting
+
+app, _ = create_app([])
+with app.app_context():
+    needs_seed = (
+        User.query.filter_by(is_admin=True).first() is None
+        or Setting.query.filter_by(name="GST").first() is None
+        or Setting.query.filter_by(name="DEFAULT_TIMEZONE").first() is None
+    )
+    if needs_seed:
+        seed_initial_data()
+PYTHON
+
 if [ "$1" = "gunicorn" ]; then
     shift
     exec gunicorn --bind "0.0.0.0:${PORT}" "$@"


### PR DESCRIPTION
## Summary
- Ensure entrypoint checks for admin user and required settings
- Run seed script automatically when admin or settings are missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb777026ec83248c6dac0eb93af1c7