### PR TITLE
Add supplier filter and toggleable filter panel for items

### DIFF
--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -77,6 +77,8 @@ def view_products():
     selected_sales_gl_code = (
         db.session.get(GLCode, sales_gl_code_id) if sales_gl_code_id else None
     )
+    gl_codes = GLCode.query.order_by(GLCode.code).all()
+    selected_gl_code = db.session.get(GLCode, gl_code_id) if gl_code_id else None
     return render_template(
         "products/view_products.html",
         products=products,

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -8,11 +8,12 @@
             <a href="{{ url_for('item.add_item') }}" class="btn btn-primary mb-3">Add New Item</a>
         </div>
         <div class="col-auto">
+            <button id="toggle-filters" type="button" class="btn btn-secondary mb-3">Filters</button>
             <a href="{{ url_for('item.import_items') }}" class="btn btn-info mb-3">Import Items</a>
             <button type="submit" form="bulk-delete-form" class="btn btn-warning mb-3" onclick="return confirm('Are you sure?');">Delete Items</button>
         </div>
     </div>
-    <form method="get" class="row g-2 mb-3">
+    <form id="filter-form" method="get" class="row g-2 mb-3 d-none">
         <div class="col">
             <input type="text" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
         </div>
@@ -29,6 +30,14 @@
                 <option value="">All GL Codes</option>
                 {% for gl in gl_codes %}
                 <option value="{{ gl.id }}" {% if gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col">
+            <select name="vendor_id" class="form-select">
+                <option value="">All Suppliers</option>
+                {% for v in vendors %}
+                <option value="{{ v.id }}" {% if vendor_id == v.id %}selected{% endif %}>{{ v.first_name }} {{ v.last_name }}</option>
                 {% endfor %}
             </select>
         </div>
@@ -63,6 +72,11 @@
         <strong>Filtering by Base Unit:</strong> {{ base_unit|capitalize }}
     </div>
     {% endif %}
+    {% if active_vendor %}
+    <div class="mb-3">
+        <strong>Filtering by Supplier:</strong> {{ active_vendor.first_name }} {{ active_vendor.last_name }}
+    </div>
+    {% endif %}
     <form id="bulk-delete-form" action="{{ url_for('item.bulk_delete_items') }}" method="post">
         {{ form.hidden_tag() }}
         <div class="table-responsive">
@@ -95,11 +109,7 @@
         <ul class="pagination">
             {% if items.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, archived=archived) }}">Previous</a>
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Previous</a>
-            <li class="page-item"
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, base_unit=base_unit) }}">Previous</a>
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, base_unit=base_unit, cost_min=cost_min, cost_max=cost_max, archived=archived, vendor_id=vendor_id) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -107,11 +117,7 @@
             </li>
             {% if items.has_next %}
             <li class="page-item">
-
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, archived=archived) }}">Next</a>
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id) }}">Next</a>
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, base_unit=base_unit) }}">Next</a>
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max) }}">Next</a>
+                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, base_unit=base_unit, cost_min=cost_min, cost_max=cost_max, archived=archived, vendor_id=vendor_id) }}">Next</a>
             </li>
             {% endif %}
         </ul>
@@ -123,6 +129,9 @@ document.getElementById('select-all').onclick = function() {
     for (var checkbox of checkboxes) {
         checkbox.checked = this.checked;
     }
+}
+document.getElementById('toggle-filters').onclick = function() {
+    document.getElementById('filter-form').classList.toggle('d-none');
 }
 </script>
 {% endblock %}

--- a/tests/test_item_vendor_filter.py
+++ b/tests/test_item_vendor_filter.py
@@ -1,0 +1,56 @@
+from datetime import date
+
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import (
+    Item,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    User,
+    Vendor,
+)
+from tests.utils import login
+
+
+def setup_data(app):
+    with app.app_context():
+        user = User(
+            email="vendorfilter@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        vendor1 = Vendor(first_name="Sup", last_name="One")
+        vendor2 = Vendor(first_name="Sup", last_name="Two")
+        item1 = Item(name="A0", base_unit="each")
+        item2 = Item(name="B0", base_unit="each")
+        db.session.add_all([user, vendor1, vendor2, item1, item2])
+        db.session.commit()
+
+        po = PurchaseOrder(
+            vendor_id=vendor1.id,
+            user_id=user.id,
+            vendor_name=f"{vendor1.first_name} {vendor1.last_name}",
+            order_date=date.today(),
+            expected_date=date.today(),
+        )
+        db.session.add(po)
+        db.session.commit()
+
+        db.session.add(
+            PurchaseOrderItem(purchase_order_id=po.id, item_id=item1.id, quantity=1)
+        )
+        db.session.commit()
+        return user.email, vendor1.id
+
+
+def test_view_items_filter_by_vendor(client, app):
+    email, vendor_id = setup_data(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get(f"/items?vendor_id={vendor_id}")
+        assert resp.status_code == 200
+        assert b"A0" in resp.data
+        assert b"B0" not in resp.data
+        assert b"Filtering by Supplier" in resp.data
+


### PR DESCRIPTION
## Summary
- hide item filters behind a toggle and add a supplier dropdown
- support supplier filtering in item routes
- restore missing GL code setup in product routes
- add test covering filtering items by supplier

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc7e4e4f88324a38c16f919890ac6