### PR TITLE
Add GL code filtering to product list

### DIFF
--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -26,6 +26,7 @@ def view_products():
     page = request.args.get("page", 1, type=int)
     name_query = request.args.get("name_query", "")
     match_mode = request.args.get("match_mode", "contains")
+    gl_code_id = request.args.get("gl_code_id", type=int)
 
     query = Product.query
     if name_query:
@@ -40,13 +41,23 @@ def view_products():
         else:
             query = query.filter(Product.name.like(f"%{name_query}%"))
 
+    if gl_code_id:
+        query = query.filter(Product.gl_code_id == gl_code_id)
+
     products = query.paginate(page=page, per_page=20)
+    gl_codes = GLCode.query.order_by(GLCode.code).all()
+    selected_gl_code = (
+        db.session.get(GLCode, gl_code_id) if gl_code_id else None
+    )
     return render_template(
         "products/view_products.html",
         products=products,
         delete_form=delete_form,
         name_query=name_query,
         match_mode=match_mode,
+        gl_code_id=gl_code_id,
+        gl_codes=gl_codes,
+        selected_gl_code=selected_gl_code,
     )
 
 

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -19,10 +19,21 @@
                 <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
             </select>
         </div>
+        <div class="col">
+            <select name="gl_code_id" class="form-select">
+                <option value="">All GL Codes</option>
+                {% for gl in gl_codes %}
+                <option value="{{ gl.id }}" {% if gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
+                {% endfor %}
+            </select>
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-secondary">Search</button>
         </div>
     </form>
+    {% if selected_gl_code %}
+    <p>Filtering by GL Code: {{ selected_gl_code.code }}{% if selected_gl_code.description %} - {{ selected_gl_code.description }}{% endif %}</p>
+    {% endif %}
     <div class="table-responsive">
     <table class="table">
         <thead>
@@ -57,7 +68,7 @@
         <ul class="pagination">
             {% if products.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -65,7 +76,7 @@
             </li>
             {% if products.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode) }}">Next</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Next</a>
             </li>
             {% endif %}
         </ul>


### PR DESCRIPTION
## Summary
- allow `view_products` to filter by GL code
- provide GL code selection and display on product list page
- keep GL code filter across pagination and test it

## Testing
- `pre-commit run --files tests/test_product_routes_additional.py app/routes/product_routes.py app/templates/products/view_products.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5d100348324b15582bd7fa3edba