### PR TITLE
Add pagination for vendors, customers, and invoices

### DIFF
--- a/app/routes/customer_routes.py
+++ b/app/routes/customer_routes.py
@@ -21,7 +21,10 @@ customer = Blueprint("customer", __name__)
 @login_required
 def view_customers():
     """Display all customers."""
-    customers = Customer.query.filter_by(archived=False).all()
+    page = request.args.get("page", 1, type=int)
+    customers = (
+        Customer.query.filter_by(archived=False).paginate(page=page, per_page=20)
+    )
     delete_form = DeleteForm()
     return render_template(
         "customers/view_customers.html",

--- a/app/routes/invoice_routes.py
+++ b/app/routes/invoice_routes.py
@@ -252,8 +252,10 @@ def view_invoices():
             Invoice.date_created
             <= datetime.combine(end_date, datetime.max.time())
         )
-
-    invoices = query.order_by(Invoice.date_created.desc()).all()
+    page = request.args.get("page", 1, type=int)
+    invoices = query.order_by(Invoice.date_created.desc()).paginate(
+        page=page, per_page=20
+    )
     delete_form = DeleteForm()
     return render_template(
         "invoices/view_invoices.html",

--- a/app/routes/vendor_routes.py
+++ b/app/routes/vendor_routes.py
@@ -21,7 +21,8 @@ vendor = Blueprint("vendor", __name__)
 @login_required
 def view_vendors():
     """Display all vendors."""
-    vendors = Vendor.query.filter_by(archived=False).all()
+    page = request.args.get("page", 1, type=int)
+    vendors = Vendor.query.filter_by(archived=False).paginate(page=page, per_page=20)
     delete_form = DeleteForm()
     return render_template(
         "vendors/view_vendors.html", vendors=vendors, delete_form=delete_form

--- a/app/templates/customers/view_customers.html
+++ b/app/templates/customers/view_customers.html
@@ -17,7 +17,7 @@
             </tr>
         </thead>
         <tbody>
-            {% for customer in customers %}
+            {% for customer in customers.items %}
             <tr>
                 <td>{{ customer.first_name }} {{ customer.last_name }}</td>
                 <td>{{ 'Yes' if customer.gst_exempt else 'No' }}</td>
@@ -34,5 +34,22 @@
         </tbody>
     </table>
     </div>
+    <nav aria-label="Customer pagination">
+        <ul class="pagination">
+            {% if customers.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ customers.page }} of {{ customers.pages }}</span>
+            </li>
+            {% if customers.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}

--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -36,7 +36,7 @@
             </tr>
         </thead>
         <tbody>
-            {% for invoice in invoices %}
+            {% for invoice in invoices.items %}
             <tr>
                 <td>{{ invoice.id }}</td>
                 <td>{{ invoice.date_created|format_datetime('%Y-%m-%d') }}</td>
@@ -54,5 +54,22 @@
         </tbody>
     </table>
     </div>
+    <nav aria-label="Invoice pagination">
+        <ul class="pagination">
+            {% if invoices.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('invoice.view_invoices', page=invoices.prev_num, invoice_id=request.args.get('invoice_id'), customer_id=request.args.get('customer_id'), start_date=request.args.get('start_date'), end_date=request.args.get('end_date')) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ invoices.page }} of {{ invoices.pages }}</span>
+            </li>
+            {% if invoices.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('invoice.view_invoices', page=invoices.next_num, invoice_id=request.args.get('invoice_id'), customer_id=request.args.get('customer_id'), start_date=request.args.get('start_date'), end_date=request.args.get('end_date')) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}

--- a/app/templates/vendors/view_vendors.html
+++ b/app/templates/vendors/view_vendors.html
@@ -18,7 +18,7 @@
             </tr>
         </thead>
         <tbody>
-            {% for vendor in vendors %}
+            {% for vendor in vendors.items %}
             <tr>
                 <td>{{ vendor.first_name }} {{ vendor.last_name }}</td>
                 <td>{{ 'Yes' if vendor.gst_exempt else 'No' }}</td>
@@ -35,5 +35,22 @@
         </tbody>
     </table>
     </div>
+    <nav aria-label="Vendor pagination">
+        <ul class="pagination">
+            {% if vendors.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('vendor.view_vendors', page=vendors.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ vendors.page }} of {{ vendors.pages }}</span>
+            </li>
+            {% if vendors.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('vendor.view_vendors', page=vendors.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- paginate vendor list view and template
- paginate customer list view and template
- paginate invoice list view and template, preserving filters

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbc5b39de8832480d8778cc97e7c08