### PR TITLE
Use modal and AJAX for GL code management

### DIFF
--- a/app/templates/gl_codes/view_gl_codes.html
+++ b/app/templates/gl_codes/view_gl_codes.html
@@ -3,9 +3,9 @@
 {% block content %}
 <div class="container mt-5">
     <h2>GL Codes</h2>
-    <a href="{{ url_for('glcode.create_gl_code') }}" class="btn btn-primary mb-3">Add GL Code</a>
+    <button id="add-gl-code" type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#glCodeModal">Add GL Code</button>
     <div class="table-responsive">
-    <table class="table">
+    <table class="table" id="gl-codes-table">
         <thead>
             <tr>
                 <th>Code</th>
@@ -13,13 +13,13 @@
                 <th>Actions</th>
             </tr>
         </thead>
-        <tbody>
+        <tbody id="gl-code-body">
             {% for code in codes.items %}
-            <tr>
-                <td>{{ code.code }}</td>
-                <td>{{ code.description or '' }}</td>
+            <tr data-id="{{ code.id }}">
+                <td class="gl-code">{{ code.code }}</td>
+                <td class="gl-description">{{ code.description or '' }}</td>
                 <td>
-                    <a href="{{ url_for('glcode.edit_gl_code', code_id=code.id) }}" class="btn btn-secondary btn-sm">Edit</a>
+                    <button type="button" class="btn btn-secondary btn-sm edit-gl-code" data-id="{{ code.id }}" data-code="{{ code.code }}" data-description="{{ code.description or '' }}">Edit</button>
                     <form action="{{ url_for('glcode.delete_gl_code', code_id=code.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
                         <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure?');">Delete</button>
@@ -48,4 +48,105 @@
         </ul>
     </nav>
 </div>
+
+<div class="modal fade" id="glCodeModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="glCodeModalLabel">Add GL Code</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="gl-code-form">
+          {{ form.hidden_tag() }}
+          <div class="mb-3">
+            {{ form.code.label(class="form-label") }}
+            {{ form.code(class="form-control", id="gl-code-field") }}
+          </div>
+          <div class="mb-3">
+            {{ form.description.label(class="form-label") }}
+            {{ form.description(class="form-control", id="gl-description-field") }}
+          </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" form="gl-code-form" class="btn btn-primary">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const modalEl = document.getElementById('glCodeModal');
+    const modal = new bootstrap.Modal(modalEl);
+    const form = document.getElementById('gl-code-form');
+    const title = document.getElementById('glCodeModalLabel');
+    const csrfToken = '{{ delete_form.csrf_token._value() }}';
+
+    document.getElementById('add-gl-code').addEventListener('click', () => {
+        form.reset();
+        form.dataset.id = '';
+        title.textContent = 'Add GL Code';
+    });
+
+    function attachEditHandlers() {
+        document.querySelectorAll('.edit-gl-code').forEach(btn => {
+            btn.addEventListener('click', () => {
+                form.reset();
+                form.dataset.id = btn.dataset.id;
+                form.querySelector('[name="code"]').value = btn.dataset.code;
+                form.querySelector('[name="description"]').value = btn.dataset.description;
+                title.textContent = 'Edit GL Code';
+                modal.show();
+            });
+        });
+    }
+    attachEditHandlers();
+
+    form.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const id = form.dataset.id;
+        const url = id ? `/gl_codes/${id}/ajax/update` : '/gl_codes/ajax/create';
+        fetch(url, {
+            method: 'POST',
+            body: new FormData(form)
+        }).then(r => {
+            if (!r.ok) return r.json().then(data => Promise.reject(data));
+            return r.json();
+        }).then(data => {
+            const tbody = document.getElementById('gl-code-body');
+            if (id) {
+                const row = tbody.querySelector(`tr[data-id="${id}"]`);
+                row.querySelector('.gl-code').textContent = data.code;
+                row.querySelector('.gl-description').textContent = data.description;
+                const btn = row.querySelector('.edit-gl-code');
+                btn.dataset.code = data.code;
+                btn.dataset.description = data.description;
+            } else {
+                const row = document.createElement('tr');
+                row.setAttribute('data-id', data.id);
+                row.innerHTML = `
+                    <td class="gl-code">${data.code}</td>
+                    <td class="gl-description">${data.description}</td>
+                    <td>
+                        <button type="button" class="btn btn-secondary btn-sm edit-gl-code" data-id="${data.id}" data-code="${data.code}" data-description="${data.description}">Edit</button>
+                        <form action="/gl_codes/${data.id}/delete" method="post" class="d-inline">
+                            <input type="hidden" name="csrf_token" value="${csrfToken}">
+                            <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure?');">Delete</button>
+                        </form>
+                    </td>`;
+                tbody.prepend(row);
+                attachEditHandlers();
+            }
+            modal.hide();
+        }).catch(err => {
+            console.error(err);
+        });
+    });
+});
+</script>
+
 {% endblock %}
+


### PR DESCRIPTION
## Summary
- Embed GL code form in a modal on the list page
- Add AJAX endpoints for creating and updating GL codes
- Refresh table rows dynamically after form submission

## Testing
- `pytest tests/test_gl_code_model.py tests/test_gl_codes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bcde4ba4bc8324b0d9e0f42bd7ffa1