### PR TITLE
Enable stand sheet scan uploads and improve print layout

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -672,7 +672,11 @@ def scan_stand_sheet():
         db.session.commit()
         os.remove(path)
         flash("Stand sheet imported")
-        return redirect(url_for("event.view_event", event_id=event_id))
+        return redirect(
+            url_for(
+                "event.stand_sheet", event_id=event_id, location_id=location_id
+            )
+        )
     return render_template("events/scan_stand_sheet.html")
 
 

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -1,7 +1,14 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>{{ event.name }} - Stand Sheets</h2>
+<style>
+@media print {
+  .standsheet-page { page-break-after: always; }
+  .standsheet-page:last-child { page-break-after: auto; }
+}
+</style>
 {% for entry in data %}
+<div class="standsheet-page">
     <h3>{{ entry.location.name }}</h3>
     <img src="data:image/png;base64,{{ entry.qr }}" alt="QR Code" class="mb-2"/>
     <div class="table-responsive">
@@ -15,7 +22,6 @@
                 <th>Transferred Out</th>
                 <th>Eaten</th>
                 <th>Spoiled</th>
-                <th>Terminal Sales</th>
                 <th>Closing Count</th>
                 <th>Variance</th>
             </tr>
@@ -30,7 +36,6 @@
                 <td></td>
                 <td></td>
                 <td></td>
-                <td>{{ s.sales }}</td>
                 <td></td>
                 <td></td>
             </tr>
@@ -38,6 +43,6 @@
         </tbody>
     </table>
     </div>
-    <div style="page-break-after: always;"></div>
+</div>
 {% endfor %}
 {% endblock %}

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -3,6 +3,13 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Stand Sheet - {{ location.name }}</h2>
+    <form action="{{ url_for('event.scan_stand_sheet') }}" method="post" enctype="multipart/form-data" class="mb-3">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <div class="input-group">
+            <input type="file" class="form-control" name="file" required>
+            <button class="btn btn-secondary" type="submit">Upload Scanned Sheet</button>
+        </div>
+    </form>
     <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <div class="table-responsive">

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -20,6 +20,7 @@
             {% if event.event_type == 'inventory' %}| <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a>{% endif %} |
             <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> |
             <a href="{{ url_for('event.upload_terminal_sales', event_id=event.id) }}">Upload Sales</a> |
+            <a href="{{ url_for('event.scan_stand_sheet') }}">Upload Stand Sheet</a> |
             <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>
         {% else %}
             Stand Sheet | Terminal Sales


### PR DESCRIPTION
## Summary
- allow uploading scanned stand sheets from location pages
- redirect scan handler back to the appropriate stand sheet
- simplify printed stand sheets and ensure each location starts on a new page

## Testing
- `pre-commit run --files app/routes/event_routes.py app/templates/events/bulk_stand_sheets.html app/templates/events/stand_sheet.html app/templates/events/view_event.html`
- `pytest tests/test_stand_sheet_scanning.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd3259d6e88324b39b6fddc04d364c