### PR TITLE
Enable filtering products by sales GL code

### DIFF
--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -26,7 +26,7 @@ def view_products():
     page = request.args.get("page", 1, type=int)
     name_query = request.args.get("name_query", "")
     match_mode = request.args.get("match_mode", "contains")
-    gl_code_id = request.args.get("gl_code_id", type=int)
+    sales_gl_code_id = request.args.get("sales_gl_code_id", type=int)
 
     query = Product.query
     if name_query:
@@ -41,13 +41,14 @@ def view_products():
         else:
             query = query.filter(Product.name.like(f"%{name_query}%"))
 
-    if gl_code_id:
-        query = query.filter(Product.gl_code_id == gl_code_id)
-
+    if sales_gl_code_id:
+        query = query.filter(Product.sales_gl_code_id == sales_gl_code_id)
     products = query.paginate(page=page, per_page=20)
-    gl_codes = GLCode.query.order_by(GLCode.code).all()
-    selected_gl_code = (
-        db.session.get(GLCode, gl_code_id) if gl_code_id else None
+    sales_gl_codes = (
+        GLCode.query.filter(GLCode.code.like("4%")).order_by(GLCode.code).all()
+    )
+    selected_sales_gl_code = (
+        db.session.get(GLCode, sales_gl_code_id) if sales_gl_code_id else None
     )
     return render_template(
         "products/view_products.html",
@@ -55,9 +56,9 @@ def view_products():
         delete_form=delete_form,
         name_query=name_query,
         match_mode=match_mode,
-        gl_code_id=gl_code_id,
-        gl_codes=gl_codes,
-        selected_gl_code=selected_gl_code,
+        sales_gl_code_id=sales_gl_code_id,
+        sales_gl_codes=sales_gl_codes,
+        selected_sales_gl_code=selected_sales_gl_code,
     )
 
 

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -20,10 +20,10 @@
             </select>
         </div>
         <div class="col">
-            <select name="gl_code_id" class="form-select">
-                <option value="">All GL Codes</option>
-                {% for gl in gl_codes %}
-                <option value="{{ gl.id }}" {% if gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
+            <select name="sales_gl_code_id" class="form-select">
+                <option value="">All Sales GL Codes</option>
+                {% for gl in sales_gl_codes %}
+                <option value="{{ gl.id }}" {% if sales_gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
                 {% endfor %}
             </select>
         </div>
@@ -31,8 +31,8 @@
             <button type="submit" class="btn btn-secondary">Search</button>
         </div>
     </form>
-    {% if selected_gl_code %}
-    <p>Filtering by GL Code: {{ selected_gl_code.code }}{% if selected_gl_code.description %} - {{ selected_gl_code.description }}{% endif %}</p>
+    {% if selected_sales_gl_code %}
+    <p>Filtering by Sales GL Code: {{ selected_sales_gl_code.code }}{% if selected_sales_gl_code.description %} - {{ selected_sales_gl_code.description }}{% endif %}</p>
     {% endif %}
     <div class="table-responsive">
     <table class="table">
@@ -68,7 +68,7 @@
         <ul class="pagination">
             {% if products.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_id) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -76,7 +76,7 @@
             </li>
             {% if products.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Next</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_id) }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/tests/test_product_routes_additional.py
+++ b/tests/test_product_routes_additional.py
@@ -113,22 +113,25 @@ def test_additional_product_routes(client, app):
         assert client.get("/products/999/recipe").status_code == 404
 
 
-def test_view_products_gl_code_filter(client, app):
+def test_view_products_sales_gl_code_filter(client, app):
     email, item_id, unit_id = setup_data(app)
     with app.app_context():
         gl1 = GLCode.query.filter_by(code="4000").first()
         gl2 = GLCode.query.filter_by(code="5000").first()
         gl1_id, gl2_id = gl1.id, gl2.id
-        db.session.add_all(
-            [
-                Product(name="P1", price=1, cost=1, gl_code_id=gl1_id),
-                Product(name="P2", price=1, cost=1, gl_code_id=gl2_id),
-            ]
+        products = [
+            Product(name=f"P{i}", price=1, cost=1, sales_gl_code_id=gl1_id)
+            for i in range(21)
+        ]
+        products.append(
+            Product(name="Other", price=1, cost=1, sales_gl_code_id=gl2_id)
         )
+        db.session.add_all(products)
         db.session.commit()
     with client:
         login(client, email, "pass")
-        resp = client.get(f"/products?gl_code_id={gl1_id}")
+        resp = client.get(f"/products?sales_gl_code_id={gl1_id}")
         assert resp.status_code == 200
-        assert b"P1" in resp.data
-        assert b"P2" not in resp.data
+        assert b"P0" in resp.data
+        assert b"Other" not in resp.data
+        assert f"sales_gl_code_id={gl1_id}".encode() in resp.data


### PR DESCRIPTION
## Summary
- add `sales_gl_code_id` query parameter and filter products by `Product.sales_gl_code_id`
- expose sales GL codes (starting with 4) in product list filter and keep selection across pages
- extend tests for sales GL code filtering and pagination persistence

## Testing
- `pre-commit run --files app/routes/product_routes.py app/templates/products/view_products.html tests/test_product_routes_additional.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbd81c4e8c83249934e54eb888a0cb