### PR TITLE
Add cost and price range filters

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -34,6 +34,8 @@ def view_items():
     name_query = request.args.get("name_query", "")
     match_mode = request.args.get("match_mode", "contains")
     gl_code_id = request.args.get("gl_code_id", type=int)
+    cost_min = request.args.get("cost_min", type=float)
+    cost_max = request.args.get("cost_max", type=float)
 
     query = Item.query.filter_by(archived=False)
     if name_query:
@@ -51,6 +53,14 @@ def view_items():
     if gl_code_id is not None:
         query = query.filter(Item.gl_code_id == gl_code_id)
 
+    if cost_min is not None and cost_max is not None and cost_min > cost_max:
+        flash("Invalid cost range: min cannot be greater than max.", "error")
+        return redirect(url_for("item.view_items"))
+    if cost_min is not None:
+        query = query.filter(Item.cost >= cost_min)
+    if cost_max is not None:
+        query = query.filter(Item.cost <= cost_max)
+
     items = query.order_by(Item.name).paginate(page=page, per_page=20)
     form = ItemForm()
     gl_codes = GLCode.query.order_by(GLCode.code).all()
@@ -63,6 +73,8 @@ def view_items():
         match_mode=match_mode,
         gl_codes=gl_codes,
         gl_code_id=gl_code_id,
+        cost_min=cost_min,
+        cost_max=cost_max,
         active_gl_code=active_gl_code,
     )
 

--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -27,6 +27,10 @@ def view_products():
     name_query = request.args.get("name_query", "")
     match_mode = request.args.get("match_mode", "contains")
     gl_code_id = request.args.get("gl_code_id", type=int)
+    cost_min = request.args.get("cost_min", type=float)
+    cost_max = request.args.get("cost_max", type=float)
+    price_min = request.args.get("price_min", type=float)
+    price_max = request.args.get("price_max", type=float)
 
     query = Product.query
     if name_query:
@@ -44,6 +48,25 @@ def view_products():
     if gl_code_id:
         query = query.filter(Product.gl_code_id == gl_code_id)
 
+    if cost_min is not None and cost_max is not None and cost_min > cost_max:
+        flash("Invalid cost range: min cannot be greater than max.", "error")
+        return redirect(url_for("product.view_products"))
+    if (
+        price_min is not None
+        and price_max is not None
+        and price_min > price_max
+    ):
+        flash("Invalid price range: min cannot be greater than max.", "error")
+        return redirect(url_for("product.view_products"))
+    if cost_min is not None:
+        query = query.filter(Product.cost >= cost_min)
+    if cost_max is not None:
+        query = query.filter(Product.cost <= cost_max)
+    if price_min is not None:
+        query = query.filter(Product.price >= price_min)
+    if price_max is not None:
+        query = query.filter(Product.price <= price_max)
+
     products = query.paginate(page=page, per_page=20)
     gl_codes = GLCode.query.order_by(GLCode.code).all()
     selected_gl_code = (
@@ -56,6 +79,10 @@ def view_products():
         name_query=name_query,
         match_mode=match_mode,
         gl_code_id=gl_code_id,
+        cost_min=cost_min,
+        cost_max=cost_max,
+        price_min=price_min,
+        price_max=price_max,
         gl_codes=gl_codes,
         selected_gl_code=selected_gl_code,
     )

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -32,6 +32,12 @@
                 {% endfor %}
             </select>
         </div>
+        <div class="col">
+            <input type="number" step="0.01" name="cost_min" class="form-control" placeholder="Cost ≥" value="{{ cost_min if cost_min is not none else '' }}">
+        </div>
+        <div class="col">
+            <input type="number" step="0.01" name="cost_max" class="form-control" placeholder="Cost ≤" value="{{ cost_max if cost_max is not none else '' }}">
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-secondary">Search</button>
         </div>
@@ -73,7 +79,7 @@
         <ul class="pagination">
             {% if items.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -81,7 +87,7 @@
             </li>
             {% if items.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Next</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max) }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -27,6 +27,18 @@
                 {% endfor %}
             </select>
         </div>
