### PR TITLE
Use Bootstrap modal for item filters

### DIFF
--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -8,60 +8,77 @@
             <a href="{{ url_for('item.add_item') }}" class="btn btn-primary mb-3">Add New Item</a>
         </div>
         <div class="col-auto">
-            <button id="toggle-filters" type="button" class="btn btn-secondary mb-3">Filters</button>
+            <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
+                Filters
+            </button>
             <a href="{{ url_for('item.import_items') }}" class="btn btn-info mb-3">Import Items</a>
             <button type="submit" form="bulk-delete-form" class="btn btn-warning mb-3" onclick="return confirm('Are you sure?');">Delete Items</button>
         </div>
     </div>
-    <form id="filter-form" method="get" class="row g-2 mb-3 d-none">
-        <div class="col">
-            <input type="text" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+
+    <!-- Filter Modal -->
+    <div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="filterModalLabel">Filters</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="filter-form" method="get" class="row g-2">
+                        <div class="col">
+                            <input type="text" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+                        </div>
+                        <div class="col">
+                            <select name="match_mode" class="form-select">
+                                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
+                                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
+                                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
+                                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
+                            </select>
+                        </div>
+                        <div class="col">
+                            <select name="gl_code_id" class="form-select">
+                                <option value="">All GL Codes</option>
+                                {% for gl in gl_codes %}
+                                <option value="{{ gl.id }}" {% if gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col">
+                            <select name="vendor_id" class="form-select">
+                                <option value="">All Suppliers</option>
+                                {% for v in vendors %}
+                                <option value="{{ v.id }}" {% if vendor_id == v.id %}selected{% endif %}>{{ v.first_name }} {{ v.last_name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col">
+                            <select name="archived" class="form-select">
+                                <option value="active" {% if archived == 'active' %}selected{% endif %}>Active</option>
+                                <option value="archived" {% if archived == 'archived' %}selected{% endif %}>Archived</option>
+                                <option value="all" {% if archived == 'all' %}selected{% endif %}>All</option>
+                            </select>
+                            <select name="base_unit" class="form-select">
+                                <option value="">All Base Units</option>
+                                {% for unit in base_units %}
+                                <option value="{{ unit }}" {% if base_unit == unit %}selected{% endif %}>{{ unit|capitalize }}</option>
+                                {% endfor %}
+                            </select>
+                            <input type="number" step="0.01" name="cost_min" class="form-control" placeholder="Cost ≥" value="{{ cost_min if cost_min is not none else '' }}">
+                        </div>
+                        <div class="col">
+                            <input type="number" step="0.01" name="cost_max" class="form-control" placeholder="Cost ≤" value="{{ cost_max if cost_max is not none else '' }}">
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
+                </div>
+            </div>
         </div>
-        <div class="col">
-            <select name="match_mode" class="form-select">
-                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
-                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
-                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
-                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
-            </select>
-        </div>
-        <div class="col">
-            <select name="gl_code_id" class="form-select">
-                <option value="">All GL Codes</option>
-                {% for gl in gl_codes %}
-                <option value="{{ gl.id }}" {% if gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="col">
-            <select name="vendor_id" class="form-select">
-                <option value="">All Suppliers</option>
-                {% for v in vendors %}
-                <option value="{{ v.id }}" {% if vendor_id == v.id %}selected{% endif %}>{{ v.first_name }} {{ v.last_name }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="col">
-            <select name="archived" class="form-select">
-                <option value="active" {% if archived == 'active' %}selected{% endif %}>Active</option>
-                <option value="archived" {% if archived == 'archived' %}selected{% endif %}>Archived</option>
-                <option value="all" {% if archived == 'all' %}selected{% endif %}>All</option>
-            </select>
-            <select name="base_unit" class="form-select">
-                <option value="">All Base Units</option>
-                {% for unit in base_units %}
-                <option value="{{ unit }}" {% if base_unit == unit %}selected{% endif %}>{{ unit|capitalize }}</option>
-                {% endfor %}
-            </select>
-            <input type="number" step="0.01" name="cost_min" class="form-control" placeholder="Cost ≥" value="{{ cost_min if cost_min is not none else '' }}">
-        </div>
-        <div class="col">
-            <input type="number" step="0.01" name="cost_max" class="form-control" placeholder="Cost ≤" value="{{ cost_max if cost_max is not none else '' }}">
-        </div>
-        <div class="col-auto">
-            <button type="submit" class="btn btn-secondary">Search</button>
-        </div>
-    </form>
+    </div>
     {% if active_gl_code %}
     <div class="mb-3">
         <strong>Filtering by GL Code:</strong> {{ active_gl_code.code }} - {{ active_gl_code.description }}
@@ -129,9 +146,6 @@ document.getElementById('select-all').onclick = function() {
     for (var checkbox of checkboxes) {
         checkbox.checked = this.checked;
     }
-}
-document.getElementById('toggle-filters').onclick = function() {
-    document.getElementById('filter-form').classList.toggle('d-none');
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace filter toggle button with Bootstrap modal trigger
- Move filter form into new modal with Apply/Cancel buttons
- Remove inline filter form and JavaScript toggle logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcce63bcc08324a103316cfb0dd53c