### PR TITLE
Fix item editing and restore purchase order flow

### DIFF
--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -6,7 +6,6 @@ from flask import (
     render_template,
     request,
     url_for,
-    jsonify,
 )
 from flask_login import current_user, login_required
 
@@ -96,32 +95,6 @@ def view_purchase_orders():
 def create_purchase_order():
     """Create a purchase order."""
     form = PurchaseOrderForm()
-    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
-        vendor_id = request.form.get("vendor", type=int)
-        order_date = request.form.get("order_date")
-        expected_date = request.form.get("expected_date")
-        delivery_charge = request.form.get("delivery_charge", type=float) or 0.0
-        po = PurchaseOrder(
-            vendor_id=vendor_id,
-            user_id=current_user.id,
-            vendor_name=f"{db.session.get(Vendor, vendor_id).first_name} {db.session.get(Vendor, vendor_id).last_name}",
-            order_date=datetime.date.fromisoformat(order_date),
-            expected_date=datetime.date.fromisoformat(expected_date),
-            delivery_charge=delivery_charge,
-        )
-        db.session.add(po)
-        db.session.commit()
-        return jsonify(
-            success=True,
-            order={
-                "id": po.id,
-                "vendor": po.vendor_name,
-                "vendor_id": po.vendor_id,
-                "order_date": po.order_date.isoformat(),
-                "expected_date": po.expected_date.isoformat(),
-                "delivery_charge": po.delivery_charge,
-            },
-        )
     if form.validate_on_submit():
         po = PurchaseOrder(
             vendor_id=form.vendor.data,
@@ -175,28 +148,6 @@ def edit_purchase_order(po_id):
     if po is None:
         abort(404)
     form = PurchaseOrderForm()
-    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
-        vendor_id = request.form.get("vendor", type=int)
-        order_date = request.form.get("order_date")
-        expected_date = request.form.get("expected_date")
-        delivery_charge = request.form.get("delivery_charge", type=float) or 0.0
-        po.vendor_id = vendor_id
-        po.vendor_name = f"{db.session.get(Vendor, vendor_id).first_name} {db.session.get(Vendor, vendor_id).last_name}"
-        po.order_date = datetime.date.fromisoformat(order_date)
-        po.expected_date = datetime.date.fromisoformat(expected_date)
-        po.delivery_charge = delivery_charge
-        db.session.commit()
-        return jsonify(
-            success=True,
-            order={
-                "id": po.id,
-                "vendor": po.vendor_name,
-                "vendor_id": po.vendor_id,
-                "order_date": po.order_date.isoformat(),
-                "expected_date": po.expected_date.isoformat(),
-                "delivery_charge": po.delivery_charge,
-            },
-        )
     if form.validate_on_submit():
         po.vendor_id = form.vendor.data
         po.vendor_name = f"{db.session.get(Vendor, form.vendor.data).first_name} {db.session.get(Vendor, form.vendor.data).last_name}"

--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -3,7 +3,7 @@
     <td>{{ item.name }}</td>
     <td>{{ item.cost }}</td>
     <td>
-        <button class="btn btn-secondary edit-item-btn" data-item-id="{{ item.id }}">Edit</button>
+        <button type="button" class="btn btn-secondary edit-item-btn" data-item-id="{{ item.id }}">Edit</button>
         <a href="{{ url_for('item.item_locations', item_id=item.id) }}" class="btn btn-info ms-1">Locations</a>
     </td>
 </tr>

--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -54,59 +54,61 @@
     </div>
 </div>
 <script>
-const csrfToken = document.getElementById('csrf_token').value;
-const locationModal = new bootstrap.Modal(document.getElementById('locationModal'));
+document.addEventListener('DOMContentLoaded', function() {
+    const csrfToken = document.getElementById('csrf_token').value;
+    const locationModal = new bootstrap.Modal(document.getElementById('locationModal'));
 
-$('#addLocationBtn').on('click', function() {
-    $.get('{{ url_for('locations.add_location') }}', function(data) {
-        $('#locationModal .modal-content').html(data);
-        locationModal.show();
+    $('#addLocationBtn').on('click', function() {
+        $.get('{{ url_for('locations.add_location') }}', function(data) {
+            $('#locationModal .modal-content').html(data);
+            locationModal.show();
+        });
     });
-});
 
-$(document).on('click', '.edit-location-btn', function() {
-    const id = $(this).data('id');
-    $.get(`/locations/edit/${id}`, function(data) {
-        $('#locationModal .modal-content').html(data);
-        locationModal.show();
+    $(document).on('click', '.edit-location-btn', function() {
+        const id = $(this).data('id');
+        $.get(`/locations/edit/${id}`, function(data) {
+            $('#locationModal .modal-content').html(data);
+            locationModal.show();
+        });
     });
-});
 
-$(document).on('submit', '#locationForm', function(e) {
-    e.preventDefault();
-    const form = $(this);
-    $.post(form.attr('action'), form.serialize(), function(response) {
-        if (response.success) {
-            if (response.action === 'create') {
-                addRow(response.location);
-            } else {
-                updateRow(response.location);
+    $(document).on('submit', '#locationForm', function(e) {
+        e.preventDefault();
+        const form = $(this);
+        $.post(form.attr('action'), form.serialize(), function(response) {
+            if (response.success) {
+                if (response.action === 'create') {
+                    addRow(response.location);
+                } else {
+                    updateRow(response.location);
+                }
+                locationModal.hide();
             }
-            locationModal.hide();
-        }
-    }).fail(function(xhr) {
-        alert('Error: ' + (xhr.responseJSON?.errors ? JSON.stringify(xhr.responseJSON.errors) : 'Unknown error'));
+        }).fail(function(xhr) {
+            alert('Error: ' + (xhr.responseJSON?.errors ? JSON.stringify(xhr.responseJSON.errors) : 'Unknown error'));
+        });
     });
+
+    function addRow(loc) {
+        const row = `<tr data-id="${loc.id}">
+            <td>${loc.name}</td>
+            <td>
+                <button type="button" class="btn btn-info edit-location-btn" data-id="${loc.id}">Edit</button>
+                <a href="/locations/${loc.id}/stand_sheet" class="btn btn-secondary">Stand Sheet</a>
+                <form action="/locations/delete/${loc.id}" method="post" class="d-inline">
+                    <input type="hidden" name="csrf_token" value="${csrfToken}">
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </form>
+            </td>
+        </tr>`;
+        $('table tbody').append(row);
+    }
+
+    function updateRow(loc) {
+        const row = $(`tr[data-id='${loc.id}']`);
+        row.find('td:first').text(loc.name);
+    }
 });
-
-function addRow(loc) {
-    const row = `<tr data-id="${loc.id}">
-        <td>${loc.name}</td>
-        <td>
-            <button type="button" class="btn btn-info edit-location-btn" data-id="${loc.id}">Edit</button>
-            <a href="/locations/${loc.id}/stand_sheet" class="btn btn-secondary">Stand Sheet</a>
-            <form action="/locations/delete/${loc.id}" method="post" class="d-inline">
-                <input type="hidden" name="csrf_token" value="${csrfToken}">
-                <button type="submit" class="btn btn-danger">Delete</button>
-            </form>
-        </td>
-    </tr>`;
-    $('table tbody').append(row);
-}
-
-function updateRow(loc) {
-    const row = $(`tr[data-id='${loc.id}']`);
-    row.find('td:first').text(loc.name);
-}
 </script>
 {% endblock %}

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -94,6 +94,7 @@
 </div>
 
 <script>
+document.addEventListener('DOMContentLoaded', function() {
     let itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
 
@@ -210,5 +211,6 @@
     });
 
     document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
+});
 </script>
 {% endblock %}

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -94,6 +94,7 @@
 </div>
 
 <script>
+document.addEventListener('DOMContentLoaded', function() {
     let itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
 
@@ -195,6 +196,7 @@
     });
 
     document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
+});
 </script>
 </div>
 {% endblock %}

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Purchase Orders</h2>
-    <button class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createPurchaseOrderModal">Create Purchase Order</button>
+    <a class="btn btn-primary mb-3" href="{{ url_for('purchase.create_purchase_order') }}">Create Purchase Order</a>
     <div class="table-responsive">
     <table class="table">
         <thead>
@@ -24,7 +24,7 @@
                 <td class="po-expected-date">{{ order.expected_date }}</td>
                 <td class="po-delivery">{{ order.delivery_charge }}</td>
                 <td>
-                    <button type="button" class="btn btn-sm btn-primary edit-po-btn" data-bs-toggle="modal" data-bs-target="#editPurchaseOrderModal">Edit</button>
+                    <a href="{{ url_for('purchase.edit_purchase_order', po_id=order.id) }}" class="btn btn-sm btn-primary">Edit</a>
                     <a href="{{ url_for('purchase.receive_invoice', po_id=order.id) }}" class="btn btn-sm btn-success">Receive</a>
                     <form action="{{ url_for('purchase.delete_purchase_order', po_id=order.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
@@ -54,164 +54,4 @@
         </ul>
     </nav>
 </div>
-
-<!-- Create Modal -->
-<div class="modal fade" id="createPurchaseOrderModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Create Purchase Order</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <form id="createPurchaseOrderForm">
-      <div class="modal-body">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <div class="form-group">
-          <label for="create-vendor" class="form-label">Vendor</label>
-          <select id="create-vendor" name="vendor" class="form-control">
-            {% for v in vendors %}
-            <option value="{{ v.id }}">{{ v.first_name }} {{ v.last_name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-group">
-          <label for="create-order-date" class="form-label">Order Date</label>
-          <input type="date" id="create-order-date" name="order_date" class="form-control">
-        </div>
-        <div class="form-group">
-          <label for="create-expected-date" class="form-label">Expected Date</label>
-          <input type="date" id="create-expected-date" name="expected_date" class="form-control">
-        </div>
-        <div class="form-group">
-          <label for="create-delivery" class="form-label">Delivery Charge</label>
-          <input type="number" step="any" id="create-delivery" name="delivery_charge" class="form-control">
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="submit" class="btn btn-primary">Save</button>
-      </div>
-      </form>
-    </div>
-  </div>
-</div>
-
-<!-- Edit Modal -->
-<div class="modal fade" id="editPurchaseOrderModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Edit Purchase Order</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <form id="editPurchaseOrderForm">
-      <div class="modal-body">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <input type="hidden" id="edit-po-id" name="po_id">
-        <div class="form-group">
-          <label for="edit-vendor" class="form-label">Vendor</label>
-          <select id="edit-vendor" name="vendor" class="form-control">
-            {% for v in vendors %}
-            <option value="{{ v.id }}">{{ v.first_name }} {{ v.last_name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-group">
-          <label for="edit-order-date" class="form-label">Order Date</label>
-          <input type="date" id="edit-order-date" name="order_date" class="form-control">
-        </div>
-        <div class="form-group">
-          <label for="edit-expected-date" class="form-label">Expected Date</label>
-          <input type="date" id="edit-expected-date" name="expected_date" class="form-control">
-        </div>
-        <div class="form-group">
-          <label for="edit-delivery" class="form-label">Delivery Charge</label>
-          <input type="number" step="any" id="edit-delivery" name="delivery_charge" class="form-control">
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="submit" class="btn btn-primary">Save</button>
-      </div>
-      </form>
-    </div>
-  </div>
-</div>
-
-<script>
-function attachEditHandlers() {
-  document.querySelectorAll('.edit-po-btn').forEach(btn => {
-    btn.onclick = function() {
-      const row = this.closest('tr');
-      document.getElementById('edit-po-id').value = row.dataset.id;
-      document.getElementById('edit-vendor').value = row.dataset.vendor;
-      document.getElementById('edit-order-date').value = row.dataset.orderDate;
-      document.getElementById('edit-expected-date').value = row.dataset.expectedDate;
-      document.getElementById('edit-delivery').value = row.dataset.delivery;
-    };
-  });
-}
-attachEditHandlers();
-
-document.getElementById('createPurchaseOrderForm').addEventListener('submit', function(e) {
-  e.preventDefault();
-  const form = this;
-  fetch("{{ url_for('purchase.create_purchase_order') }}", {
-    method: 'POST',
-    headers: {'X-Requested-With': 'XMLHttpRequest'},
-    body: new FormData(form)
-  }).then(r => r.json()).then(data => {
-    if (data.success) {
-      const tbody = document.getElementById('po-table-body');
-      const row = document.createElement('tr');
-      row.dataset.id = data.order.id;
-      row.dataset.vendor = data.order.vendor_id;
-      row.dataset.orderDate = data.order.order_date;
-      row.dataset.expectedDate = data.order.expected_date;
-      row.dataset.delivery = data.order.delivery_charge;
-      row.innerHTML = `<td>${data.order.id}</td>
-        <td class="po-vendor">${data.order.vendor}</td>
-        <td class="po-order-date">${data.order.order_date}</td>
-        <td class="po-expected-date">${data.order.expected_date}</td>
-        <td class="po-delivery">${data.order.delivery_charge}</td>
-        <td>
-          <button type="button" class="btn btn-sm btn-primary edit-po-btn" data-bs-toggle="modal" data-bs-target="#editPurchaseOrderModal">Edit</button>
-          <a href="/purchase_orders/${data.order.id}/receive" class="btn btn-sm btn-success">Receive</a>
-          <form action="/purchase_orders/${data.order.id}/delete" method="post" class="d-inline">
-            <input type="hidden" name="csrf_token" value="{{ delete_form.csrf_token._value() if delete_form.csrf_token else '' }}">
-            <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Are you sure?');">Delete</button>
-          </form>
-        </td>`;
-      tbody.prepend(row);
-      attachEditHandlers();
-      bootstrap.Modal.getInstance(document.getElementById('createPurchaseOrderModal')).hide();
-      form.reset();
-    }
-  });
-});
-
-document.getElementById('editPurchaseOrderForm').addEventListener('submit', function(e) {
-  e.preventDefault();
-  const form = this;
-  const id = document.getElementById('edit-po-id').value;
-  fetch(`/purchase_orders/edit/${id}`, {
-    method: 'POST',
-    headers: {'X-Requested-With': 'XMLHttpRequest'},
-    body: new FormData(form)
-  }).then(r => r.json()).then(data => {
-    if (data.success) {
-      const row = document.querySelector(`tr[data-id='${id}']`);
-      row.dataset.vendor = data.order.vendor_id;
-      row.dataset.orderDate = data.order.order_date;
-      row.dataset.expectedDate = data.order.expected_date;
-      row.dataset.delivery = data.order.delivery_charge;
-      row.querySelector('.po-vendor').textContent = data.order.vendor;
-      row.querySelector('.po-order-date').textContent = data.order.order_date;
-      row.querySelector('.po-expected-date').textContent = data.order.expected_date;
-      row.querySelector('.po-delivery').textContent = data.order.delivery_charge;
-      bootstrap.Modal.getInstance(document.getElementById('editPurchaseOrderModal')).hide();
-    }
-  });
-});
-</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Fix item edit button so table form doesn't submit
- Ensure location and purchase order scripts wait for Bootstrap to load
- Revert purchase order list to link-based create/edit pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bce6cb73fc83248f6311d69756a905