### PR TITLE
Add modal filters and AJAX table update for spoilage report

### DIFF
--- a/app/routes/spoilage_routes.py
+++ b/app/routes/spoilage_routes.py
@@ -10,7 +10,14 @@ from sqlalchemy import and_, or_
 
 from app import db
 from app.forms import SpoilageFilterForm
-from app.models import GLCode, Item, Location, LocationStandItem, Transfer, TransferItem
+from app.models import (
+    GLCode,
+    Item,
+    Location,
+    LocationStandItem,
+    Transfer,
+    TransferItem,
+)
 
 spoilage = Blueprint("spoilage", __name__)
 
@@ -48,14 +55,16 @@ def view_spoilage():
         start_date = datetime.strptime(start_date_str, "%Y-%m-%d").date()
         form.start_date.data = start_date
         query = query.filter(
-            Transfer.date_created >= datetime.combine(start_date, datetime.min.time())
+            Transfer.date_created
+            >= datetime.combine(start_date, datetime.min.time())
         )
     end_date_str = request.args.get("end_date")
     if end_date_str:
         end_date = datetime.strptime(end_date_str, "%Y-%m-%d").date()
         form.end_date.data = end_date
         query = query.filter(
-            Transfer.date_created <= datetime.combine(end_date, datetime.max.time())
+            Transfer.date_created
+            <= datetime.combine(end_date, datetime.max.time())
         )
     if form.purchase_gl_code.data:
         code_id = form.purchase_gl_code.data
@@ -73,5 +82,9 @@ def view_spoilage():
 
     results = query.order_by(Transfer.date_created.desc()).all()
 
-    return render_template("spoilage/view_spoilage.html", form=form, results=results)
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        return render_template("spoilage/_table.html", results=results)
 
+    return render_template(
+        "spoilage/view_spoilage.html", form=form, results=results
+    )

--- a/app/templates/spoilage/_table.html
+++ b/app/templates/spoilage/_table.html
@@ -1,0 +1,37 @@
+{% if results %}
+<div class="mb-3">
+    <button onclick="window.print()" class="btn btn-secondary">Print</button>
+</div>
+<div class="table-responsive">
+<table class="table">
+    <thead>
+        <tr>
+            <th>Date</th>
+            <th>From Location</th>
+            <th>Item</th>
+            <th>Quantity</th>
+            <th>Purchase GL Code</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for ti, tr, item, from_loc, lsi in results %}
+        <tr>
+            <td>{{ tr.date_created.date() }}</td>
+            <td>{{ from_loc.name }}</td>
+            <td>{{ item.name }}</td>
+            <td>{{ ti.quantity }}</td>
+            <td>
+                {{
+                    lsi.purchase_gl_code.code
+                    if lsi and lsi.purchase_gl_code
+                    else (item.purchase_gl_code.code if item.purchase_gl_code else '')
+                }}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</div>
+{% else %}
+<p>No spoilage records found.</p>
+{% endif %}

--- a/app/templates/spoilage/view_spoilage.html
+++ b/app/templates/spoilage/view_spoilage.html
@@ -3,63 +3,70 @@
 {% block content %}
 <div class="container mt-5">
     <h2>Spoilage</h2>
-    <form method="get" class="row g-3 mb-4">
-        <div class="col-auto">
-            {{ form.start_date.label }}
-            {{ form.start_date(class='form-control') }}
-        </div>
-        <div class="col-auto">
-            {{ form.end_date.label }}
-            {{ form.end_date(class='form-control') }}
-        </div>
-        <div class="col-auto">
-            {{ form.purchase_gl_code.label }}
-            {{ form.purchase_gl_code(class='form-select') }}
-        </div>
-        <div class="col-auto">
-            {{ form.items.label }}
-            {{ form.items(class='form-select', multiple=True) }}
-        </div>
-        <div class="col-auto align-self-end">
-            <button type="submit" class="btn btn-primary">Filter</button>
-        </div>
-    </form>
-    {% if results %}
-    <div class="mb-3">
-        <button onclick="window.print()" class="btn btn-secondary">Print</button>
+    <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
+        Filters
+    </button>
+
+    <div id="results-container">
+        {% include 'spoilage/_table.html' %}
     </div>
-    <div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Date</th>
-                <th>From Location</th>
-                <th>Item</th>
-                <th>Quantity</th>
-                <th>Purchase GL Code</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for ti, tr, item, from_loc, lsi in results %}
-            <tr>
-                <td>{{ tr.date_created.date() }}</td>
-                <td>{{ from_loc.name }}</td>
-                <td>{{ item.name }}</td>
-                <td>{{ ti.quantity }}</td>
-                <td>
-                    {{
-                        lsi.purchase_gl_code.code
-                        if lsi and lsi.purchase_gl_code
-                        else (item.purchase_gl_code.code if item.purchase_gl_code else '')
-                    }}
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    </div>
-    {% else %}
-    <p>No spoilage records found.</p>
-    {% endif %}
 </div>
+
+<!-- Filter Modal -->
+<div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <form id="filterForm">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="filterModalLabel">Filters</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="row g-3">
+                        <div class="col-12">
+                            {{ form.start_date.label }}
+                            {{ form.start_date(class='form-control') }}
+                        </div>
+                        <div class="col-12">
+                            {{ form.end_date.label }}
+                            {{ form.end_date(class='form-control') }}
+                        </div>
+                        <div class="col-12">
+                            {{ form.purchase_gl_code.label }}
+                            {{ form.purchase_gl_code(class='form-select') }}
+                        </div>
+                        <div class="col-12">
+                            {{ form.items.label }}
+                            {{ form.items(class='form-select', multiple=True) }}
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="submit" class="btn btn-primary">Apply</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+    $(function () {
+        $('#filterForm').on('submit', function (e) {
+            e.preventDefault();
+            var params = $(this).serialize();
+            $.ajax({
+                url: '{{ url_for('spoilage.view_spoilage') }}',
+                type: 'GET',
+                data: params,
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                success: function (response) {
+                    $('#results-container').html(response);
+                    var modalEl = document.getElementById('filterModal');
+                    var modal = bootstrap.Modal.getInstance(modalEl);
+                    modal.hide();
+                }
+            });
+        });
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- wrap spoilage filters in a Bootstrap modal and trigger with a Filters button
- update spoilage endpoint to return table partial for AJAX requests
- refresh report table dynamically without full page reload

## Testing
- `pre-commit run --files app/templates/spoilage/_table.html app/templates/spoilage/view_spoilage.html app/routes/spoilage_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcde6192a883248d27bea212c00ce3