### PR TITLE
Add AJAX vendor creation modal

### DIFF
--- a/app/routes/vendor_routes.py
+++ b/app/routes/vendor_routes.py
@@ -2,6 +2,7 @@ from flask import (
     Blueprint,
     abort,
     flash,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -45,10 +46,21 @@ def create_vendor():
         db.session.add(vendor)
         db.session.commit()
         log_activity(f"Created vendor {vendor.id}")
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            delete_form = DeleteForm()
+            row_html = render_template(
+                "vendors/_vendor_row.html", vendor=vendor, delete_form=delete_form
+            )
+            return jsonify({"success": True, "row_html": row_html})
         flash("Vendor created successfully!", "success")
         return redirect(url_for("vendor.view_vendors"))
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        if request.method == "POST":
+            form_html = render_template("vendors/vendor_form.html", form=form)
+            return jsonify({"success": False, "form_html": form_html})
+        return render_template("vendors/vendor_form.html", form=form)
     return render_template(
-        "vendors/vendor_form.html", form=form, title="Create Vendor"
+        "vendors/vendor_form_page.html", form=form, title="Create Vendor"
     )
 
 
@@ -80,7 +92,7 @@ def edit_vendor(vendor_id):
         form.pst_exempt.data = not vendor.pst_exempt
 
     return render_template(
-        "vendors/vendor_form.html", form=form, title="Edit Vendor"
+        "vendors/vendor_form_page.html", form=form, title="Edit Vendor"
     )
 
 

--- a/app/templates/vendors/_vendor_row.html
+++ b/app/templates/vendors/_vendor_row.html
@@ -1,0 +1,12 @@
+<tr>
+    <td>{{ vendor.first_name }} {{ vendor.last_name }}</td>
+    <td>{{ 'Yes' if vendor.gst_exempt else 'No' }}</td>
+    <td>{{ 'Yes' if vendor.pst_exempt else 'No' }}</td>
+    <td>
+        <a href="{{ url_for('vendor.edit_vendor', vendor_id=vendor.id) }}" class="btn btn-primary mr-2">Edit</a>
+        <form action="{{ url_for('vendor.delete_vendor', vendor_id=vendor.id) }}" method="post" class="d-inline">
+            {{ delete_form.hidden_tag() }}
+            <button type="submit" class="btn btn-danger mr-2" onclick="return confirm('Are you sure you want to delete this vendor?')">Delete</button>
+        </form>
+    </td>
+</tr>

--- a/app/templates/vendors/vendor_form.html
+++ b/app/templates/vendors/vendor_form.html
@@ -1,5 +1,1 @@
-{% extends 'shared/form_page.html' %}
-
-{% block form_content %}
-    {% include 'shared/person_fields.html' %}
-{% endblock %}
+{% include 'shared/person_fields.html' %}

--- a/app/templates/vendors/vendor_form_page.html
+++ b/app/templates/vendors/vendor_form_page.html
@@ -1,0 +1,5 @@
+{% extends 'shared/form_page.html' %}
+
+{% block form_content %}
+    {% include 'vendors/vendor_form.html' %}
+{% endblock %}

--- a/app/templates/vendors/view_vendors.html
+++ b/app/templates/vendors/view_vendors.html
@@ -6,9 +6,9 @@
 {% block content %}
 <div class="container mt-5">
     <h2>Vendors</h2>
-    <a href="{{ url_for('vendor.create_vendor') }}" class="btn btn-primary mb-3">Create Vendor</a>
+    <button type="button" class="btn btn-primary mb-3" id="createVendorBtn">Create Vendor</button>
     <div class="table-responsive">
-    <table class="table">
+    <table class="table" id="vendorTable">
         <thead>
             <tr>
                 <th>Name</th>
@@ -19,18 +19,7 @@
         </thead>
         <tbody>
             {% for vendor in vendors.items %}
-            <tr>
-                <td>{{ vendor.first_name }} {{ vendor.last_name }}</td>
-                <td>{{ 'Yes' if vendor.gst_exempt else 'No' }}</td>
-                <td>{{ 'Yes' if vendor.pst_exempt else 'No' }}</td>
-                <td>
-                    <a href="{{ url_for('vendor.edit_vendor', vendor_id=vendor.id) }}" class="btn btn-primary mr-2">Edit</a>
-                    <form action="{{ url_for('vendor.delete_vendor', vendor_id=vendor.id) }}" method="post" class="d-inline">
-                        {{ delete_form.hidden_tag() }}
-                        <button type="submit" class="btn btn-danger mr-2" onclick="return confirm('Are you sure you want to delete this vendor?')">Delete</button>
-                    </form>
-                </td>
-            </tr>
+            {% include 'vendors/_vendor_row.html' with context %}
             {% endfor %}
         </tbody>
     </table>
@@ -53,4 +42,57 @@
         </ul>
     </nav>
 </div>
+
+<!-- Vendor Modal -->
+<div class="modal fade" id="vendorModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Create Vendor</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body"></div>
+        </div>
+    </div>
+</div>
+
+<script>
+const modalEl = document.getElementById('vendorModal');
+
+function bindVendorForm() {
+    const form = modalEl.querySelector('form');
+    if (!form) return;
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const formData = new FormData(form);
+        fetch('{{ url_for('vendor.create_vendor') }}', {
+            method: 'POST',
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                'X-CSRFToken': formData.get('csrf_token')
+            },
+            body: formData
+        }).then(r => r.json()).then(data => {
+            if (data.success) {
+                document.querySelector('#vendorTable tbody').insertAdjacentHTML('beforeend', data.row_html);
+                bootstrap.Modal.getInstance(modalEl).hide();
+            } else if (data.form_html) {
+                modalEl.querySelector('.modal-body').innerHTML = data.form_html;
+                bindVendorForm();
+            }
+        });
+    });
+}
+
+document.getElementById('createVendorBtn').addEventListener('click', function() {
+    fetch('{{ url_for('vendor.create_vendor') }}', {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+    }).then(r => r.text()).then(html => {
+        modalEl.querySelector('.modal-body').innerHTML = html;
+        const modal = new bootstrap.Modal(modalEl);
+        modal.show();
+        bindVendorForm();
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- open Create Vendor in a Bootstrap modal and submit via AJAX
- process vendor creation requests with JSON responses
- append new vendors to the table without page reload

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcde3fbf1883248b3e32775d98fb12