### PR TITLE
Add pagination to GL code list view

### DIFF
--- a/app/routes/glcode_routes.py
+++ b/app/routes/glcode_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, abort, flash, redirect, render_template, url_for
+from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
 from flask_login import login_required
 
 from app import db
@@ -12,7 +12,8 @@ glcode_bp = Blueprint("glcode", __name__)
 @login_required
 def view_gl_codes():
     """List GL codes."""
-    codes = GLCode.query.all()
+    page = request.args.get("page", 1, type=int)
+    codes = GLCode.query.order_by(GLCode.code).paginate(page, per_page=20)
     delete_form = DeleteForm()
     return render_template(
         "gl_codes/view_gl_codes.html", codes=codes, delete_form=delete_form

--- a/app/templates/gl_codes/view_gl_codes.html
+++ b/app/templates/gl_codes/view_gl_codes.html
@@ -14,7 +14,7 @@
             </tr>
         </thead>
         <tbody>
-            {% for code in codes %}
+            {% for code in codes.items %}
             <tr>
                 <td>{{ code.code }}</td>
                 <td>{{ code.description or '' }}</td>
@@ -30,5 +30,22 @@
         </tbody>
     </table>
     </div>
+    <nav aria-label="GL code pagination">
+        <ul class="pagination">
+            {% if codes.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ codes.page }} of {{ codes.pages }}</span>
+            </li>
+            {% if codes.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Paginate GL code listing and order codes by numeric code
- Update GL code listing template to handle pagination and show navigation links

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbc5ae81488324b1ca77fd80912d6e