### PR TITLE
Use headless OpenCV and configure rate limiter storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ reportlab==4.4.2
 pdfplumber==0.9.0
 twilio==9.0.0
 pytesseract==0.3.10
-opencv-python==4.10.0.84
+opencv-python-headless==4.10.0.84
 qrcode==7.4.2


### PR DESCRIPTION
## Summary
- Replace `opencv-python` with `opencv-python-headless` to avoid missing libGL error
- Configure Flask-Limiter to use an explicit in-memory storage backend

## Testing
- `pre-commit run --files app/__init__.py requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd2d8b2edc83249c0d6cb91843e294