### PR TITLE
Use modal for product filters

### DIFF
--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -5,46 +5,81 @@
 {% block content %}
 <div class="container mt-5">
     <h2>Products</h2>
-    <a href="{{ url_for('product.create_product') }}" class="btn btn-primary mb-3">Create Product</a>
-    <a href="{{ url_for('report.product_recipe_report') }}" class="btn btn-secondary mb-3">Recipe Report</a>
-    <form method="get" class="row g-2 mb-3">
-        <div class="col">
-            <input type="text" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
-        </div>
-        <div class="col">
-            <select name="match_mode" class="form-select">
-                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
-                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
-                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
-                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
-            </select>
-        </div>
-        <div class="col">
-            <select name="sales_gl_code_id" class="form-select">
-                <option value="">All Sales GL Codes</option>
-                {% for gl in sales_gl_codes %}
-                <option value="{{ gl.id }}" {% if sales_gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="col">
-            <input type="number" step="0.01" name="cost_min" class="form-control" placeholder="Cost ≥" value="{{ cost_min if cost_min is not none else '' }}">
-        </div>
-        <div class="col">
-            <input type="number" step="0.01" name="cost_max" class="form-control" placeholder="Cost ≤" value="{{ cost_max if cost_max is not none else '' }}">
-        </div>
-        <div class="col">
-            <input type="number" step="0.01" name="price_min" class="form-control" placeholder="Price ≥" value="{{ price_min if price_min is not none else '' }}">
-        </div>
-        <div class="col">
-            <input type="number" step="0.01" name="price_max" class="form-control" placeholder="Price ≤" value="{{ price_max if price_max is not none else '' }}">
+    <div class="row justify-content-between">
+        <div class="col-auto">
+            <a href="{{ url_for('product.create_product') }}" class="btn btn-primary mb-3">Create Product</a>
+            <a href="{{ url_for('report.product_recipe_report') }}" class="btn btn-secondary mb-3">Recipe Report</a>
         </div>
         <div class="col-auto">
-            <button type="submit" class="btn btn-secondary">Search</button>
+            <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
+                Filters
+            </button>
         </div>
-    </form>
+    </div>
+
+    <!-- Filter Modal -->
+    <div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="filterModalLabel">Filters</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="filter-form" method="get" class="row g-2">
+                        <div class="col">
+                            <input type="text" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+                        </div>
+                        <div class="col">
+                            <select name="match_mode" class="form-select">
+                                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
+                                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
+                                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
+                                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
+                            </select>
+                        </div>
+                        <div class="col">
+                            <select name="sales_gl_code_id" class="form-select">
+                                <option value="">All Sales GL Codes</option>
+                                {% for gl in sales_gl_codes %}
+                                <option value="{{ gl.id }}" {% if sales_gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col">
+                            <select name="gl_code_id" class="form-select">
+                                <option value="">All GL Codes</option>
+                                {% for gl in gl_codes %}
+                                <option value="{{ gl.id }}" {% if gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col">
+                            <input type="number" step="0.01" name="cost_min" class="form-control" placeholder="Cost ≥" value="{{ cost_min if cost_min is not none else '' }}">
+                        </div>
+                        <div class="col">
+                            <input type="number" step="0.01" name="cost_max" class="form-control" placeholder="Cost ≤" value="{{ cost_max if cost_max is not none else '' }}">
+                        </div>
+                        <div class="col">
+                            <input type="number" step="0.01" name="price_min" class="form-control" placeholder="Price ≥" value="{{ price_min if price_min is not none else '' }}">
+                        </div>
+                        <div class="col">
+                            <input type="number" step="0.01" name="price_max" class="form-control" placeholder="Price ≤" value="{{ price_max if price_max is not none else '' }}">
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
+                </div>
+            </div>
+        </div>
+    </div>
     {% if selected_sales_gl_code %}
     <p>Filtering by Sales GL Code: {{ selected_sales_gl_code.code }}{% if selected_sales_gl_code.description %} - {{ selected_sales_gl_code.description }}{% endif %}</p>
+    {% endif %}
+    {% if selected_gl_code %}
+    <p>Filtering by GL Code: {{ selected_gl_code.code }}{% if selected_gl_code.description %} - {{ selected_gl_code.description }}{% endif %}</p>
     {% endif %}
     <div class="table-responsive">
     <table class="table">
@@ -80,8 +115,7 @@
         <ul class="pagination">
             {% if products.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_id) }}">Previous</a>
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_id, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -89,8 +123,7 @@
             </li>
             {% if products.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_id) }}">Next</a>
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max) }}">Next</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_id, gl_code_id=gl_code_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max) }}">Next</a>
             </li>
             {% endif %}
         </ul>


### PR DESCRIPTION
## Summary
- Replace inline product filters with a Bootstrap modal triggered by a Filters button.
- Support filtering by name, GL codes, and cost/price ranges inside the modal.
- Show active GL filters and streamline pagination links to retain filter parameters.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcd3d395488324930f64c5dd18f698