### PR TITLE
Add AJAX customer creation modal

### DIFF
--- a/app/templates/customers/customer_form.html
+++ b/app/templates/customers/customer_form.html
@@ -1,5 +1,17 @@
-{% extends 'shared/form_page.html' %}
-
-{% block form_content %}
-    {% include 'shared/person_fields.html' %}
-{% endblock %}
+{% import 'macros/forms.html' as forms %}
+<form id="customerForm" method="POST">
+    {{ form.hidden_tag() }}
+    {{ forms.render_field(form.first_name) }}
+    {{ forms.render_field(form.last_name) }}
+    <div class="row my-2">
+        <div class="form-group col-auto">
+            {{ form.gst_exempt(class="form-check-input") }}
+            {{ form.gst_exempt.label(class="form-check-label") }}
+        </div>
+        <div class="form-group col-auto">
+            {{ form.pst_exempt(class="form-check-input") }}
+            {{ form.pst_exempt.label(class="form-check-label") }}
+        </div>
+    </div>
+    <button type="submit" class="btn btn-primary">Submit</button>
+</form>

--- a/app/templates/customers/customer_form_page.html
+++ b/app/templates/customers/customer_form_page.html
@@ -1,0 +1,5 @@
+{% extends 'shared/form_page.html' %}
+
+{% block form_content %}
+    {% include 'customers/customer_form.html' %}
+{% endblock %}

--- a/app/templates/customers/view_customers.html
+++ b/app/templates/customers/view_customers.html
@@ -5,7 +5,7 @@
 {% block content %}
 <div class="container mt-5">
     <h2>Customers</h2>
-    <a href="{{ url_for('customer.create_customer') }}" class="btn btn-primary mb-3">Create Customer</a>
+    <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createCustomerModal">Create Customer</button>
     <div class="table-responsive">
     <table class="table">
         <thead>
@@ -51,5 +51,58 @@
             {% endif %}
         </ul>
     </nav>
+
+    <!-- Create Customer Modal -->
+    <div class="modal fade" id="createCustomerModal" tabindex="-1" aria-labelledby="createCustomerModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="createCustomerModalLabel">Create Customer</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    {% include 'customers/customer_form.html' %}
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const form = document.getElementById('customerForm');
+        if (!form) return;
+        form.addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const response = await fetch('{{ url_for('customer.create_customer_modal') }}', {
+                method: 'POST',
+                body: new FormData(form)
+            });
+            if (response.ok) {
+                const data = await response.json();
+                if (data.success) {
+                    const tbody = document.querySelector('table tbody');
+                    const row = document.createElement('tr');
+                    row.innerHTML = `
+                        <td>${data.customer.first_name} ${data.customer.last_name}</td>
+                        <td>${data.customer.gst_exempt ? 'Yes' : 'No'}</td>
+                        <td>${data.customer.pst_exempt ? 'Yes' : 'No'}</td>
+                        <td>
+                            <a href="/customers/${data.customer.id}/edit" class="btn btn-primary mr-2">Edit</a>
+                            <form action="/customers/${data.customer.id}/delete" method="post" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="${data.delete_csrf_token}">
+                                <button type="submit" class="btn btn-danger mr-2" onclick="return confirm('Are you sure you want to delete this customer?')">Delete</button>
+                            </form>
+                        </td>`;
+                    tbody.appendChild(row);
+                    form.reset();
+                    const modalEl = document.getElementById('createCustomerModal');
+                    bootstrap.Modal.getInstance(modalEl).hide();
+                }
+            } else {
+                console.error('Error creating customer');
+            }
+        });
+    });
+    </script>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace customer creation link with button triggering modal and embedded form
- Add `/customers/create-modal` endpoint returning JSON and update routes to use form partial
- Submit modal via AJAX to append new customer to table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcde3bcd2c8324b823bff8a2f7bd85