### PR TITLE
Add AJAX modals for purchase orders

### DIFF
--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Purchase Orders</h2>
-    <a href="{{ url_for('purchase.create_purchase_order') }}" class="btn btn-primary mb-3">Create Purchase Order</a>
+    <button class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createPurchaseOrderModal">Create Purchase Order</button>
     <div class="table-responsive">
     <table class="table">
         <thead>
@@ -15,16 +15,16 @@
                 <th>Actions</th>
             </tr>
         </thead>
-        <tbody>
+        <tbody id="po-table-body">
         {% for order in orders.items %}
-            <tr>
+            <tr data-id="{{ order.id }}" data-vendor="{{ order.vendor_id }}" data-order-date="{{ order.order_date }}" data-expected-date="{{ order.expected_date }}" data-delivery="{{ order.delivery_charge }}">
                 <td>{{ order.id }}</td>
-                <td>{{ order.vendor.first_name }} {{ order.vendor.last_name }}</td>
-                <td>{{ order.order_date }}</td>
-                <td>{{ order.expected_date }}</td>
-                <td>{{ order.delivery_charge }}</td>
+                <td class="po-vendor">{{ order.vendor.first_name }} {{ order.vendor.last_name }}</td>
+                <td class="po-order-date">{{ order.order_date }}</td>
+                <td class="po-expected-date">{{ order.expected_date }}</td>
+                <td class="po-delivery">{{ order.delivery_charge }}</td>
                 <td>
-                    <a href="{{ url_for('purchase.edit_purchase_order', po_id=order.id) }}" class="btn btn-sm btn-primary">Edit</a>
+                    <button type="button" class="btn btn-sm btn-primary edit-po-btn" data-bs-toggle="modal" data-bs-target="#editPurchaseOrderModal">Edit</button>
                     <a href="{{ url_for('purchase.receive_invoice', po_id=order.id) }}" class="btn btn-sm btn-success">Receive</a>
                     <form action="{{ url_for('purchase.delete_purchase_order', po_id=order.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
@@ -32,7 +32,7 @@
                     </form>
                 </td>
             </tr>
-            {% endfor %}
+        {% endfor %}
         </tbody>
     </table>
     </div>
@@ -54,4 +54,164 @@
         </ul>
     </nav>
 </div>
