### PR TITLE
Add indexes for commonly filtered fields

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -111,6 +111,8 @@ class Location(db.Model):
         cascade="all, delete-orphan",
     )
 
+    __table_args__ = (db.Index("ix_location_archived", "archived"),)
+
 
 class Item(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -168,6 +170,7 @@ class Item(db.Model):
             unique=True,
             sqlite_where=db.text("archived = 0"),
         ),
+        db.Index("ix_item_archived", "archived"),
     )
 
 
@@ -217,6 +220,16 @@ class Transfer(db.Model):
         "TransferItem", backref="transfer", cascade="all, delete-orphan"
     )
 
+    __table_args__ = (
+        db.Index(
+            "ix_transfer_to_location_completed",
+            "to_location_id",
+            "completed",
+        ),
+        db.Index("ix_transfer_date_created", "date_created"),
+        db.Index("ix_transfer_user_id", "user_id"),
+    )
+
 
 class TransferItem(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -242,7 +255,10 @@ class Customer(db.Model):
     archived = db.Column(
         db.Boolean, default=False, nullable=False, server_default="0"
     )
+
     invoices = db.relationship("Invoice", backref="customer", lazy=True)
+
+    __table_args__ = (db.Index("ix_customer_archived", "archived"),)
 
 
 class Vendor(db.Model):
@@ -258,6 +274,8 @@ class Vendor(db.Model):
     archived = db.Column(
         db.Boolean, default=False, nullable=False, server_default="0"
     )
+
+    __table_args__ = (db.Index("ix_vendor_archived", "archived"),)
 
 
 class GLCode(db.Model):
@@ -329,6 +347,9 @@ class Invoice(db.Model):
             ["invoice_product.invoice_id"],
             use_alter=True,
         ),
+        db.Index("ix_invoice_date_created", "date_created"),
+        db.Index("ix_invoice_customer_id", "customer_id"),
+        db.Index("ix_invoice_user_id", "user_id"),
     )
 
     # Define the relationship with InvoiceProduct, specifying the foreign_keys argument

--- a/migrations/versions/bbdaf2ebdf4c_add_indexes.py
+++ b/migrations/versions/bbdaf2ebdf4c_add_indexes.py
@@ -1,0 +1,88 @@
+"""add indexes
+
+Revision ID: bbdaf2ebdf4c
+Revises: add_purchase_gl_code_to_location_stand_item
+Create Date: 2025-09-06 05:37:39.070861
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bbdaf2ebdf4c"
+down_revision = "add_purchase_gl_code_to_location_stand_item"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        "ix_location_archived", "location", ["archived"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_item_archived", "item", ["archived"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_transfer_to_location_completed",
+        "transfer",
+        ["to_location_id", "completed"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_transfer_date_created",
+        "transfer",
+        ["date_created"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_transfer_user_id", "transfer", ["user_id"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_customer_archived", "customer", ["archived"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_vendor_archived", "vendor", ["archived"], if_not_exists=True
+    )
+    op.create_index(
+        "ix_invoice_date_created",
+        "invoice",
+        ["date_created"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_invoice_customer_id",
+        "invoice",
+        ["customer_id"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_invoice_user_id", "invoice", ["user_id"], if_not_exists=True
+    )
+
+
+def downgrade():
+    op.drop_index("ix_invoice_user_id", table_name="invoice", if_exists=True)
+    op.drop_index(
+        "ix_invoice_customer_id", table_name="invoice", if_exists=True
+    )
+    op.drop_index(
+        "ix_invoice_date_created", table_name="invoice", if_exists=True
+    )
+    op.drop_index("ix_vendor_archived", table_name="vendor", if_exists=True)
+    op.drop_index(
+        "ix_customer_archived", table_name="customer", if_exists=True
+    )
+    op.drop_index("ix_transfer_user_id", table_name="transfer", if_exists=True)
+    op.drop_index(
+        "ix_transfer_date_created", table_name="transfer", if_exists=True
+    )
+    op.drop_index(
+        "ix_transfer_to_location_completed",
+        table_name="transfer",
+        if_exists=True,
+    )
+    op.drop_index("ix_item_archived", table_name="item", if_exists=True)
+    op.drop_index(
+        "ix_location_archived", table_name="location", if_exists=True
+    )


### PR DESCRIPTION
## Summary
- index archive flags on Location, Customer, Vendor, and Item models
- optimize Transfer queries with indexes on destination, completion, date, and user
- speed up invoice lookups via indexes on date and foreign keys

## Testing
- `pre-commit run --files app/models.py migrations/versions/bbdaf2ebdf4c_add_indexes.py`
- `flask --app run.py db upgrade`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbc7fe860c8324a48f3a454d3c14bb