### PR TITLE
Add pagination to item views

### DIFF
--- a/app/templates/items/item_locations.html
+++ b/app/templates/items/item_locations.html
@@ -7,7 +7,7 @@
         <tr><th>Location</th><th>Quantity</th><th>Purchase GL Code</th></tr>
     </thead>
     <tbody>
-    {% for e in entries %}
+    {% for e in entries.items %}
         <tr>
             <td>{{ e.location.name }}</td>
             <td>{{ e.expected_count }}</td>
@@ -22,4 +22,21 @@
     </tbody>
 </table>
 </div>
+<nav aria-label="Location pagination">
+    <ul class="pagination">
+        {% if entries.has_prev %}
+        <li class="page-item">
+            <a class="page-link" href="{{ url_for('item.item_locations', item_id=item.id, page=entries.prev_num) }}">Previous</a>
+        </li>
+        {% endif %}
+        <li class="page-item disabled">
+            <span class="page-link">Page {{ entries.page }} of {{ entries.pages }}</span>
+        </li>
+        {% if entries.has_next %}
+        <li class="page-item">
+            <a class="page-link" href="{{ url_for('item.item_locations', item_id=item.id, page=entries.next_num) }}">Next</a>
+        </li>
+        {% endif %}
+    </ul>
+</nav>
 {% endblock %}

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -25,7 +25,7 @@
                 </tr>
             </thead>
             <tbody>
-                {% for item in items %}
+                {% for item in items.items %}
                 <tr>
                     <td><input type="checkbox" name="item_ids" value="{{ item.id }}" style="transform: scale(1.5);"></td>
                     <td>{{ item.name }}</td>
@@ -40,6 +40,23 @@
         </table>
         </div>
     </form>
+    <nav aria-label="Item pagination">
+        <ul class="pagination">
+            {% if items.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ items.page }} of {{ items.pages }}</span>
+            </li>
+            {% if items.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 <script>
 document.getElementById('select-all').onclick = function() {


### PR DESCRIPTION
## Summary
- paginate item list view and order items by name
- add pagination controls to item and location templates
- include pagination for item location listings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbc5ad93588324b3718f3832fcca93