### PR TITLE
Add archived filter to item list

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -34,8 +34,13 @@ def view_items():
     name_query = request.args.get("name_query", "")
     match_mode = request.args.get("match_mode", "contains")
     gl_code_id = request.args.get("gl_code_id", type=int)
+    archived = request.args.get("archived", "active")
 
-    query = Item.query.filter_by(archived=False)
+    query = Item.query
+    if archived == "active":
+        query = query.filter(Item.archived.is_(False))
+    elif archived == "archived":
+        query = query.filter(Item.archived.is_(True))
     if name_query:
         if match_mode == "exact":
             query = query.filter(Item.name == name_query)
@@ -64,6 +69,7 @@ def view_items():
         gl_codes=gl_codes,
         gl_code_id=gl_code_id,
         active_gl_code=active_gl_code,
+        archived=archived,
     )
 
 

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -32,6 +32,13 @@
                 {% endfor %}
             </select>
         </div>
+        <div class="col">
+            <select name="archived" class="form-select">
+                <option value="active" {% if archived == 'active' %}selected{% endif %}>Active</option>
+                <option value="archived" {% if archived == 'archived' %}selected{% endif %}>Archived</option>
+                <option value="all" {% if archived == 'all' %}selected{% endif %}>All</option>
+            </select>
+        </div>
         <div class="col-auto">
             <button type="submit" class="btn btn-secondary">Search</button>
         </div>
@@ -73,7 +80,7 @@
         <ul class="pagination">
             {% if items.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, archived=archived) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -81,7 +88,7 @@
             </li>
             {% if items.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Next</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, archived=archived) }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/tests/test_item_archived_filter.py
+++ b/tests/test_item_archived_filter.py
@@ -1,0 +1,44 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import Item, User
+from tests.utils import login
+
+
+def setup_data(app):
+    with app.app_context():
+        user = User(
+            email="archived@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        db.session.add(user)
+        for i in range(21):
+            db.session.add(Item(name=f"A{i}", base_unit="each"))
+        for i in range(2):
+            db.session.add(Item(name=f"X{i}", base_unit="each", archived=True))
+        db.session.commit()
+        return user.email
+
+
+def test_view_items_archived_filter(client, app):
+    email = setup_data(app)
+    with client:
+        login(client, email, "pass")
+
+        resp = client.get("/items")
+        assert resp.status_code == 200
+        assert b"A0" in resp.data
+        assert b"X0" not in resp.data
+        assert b"archived=active" in resp.data
+
+        resp = client.get("/items?archived=archived")
+        assert resp.status_code == 200
+        assert b"A0" not in resp.data
+        assert b"X0" in resp.data
+
+        resp = client.get("/items?archived=all&page=2")
+        assert resp.status_code == 200
+        assert b"A9" in resp.data
+        assert b"X0" in resp.data
+


### PR DESCRIPTION
## Summary
- allow filtering items by archived state
- add archived toggle to item list UI and pagination links
- test archived item filtering behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbd827b3c883249ef86e5cc4b1bbf2