### PR TITLE
Add search modes for items and products

### DIFF
--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -24,11 +24,29 @@ def view_products():
     """List available products."""
     delete_form = DeleteForm()
     page = request.args.get("page", 1, type=int)
-    products = Product.query.paginate(page=page, per_page=20)
+    name_query = request.args.get("name_query", "")
+    match_mode = request.args.get("match_mode", "contains")
+
+    query = Product.query
+    if name_query:
+        if match_mode == "exact":
+            query = query.filter(Product.name == name_query)
+        elif match_mode == "startswith":
+            query = query.filter(Product.name.like(f"{name_query}%"))
+        elif match_mode == "contains":
+            query = query.filter(Product.name.like(f"%{name_query}%"))
+        elif match_mode == "not_contains":
+            query = query.filter(Product.name.notlike(f"%{name_query}%"))
+        else:
+            query = query.filter(Product.name.like(f"%{name_query}%"))
+
+    products = query.paginate(page=page, per_page=20)
     return render_template(
         "products/view_products.html",
         products=products,
         delete_form=delete_form,
+        name_query=name_query,
+        match_mode=match_mode,
     )
 
 

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -12,6 +12,22 @@
             <button type="submit" form="bulk-delete-form" class="btn btn-warning mb-3" onclick="return confirm('Are you sure?');">Delete Items</button>
         </div>
     </div>
+    <form method="get" class="row g-2 mb-3">
+        <div class="col">
+            <input type="text" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+        </div>
+        <div class="col">
+            <select name="match_mode" class="form-select">
+                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
+                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
+                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
+                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
+            </select>
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-secondary">Search</button>
+        </div>
+    </form>
     <form id="bulk-delete-form" action="{{ url_for('item.bulk_delete_items') }}" method="post">
         {{ form.hidden_tag() }}
         <div class="table-responsive">
@@ -44,7 +60,7 @@
         <ul class="pagination">
             {% if items.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -52,7 +68,7 @@
             </li>
             {% if items.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num) }}">Next</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode) }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -7,6 +7,22 @@
     <h2>Products</h2>
     <a href="{{ url_for('product.create_product') }}" class="btn btn-primary mb-3">Create Product</a>
     <a href="{{ url_for('report.product_recipe_report') }}" class="btn btn-secondary mb-3">Recipe Report</a>
+    <form method="get" class="row g-2 mb-3">
+        <div class="col">
+            <input type="text" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+        </div>
+        <div class="col">
+            <select name="match_mode" class="form-select">
+                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
+                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
+                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
+                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
+            </select>
+        </div>
+        <div class="col-auto">
+            <button type="submit" class="btn btn-secondary">Search</button>
+        </div>
+    </form>
     <div class="table-responsive">
     <table class="table">
         <thead>
@@ -41,7 +57,7 @@
         <ul class="pagination">
             {% if products.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -49,7 +65,7 @@
             </li>
             {% if products.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num) }}">Next</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode) }}">Next</a>
             </li>
             {% endif %}
         </ul>


### PR DESCRIPTION
## Summary
- allow filtering items and products by name with configurable match modes
- add search fields and mode selector to item and product listings
- keep selected filters when paginating through results

## Testing
- `pre-commit run --files app/routes/item_routes.py app/routes/product_routes.py app/templates/items/view_items.html app/templates/products/view_products.html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbd2f9fb708324987ba13484cc45bb