### PR TITLE
Add base unit filter to item list

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -34,6 +34,7 @@ def view_items():
     name_query = request.args.get("name_query", "")
     match_mode = request.args.get("match_mode", "contains")
     gl_code_id = request.args.get("gl_code_id", type=int)
+    base_unit = request.args.get("base_unit")
 
     query = Item.query.filter_by(archived=False)
     if name_query:
@@ -51,9 +52,17 @@ def view_items():
     if gl_code_id is not None:
         query = query.filter(Item.gl_code_id == gl_code_id)
 
+    if base_unit:
+        query = query.filter(Item.base_unit == base_unit)
     items = query.order_by(Item.name).paginate(page=page, per_page=20)
     form = ItemForm()
     gl_codes = GLCode.query.order_by(GLCode.code).all()
+    base_units = [
+        u
+        for (u,) in db.session.query(Item.base_unit)
+        .distinct()
+        .order_by(Item.base_unit)
+    ]
     active_gl_code = db.session.get(GLCode, gl_code_id) if gl_code_id else None
     return render_template(
         "items/view_items.html",
@@ -63,6 +72,8 @@ def view_items():
         match_mode=match_mode,
         gl_codes=gl_codes,
         gl_code_id=gl_code_id,
+        base_units=base_units,
+        base_unit=base_unit,
         active_gl_code=active_gl_code,
     )
 

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -32,6 +32,14 @@
                 {% endfor %}
             </select>
         </div>
+        <div class="col">
+            <select name="base_unit" class="form-select">
+                <option value="">All Base Units</option>
+                {% for unit in base_units %}
+                <option value="{{ unit }}" {% if base_unit == unit %}selected{% endif %}>{{ unit|capitalize }}</option>
+                {% endfor %}
+            </select>
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-secondary">Search</button>
         </div>
@@ -39,6 +47,11 @@
     {% if active_gl_code %}
     <div class="mb-3">
         <strong>Filtering by GL Code:</strong> {{ active_gl_code.code }} - {{ active_gl_code.description }}
+    </div>
+    {% endif %}
+    {% if base_unit %}
+    <div class="mb-3">
+        <strong>Filtering by Base Unit:</strong> {{ base_unit|capitalize }}
     </div>
     {% endif %}
     <form id="bulk-delete-form" action="{{ url_for('item.bulk_delete_items') }}" method="post">
@@ -73,7 +86,7 @@
         <ul class="pagination">
             {% if items.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, base_unit=base_unit) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -81,7 +94,7 @@
             </li>
             {% if items.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Next</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, base_unit=base_unit) }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/tests/test_item_base_unit_filter.py
+++ b/tests/test_item_base_unit_filter.py
@@ -1,0 +1,33 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import Item, User
+from tests.utils import login
+
+
+def setup_data(app):
+    with app.app_context():
+        user = User(
+            email="unitfilter@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        db.session.add(user)
+        db.session.commit()
+        for i in range(21):
+            db.session.add(Item(name=f"A{i}", base_unit="each"))
+        db.session.add(Item(name="B0", base_unit="gram"))
+        db.session.commit()
+        return user.email
+
+
+def test_view_items_filter_by_base_unit(client, app):
+    email = setup_data(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get("/items?base_unit=each")
+        assert resp.status_code == 200
+        assert b"A0" in resp.data
+        assert b"B0" not in resp.data
+        assert b"Filtering by Base Unit" in resp.data
+        assert b"base_unit=each" in resp.data


### PR DESCRIPTION
## Summary
- allow `view_items` to filter by a `base_unit` query parameter and expose available base units
- extend items list template with a base unit dropdown and preserve the filter across pagination
- add regression test for filtering items by base unit

## Testing
- `pre-commit run --files app/routes/item_routes.py app/templates/items/view_items.html tests/test_item_base_unit_filter.py`
- `pytest tests/test_item_base_unit_filter.py tests/test_item_gl_filter.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd8259b5c8324b6bb14c356b7cdf3