### PR TITLE
Add stand sheet scanning via QR code and OCR

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -649,7 +649,7 @@ def scan_stand_sheet():
         file = request.files.get("file")
         if not file:
             flash("No file uploaded")
-            return redirect(request.url)
+            return redirect(url_for("event.scan_stand_sheet"))
         with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
             file.save(tmp.name)
             path = tmp.name
@@ -659,14 +659,14 @@ def scan_stand_sheet():
         if not event_id or not location_id:
             os.remove(path)
             flash("Invalid or missing QR code")
-            return redirect(request.url)
+            return redirect(url_for("event.scan_stand_sheet"))
         el = EventLocation.query.filter_by(
             event_id=event_id, location_id=location_id
         ).first()
         if not el:
             os.remove(path)
             flash("Stand sheet not recognized")
-            return redirect(request.url)
+            return redirect(url_for("event.scan_stand_sheet"))
         text = pytesseract.image_to_string(Image.open(path))
         _parse_scanned_sheet(text, el)
         db.session.commit()

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -3,6 +3,7 @@
 <h2>{{ event.name }} - Stand Sheets</h2>
 {% for entry in data %}
     <h3>{{ entry.location.name }}</h3>
+    <img src="data:image/png;base64,{{ entry.qr }}" alt="QR Code" class="mb-2"/>
     <div class="table-responsive">
     <table class="table table-bordered">
         <thead>

--- a/app/templates/events/scan_stand_sheet.html
+++ b/app/templates/events/scan_stand_sheet.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <h2>Upload Scanned Stand Sheet</h2>
+  <form method="post" enctype="multipart/form-data">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <div class="mb-3">
+      <input type="file" class="form-control" name="file" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Upload</button>
+  </form>
+</div>
+{% endblock %}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -9,6 +9,7 @@ from .imports import (
     _import_locations,
     _import_products,
 )
+from .standsheet_scanner import decode_qr, generate_qr_code
 
 __all__ = [
     "log_activity",
@@ -19,4 +20,6 @@ __all__ = [
     "_import_locations",
     "_import_products",
     "send_email",
+    "generate_qr_code",
+    "decode_qr",
 ]

--- a/app/utils/standsheet_scanner.py
+++ b/app/utils/standsheet_scanner.py
@@ -1,0 +1,31 @@
+import base64
+import json
+from io import BytesIO
+from typing import Dict
+
+import cv2
+import qrcode
+
+
+def generate_qr_code(payload: Dict[str, int]) -> str:
+    """Return a base64-encoded PNG for the given payload."""
+    qr = qrcode.QRCode(box_size=4, border=2)
+    qr.add_data(json.dumps(payload))
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white")
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def decode_qr(path: str) -> Dict[str, int]:
+    """Decode a QR code from the provided image path."""
+    img = cv2.imread(path)
+    detector = cv2.QRCodeDetector()
+    data, _, _ = detector.detectAndDecode(img)
+    if data:
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError:
+            return {}
+    return {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ pandas==2.2.2
 reportlab==4.4.2
 pdfplumber==0.9.0
 twilio==9.0.0
+pytesseract==0.3.10
+opencv-python==4.10.0.84
+qrcode==7.4.2

--- a/tests/test_stand_sheet_scanning.py
+++ b/tests/test_stand_sheet_scanning.py
@@ -1,0 +1,117 @@
+import json
+from io import BytesIO
+
+import qrcode
+from PIL import Image
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import (
+    Event,
+    EventLocation,
+    EventStandSheetItem,
+    Item,
+    ItemUnit,
+    Location,
+    LocationStandItem,
+    User,
+)
+from tests.utils import login
+
+
+def setup_scan_env(app):
+    with app.app_context():
+        user = User(
+            email="scan@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        loc = Location(name="ScanLoc")
+        item = Item(name="ScanItem", base_unit="each")
+        db.session.add_all([user, loc, item])
+        db.session.commit()
+        iu = ItemUnit(
+            item_id=item.id,
+            name="each",
+            factor=1,
+            receiving_default=True,
+            transfer_default=True,
+        )
+        db.session.add(iu)
+        db.session.add(
+            LocationStandItem(
+                location_id=loc.id, item_id=item.id, expected_count=10
+            )
+        )
+        db.session.commit()
+        return user.email, loc.id, item.id
+
+
+def test_scan_stand_sheet(client, app, monkeypatch):
+    email, loc_id, item_id = setup_scan_env(app)
+    with client:
+        login(client, email, "pass")
+        client.post(
+            "/events/create",
+            data={
+                "name": "ScanEvent",
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-02",
+                "event_type": "inventory",
+            },
+            follow_redirects=True,
+        )
+    with app.app_context():
+        ev = Event.query.filter_by(name="ScanEvent").first()
+        eid = ev.id
+    with client:
+        login(client, email, "pass")
+        client.post(
+            f"/events/{eid}/add_location",
+            data={"location_id": loc_id},
+            follow_redirects=True,
+        )
+    with app.app_context():
+        el = EventLocation.query.filter_by(
+            event_id=eid, location_id=loc_id
+        ).first()
+        assert el is not None
+
+    payload = {"event_id": eid, "location_id": loc_id}
+    qr = qrcode.make(json.dumps(payload))
+    img = Image.new("RGB", (200, 200), "white")
+    img.paste(qr.resize((150, 150)), (25, 25))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+    data = {"file": (buf, "sheet.png")}
+
+    monkeypatch.setattr(
+        "pytesseract.image_to_string",
+        lambda *_args, **_kwargs: "ScanItem 10 8 2 1 0 0 5 4",
+    )
+
+    with client:
+        login(client, email, "pass")
+        resp = client.post(
+            "/events/scan_stand_sheet",
+            data=data,
+            content_type="multipart/form-data",
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+    with app.app_context():
+        el = EventLocation.query.filter_by(
+            event_id=eid, location_id=loc_id
+        ).first()
+        sheet = EventStandSheetItem.query.filter_by(
+            event_location_id=el.id, item_id=item_id
+        ).first()
+        assert sheet is not None
+        assert sheet.opening_count == 8
+        assert sheet.transferred_in == 2
+        assert sheet.transferred_out == 1
+        assert sheet.eaten == 0
+        assert sheet.spoiled == 0
+        assert sheet.closing_count == 4


### PR DESCRIPTION
## Summary
- Generate stand-sheet PDFs with QR codes for event/location identification
- Support uploading scanned stand sheets and extract counts via OCR
- Add test covering stand sheet scan workflow

## Testing
- `pre-commit run --files app/routes/event_routes.py app/templates/events/bulk_stand_sheets.html app/utils/__init__.py app/templates/events/scan_stand_sheet.html app/utils/standsheet_scanner.py tests/test_stand_sheet_scanning.py requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd0af249988324a13cdb9987972edf