### PR TITLE
Fix unit selector on purchase order pages

### DIFF
--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -117,9 +117,9 @@ document.addEventListener('DOMContentLoaded', function() {
             unitSelect.innerHTML = '';
             return;
         }
-        fetch(`/items/${itemId}/units`).then(r => r.json()).then(units => {
+        fetch(`/items/${itemId}/units`).then(r => r.json()).then(data => {
             let opts = '';
-            units.forEach(u => {
+            data.units.forEach(u => {
                 opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name}</option>`;
             });
             unitSelect.innerHTML = opts;

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -117,9 +117,9 @@ document.addEventListener('DOMContentLoaded', function() {
             unitSelect.innerHTML = '';
             return;
         }
-        fetch(`/items/${itemId}/units`).then(r => r.json()).then(units => {
+        fetch(`/items/${itemId}/units`).then(r => r.json()).then(data => {
             let opts = '';
-            units.forEach(u => {
+            data.units.forEach(u => {
                 opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name}</option>`;
             });
             unitSelect.innerHTML = opts;

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -91,9 +91,9 @@
             unitSelect.innerHTML = '';
             return;
         }
-        fetch(`/items/${itemId}/units`).then(r => r.json()).then(units => {
+        fetch(`/items/${itemId}/units`).then(r => r.json()).then(data => {
             let opts = '';
-            units.forEach(u => {
+            data.units.forEach(u => {
                 opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name}</option>`;
             });
             unitSelect.innerHTML = opts;


### PR DESCRIPTION
## Summary
- ensure unit of measure dropdowns on purchase order pages properly parse response data

## Testing
- `pre-commit run --files app/templates/purchase_orders/create_purchase_order.html app/templates/purchase_orders/edit_purchase_order.html app/templates/purchase_orders/receive_invoice.html`
- `pytest tests/test_purchase_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68bcea057338832482740849ee37cc0d