### PR TITLE
Use socketio.run for WebSocket stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ EXPOSE ${PORT}
 USER app
 
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["gunicorn", "run:app"]
+CMD ["gunicorn", "--worker-class", "eventlet", "run:app"]

--- a/run.py
+++ b/run.py
@@ -11,8 +11,4 @@ app.debug = debug
 
 if __name__ == "__main__":
     port = int(os.getenv("PORT", "5000"))
-    # Run using eventlet's production WSGI server
-    import eventlet
-    from eventlet import wsgi
-
-    wsgi.server(eventlet.listen(("0.0.0.0", port)), app)
+    socketio.run(app, host="0.0.0.0", port=port, debug=debug)


### PR DESCRIPTION
## Summary
- run the app with `socketio.run` so WebSocket handling is delegated to Flask-SocketIO
- default Gunicorn to the eventlet worker for WebSocket support
- adjust tests for the new startup behaviour

## Testing
- `pre-commit run --files run.py Dockerfile tests/test_run_module.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdf344d2248324b0cf04b5323667ba