+
+<!-- Create Modal -->
+<div class="modal fade" id="createPurchaseOrderModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Create Purchase Order</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form id="createPurchaseOrderForm">
+      <div class="modal-body">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div class="form-group">
+          <label for="create-vendor" class="form-label">Vendor</label>
+          <select id="create-vendor" name="vendor" class="form-control">
+            {% for v in vendors %}
+            <option value="{{ v.id }}">{{ v.first_name }} {{ v.last_name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="create-order-date" class="form-label">Order Date</label>
+          <input type="date" id="create-order-date" name="order_date" class="form-control">
+        </div>
+        <div class="form-group">
+          <label for="create-expected-date" class="form-label">Expected Date</label>
+          <input type="date" id="create-expected-date" name="expected_date" class="form-control">
+        </div>
+        <div class="form-group">
+          <label for="create-delivery" class="form-label">Delivery Charge</label>
+          <input type="number" step="any" id="create-delivery" name="delivery_charge" class="form-control">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Edit Modal -->
+<div class="modal fade" id="editPurchaseOrderModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Edit Purchase Order</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <form id="editPurchaseOrderForm">
+      <div class="modal-body">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <input type="hidden" id="edit-po-id" name="po_id">
+        <div class="form-group">
+          <label for="edit-vendor" class="form-label">Vendor</label>
+          <select id="edit-vendor" name="vendor" class="form-control">
+            {% for v in vendors %}
+            <option value="{{ v.id }}">{{ v.first_name }} {{ v.last_name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="edit-order-date" class="form-label">Order Date</label>
+          <input type="date" id="edit-order-date" name="order_date" class="form-control">
+        </div>
+        <div class="form-group">
+          <label for="edit-expected-date" class="form-label">Expected Date</label>
+          <input type="date" id="edit-expected-date" name="expected_date" class="form-control">
+        </div>
+        <div class="form-group">
+          <label for="edit-delivery" class="form-label">Delivery Charge</label>
+          <input type="number" step="any" id="edit-delivery" name="delivery_charge" class="form-control">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<script>
+function attachEditHandlers() {
+  document.querySelectorAll('.edit-po-btn').forEach(btn => {
+    btn.onclick = function() {
+      const row = this.closest('tr');
+      document.getElementById('edit-po-id').value = row.dataset.id;
+      document.getElementById('edit-vendor').value = row.dataset.vendor;
+      document.getElementById('edit-order-date').value = row.dataset.orderDate;
+      document.getElementById('edit-expected-date').value = row.dataset.expectedDate;
+      document.getElementById('edit-delivery').value = row.dataset.delivery;
+    };
+  });
+}
+attachEditHandlers();
+
+document.getElementById('createPurchaseOrderForm').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const form = this;
+  fetch("{{ url_for('purchase.create_purchase_order') }}", {
+    method: 'POST',
+    headers: {'X-Requested-With': 'XMLHttpRequest'},
+    body: new FormData(form)
+  }).then(r => r.json()).then(data => {
+    if (data.success) {
+      const tbody = document.getElementById('po-table-body');
+      const row = document.createElement('tr');
+      row.dataset.id = data.order.id;
+      row.dataset.vendor = data.order.vendor_id;
+      row.dataset.orderDate = data.order.order_date;
+      row.dataset.expectedDate = data.order.expected_date;
+      row.dataset.delivery = data.order.delivery_charge;
+      row.innerHTML = `<td>${data.order.id}</td>
+        <td class="po-vendor">${data.order.vendor}</td>
+        <td class="po-order-date">${data.order.order_date}</td>
+        <td class="po-expected-date">${data.order.expected_date}</td>
+        <td class="po-delivery">${data.order.delivery_charge}</td>
+        <td>
+          <button type="button" class="btn btn-sm btn-primary edit-po-btn" data-bs-toggle="modal" data-bs-target="#editPurchaseOrderModal">Edit</button>
+          <a href="/purchase_orders/${data.order.id}/receive" class="btn btn-sm btn-success">Receive</a>
+          <form action="/purchase_orders/${data.order.id}/delete" method="post" class="d-inline">
+            <input type="hidden" name="csrf_token" value="{{ delete_form.csrf_token._value() if delete_form.csrf_token else '' }}">
+            <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Are you sure?');">Delete</button>
+          </form>
+        </td>`;
+      tbody.prepend(row);
+      attachEditHandlers();
+      bootstrap.Modal.getInstance(document.getElementById('createPurchaseOrderModal')).hide();
+      form.reset();
+    }
+  });
+});
+
+document.getElementById('editPurchaseOrderForm').addEventListener('submit', function(e) {
+  e.preventDefault();
+  const form = this;
+  const id = document.getElementById('edit-po-id').value;
+  fetch(`/purchase_orders/edit/${id}`, {
+    method: 'POST',
+    headers: {'X-Requested-With': 'XMLHttpRequest'},
+    body: new FormData(form)
+  }).then(r => r.json()).then(data => {
+    if (data.success) {
+      const row = document.querySelector(`tr[data-id='${id}']`);
+      row.dataset.vendor = data.order.vendor_id;
+      row.dataset.orderDate = data.order.order_date;
+      row.dataset.expectedDate = data.order.expected_date;
+      row.dataset.delivery = data.order.delivery_charge;
+      row.querySelector('.po-vendor').textContent = data.order.vendor;
+      row.querySelector('.po-order-date').textContent = data.order.order_date;
+      row.querySelector('.po-expected-date').textContent = data.order.expected_date;
+      row.querySelector('.po-delivery').textContent = data.order.delivery_charge;
+      bootstrap.Modal.getInstance(document.getElementById('editPurchaseOrderModal')).hide();
+    }
+  });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Replace create purchase order link with modal trigger
- Add AJAX-powered create and edit modals that update the table in-place
- Enable purchase routes to respond with JSON for asynchronous requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcde597c0c83248e12bd7349ddc69b