### PR TITLE
Refine items filter modal layout

### DIFF
--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -25,54 +25,75 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <form id="filter-form" method="get" class="row g-2">
-                        <div class="col">
-                            <input type="text" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+                    <form id="filter-form" method="get">
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <label for="name_query" class="form-label">Name</label>
+                                <input type="text" id="name_query" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+                            </div>
+                            <div class="col-md-6">
+                                <label for="match_mode" class="form-label">Match Mode</label>
+                                <select id="match_mode" name="match_mode" class="form-select">
+                                    <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
+                                    <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
+                                    <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
+                                    <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
+                                </select>
+                            </div>
                         </div>
-                        <div class="col">
-                            <select name="match_mode" class="form-select">
-                                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
-                                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
-                                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
-                                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
-                            </select>
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <label for="gl_code_id" class="form-label">GL Code</label>
+                                <select id="gl_code_id" name="gl_code_id" class="form-select">
+                                    <option value="">All GL Codes</option>
+                                    {% for gl in gl_codes %}
+                                    <option value="{{ gl.id }}" {% if gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="vendor_id" class="form-label">Supplier</label>
+                                <select id="vendor_id" name="vendor_id" class="form-select">
+                                    <option value="">All Suppliers</option>
+                                    {% for v in vendors %}
+                                    <option value="{{ v.id }}" {% if vendor_id == v.id %}selected{% endif %}>{{ v.first_name }} {{ v.last_name }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
                         </div>
-                        <div class="col">
-                            <select name="gl_code_id" class="form-select">
-                                <option value="">All GL Codes</option>
-                                {% for gl in gl_codes %}
-                                <option value="{{ gl.id }}" {% if gl_code_id == gl.id %}selected{% endif %}>{{ gl.code }} - {{ gl.description }}</option>
-                                {% endfor %}
-                            </select>
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <label for="archived" class="form-label">Status</label>
+                                <select id="archived" name="archived" class="form-select">
+                                    <option value="active" {% if archived == 'active' %}selected{% endif %}>Active</option>
+                                    <option value="archived" {% if archived == 'archived' %}selected{% endif %}>Archived</option>
+                                    <option value="all" {% if archived == 'all' %}selected{% endif %}>All</option>
+                                </select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="base_unit" class="form-label">Base Unit</label>
+                                <select id="base_unit" name="base_unit" class="form-select">
+                                    <option value="">All Base Units</option>
+                                    {% for unit in base_units %}
+                                    <option value="{{ unit }}" {% if base_unit == unit %}selected{% endif %}>{{ unit|capitalize }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
                         </div>
-                        <div class="col">
-                            <select name="vendor_id" class="form-select">
-                                <option value="">All Suppliers</option>
-                                {% for v in vendors %}
-                                <option value="{{ v.id }}" {% if vendor_id == v.id %}selected{% endif %}>{{ v.first_name }} {{ v.last_name }}</option>
-                                {% endfor %}
-                            </select>
-                        </div>
-                        <div class="col">
-                            <select name="archived" class="form-select">
-                                <option value="active" {% if archived == 'active' %}selected{% endif %}>Active</option>
-                                <option value="archived" {% if archived == 'archived' %}selected{% endif %}>Archived</option>
-                                <option value="all" {% if archived == 'all' %}selected{% endif %}>All</option>
-                            </select>
-                            <select name="base_unit" class="form-select">
-                                <option value="">All Base Units</option>
-                                {% for unit in base_units %}
-                                <option value="{{ unit }}" {% if base_unit == unit %}selected{% endif %}>{{ unit|capitalize }}</option>
-                                {% endfor %}
-                            </select>
-                            <input type="number" step="0.01" name="cost_min" class="form-control" placeholder="Cost ≥" value="{{ cost_min if cost_min is not none else '' }}">
-                        </div>
-                        <div class="col">
-                            <input type="number" step="0.01" name="cost_max" class="form-control" placeholder="Cost ≤" value="{{ cost_max if cost_max is not none else '' }}">
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <label for="cost_min" class="form-label">Cost ≥</label>
+                                <input type="number" step="0.01" id="cost_min" name="cost_min" class="form-control" value="{{ cost_min if cost_min is not none else '' }}">
+                            </div>
+                            <div class="col-md-6">
+                                <label for="cost_max" class="form-label">Cost ≤</label>
+                                <input type="number" step="0.01" id="cost_max" name="cost_max" class="form-control" value="{{ cost_max if cost_max is not none else '' }}">
+                            </div>
                         </div>
                     </form>
                 </div>
                 <div class="modal-footer">
+                    <a href="{{ url_for('item.view_items') }}" class="btn btn-outline-secondary">Reset</a>
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
                 </div>


### PR DESCRIPTION
## Summary
- Reorganize filters in items modal into labeled two-column rows for better readability
- Add reset link and clearer field labels for filters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd3e97f7c8324916ff3a5c4682958