### PR TITLE
Define missing GL code variables in product listing

### DIFF
--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -77,6 +77,10 @@ def view_products():
     selected_sales_gl_code = (
         db.session.get(GLCode, sales_gl_code_id) if sales_gl_code_id else None
     )
+    gl_codes = GLCode.query.order_by(GLCode.code).all()
+    selected_gl_code = (
+        db.session.get(GLCode, gl_code_id) if gl_code_id else None
+    )
     return render_template(
         "products/view_products.html",
         products=products,


### PR DESCRIPTION
## Summary
- Avoid NameError when viewing products by defining `gl_codes` and the selected GL code

## Testing
- `pre-commit run --files app/routes/product_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcc85680c483249156e02308923299