### PR TITLE
Paginate transfers in location edit view

### DIFF
--- a/app/routes/location_routes.py
+++ b/app/routes/location_routes.py
@@ -129,9 +129,12 @@ def edit_location(location_id):
         )
 
     # Query for completed transfers to this location
-    transfers_to_location = Transfer.query.filter_by(
-        to_location_id=location_id, completed=True
-    ).all()
+    page = request.args.get("page", 1, type=int)
+    transfers_to_location = (
+        Transfer.query.filter_by(to_location_id=location_id, completed=True)
+        .order_by(Transfer.date_created.desc())
+        .paginate(page=page, per_page=20)
+    )
 
     selected_data = [{"id": p.id, "name": p.name} for p in location.products]
     return render_template(

--- a/app/templates/locations/edit_location.html
+++ b/app/templates/locations/edit_location.html
@@ -25,7 +25,7 @@
     <br>
     <h3>Transfers to This Location</h3>
     <ul class="list-group mt-3">
-        {% for transfer in transfers %}
+        {% for transfer in transfers.items %}
         <li class="list-group-item d-flex justify-content-between align-items-center">
             Transfer #{{ transfer.id }} from {{ transfer.from_location.name }}
             <a href="{{ url_for('transfer.view_transfer', transfer_id=transfer.id) }}" class="btn btn-sm btn-primary">View Transfer</a>
@@ -34,6 +34,23 @@
         <li class="list-group-item">No transfers to this location.</li>
         {% endfor %}
     </ul>
+    <nav aria-label="Transfer pagination">
+        <ul class="pagination">
+            {% if transfers.has_prev %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('locations.edit_location', location_id=location.id, page=transfers.prev_num) }}">Previous</a>
+            </li>
+            {% endif %}
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ transfers.page }} of {{ transfers.pages }}</span>
+            </li>
+            {% if transfers.has_next %}
+            <li class="page-item">
+                <a class="page-link" href="{{ url_for('locations.edit_location', location_id=location.id, page=transfers.next_num) }}">Next</a>
+            </li>
+            {% endif %}
+        </ul>
+    </nav>
 </div>
 <script>
 $(document).ready(function () {


### PR DESCRIPTION
## Summary
- paginate transfers when editing a location
- display pagination controls on the edit location page

## Testing
- `pre-commit run --files app/routes/location_routes.py app/templates/locations/edit_location.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbca29ae148324be3b4ffab467447a