+        <div class="col">
+            <input type="number" step="0.01" name="cost_min" class="form-control" placeholder="Cost ≥" value="{{ cost_min if cost_min is not none else '' }}">
+        </div>
+        <div class="col">
+            <input type="number" step="0.01" name="cost_max" class="form-control" placeholder="Cost ≤" value="{{ cost_max if cost_max is not none else '' }}">
+        </div>
+        <div class="col">
+            <input type="number" step="0.01" name="price_min" class="form-control" placeholder="Price ≥" value="{{ price_min if price_min is not none else '' }}">
+        </div>
+        <div class="col">
+            <input type="number" step="0.01" name="price_max" class="form-control" placeholder="Price ≤" value="{{ price_max if price_max is not none else '' }}">
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-secondary">Search</button>
         </div>
@@ -68,7 +80,7 @@
         <ul class="pagination">
             {% if products.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -76,7 +88,7 @@
             </li>
             {% if products.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Next</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max) }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/tests/test_item_cost_filter.py
+++ b/tests/test_item_cost_filter.py
@@ -1,0 +1,47 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import Item, User
+from tests.utils import login
+
+
+def setup_items(app):
+    with app.app_context():
+        user = User(
+            email="costfilter@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        db.session.add(user)
+        db.session.add_all(
+            [
+                Item(name="Cheap", base_unit="each", cost=5),
+                Item(name="Mid", base_unit="each", cost=10),
+                Item(name="Expensive", base_unit="each", cost=20),
+            ]
+        )
+        db.session.commit()
+        return user.email
+
+
+def test_view_items_filter_by_cost(client, app):
+    email = setup_items(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get("/items?cost_min=11")
+        assert b"Expensive" in resp.data
+        assert b"Mid" not in resp.data
+        assert b"Cheap" not in resp.data
+        resp = client.get("/items?cost_max=10")
+        assert b"Cheap" in resp.data
+        assert b"Expensive" not in resp.data
+
+
+def test_view_items_cost_invalid_range(client, app):
+    email = setup_items(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get(
+            "/items?cost_min=15&cost_max=10", follow_redirects=True
+        )
+        assert b"Invalid cost range" in resp.data

--- a/tests/test_product_cost_price_filter.py
+++ b/tests/test_product_cost_price_filter.py
@@ -1,0 +1,52 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import Product, User
+from tests.utils import login
+
+
+def setup_products(app):
+    with app.app_context():
+        user = User(
+            email="costprice@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        db.session.add(user)
+        db.session.add_all(
+            [
+                Product(name="Cheap", price=5, cost=1),
+                Product(name="Medium", price=10, cost=5),
+                Product(name="Expensive", price=20, cost=15),
+            ]
+        )
+        db.session.commit()
+        return user.email
+
+
+def test_view_products_cost_and_price_filters(client, app):
+    email = setup_products(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get("/products?cost_min=6&cost_max=16")
+        assert b"Expensive" in resp.data
+        assert b"Medium" not in resp.data
+        assert b"Cheap" not in resp.data
+        resp = client.get("/products?price_min=6&price_max=15")
+        assert b"Medium" in resp.data
+        assert b"Cheap" not in resp.data
+        assert b"Expensive" not in resp.data
+
+
+def test_view_products_invalid_ranges(client, app):
+    email = setup_products(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get(
+            "/products?cost_min=10&cost_max=5", follow_redirects=True
+        )
+        assert b"Invalid cost range" in resp.data
+        resp = client.get(
+            "/products?price_min=20&price_max=10", follow_redirects=True
+        )
+        assert b"Invalid price range" in resp.data


### PR DESCRIPTION
## Summary
- allow filtering items by cost range with validation
- add cost and price range filtering for products
- add tests for cost/price range filters and invalid ranges

## Testing
- `pre-commit run --files app/routes/item_routes.py app/routes/product_routes.py app/templates/items/view_items.html app/templates/products/view_products.html tests/test_item_cost_filter.py tests/test_product_cost_price_filter.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbd81d183083249971e578a01737a7