### PR TITLE
Paginate location listing

### DIFF
--- a/app/routes/location_routes.py
+++ b/app/routes/location_routes.py
@@ -167,7 +167,12 @@ def view_stand_sheet(location_id):
 @login_required
 def view_locations():
     """List all locations."""
-    locations = Location.query.filter_by(archived=False).all()
+    page = request.args.get("page", 1, type=int)
+    locations = (
+        Location.query.filter_by(archived=False)
+        .order_by(Location.name)
+        .paginate(page=page, per_page=20)
+    )
     delete_form = DeleteForm()
     return render_template(
         "locations/view_locations.html",

--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -13,7 +13,7 @@
             </tr>
         </thead>
         <tbody>
-            {% for location in locations %}
+            {% for location in locations.items %}
             <tr>
                 <td>{{ location.name }}</td>
                 <td>
@@ -29,5 +29,22 @@
         </tbody>
     </table>
     </div>
+    <nav aria-label="Location pagination">
+        <ul class="pagination">
+            {% if locations.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ locations.page }} of {{ locations.pages }}</span>
+            </li>
+            {% if locations.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- paginate locations query and order by name
- display location list using `locations.items` and add pagination navigation controls

## Testing
- `pre-commit run --files app/routes/location_routes.py app/templates/locations/view_locations.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbc5adbe388324ae208d54674f3d29