### PR TITLE
Ensure Gunicorn uses eventlet for Socket.IO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ EXPOSE ${PORT}
 USER app
 
 ENTRYPOINT ["./entrypoint.sh"]
-CMD ["gunicorn", "--worker-class", "eventlet", "run:app"]
+CMD ["gunicorn", "-c", "gunicorn.conf.py", "run:app"]

--- a/README.md
+++ b/README.md
@@ -73,13 +73,21 @@ Set `PORT` in your environment to change the port (default `5000`).
 
 The application uses a local SQLite database located at `inventory.db` and creates `uploads` and `backups` directories automatically on startup.
 
+For production deployments using Gunicorn, use the provided configuration to enable WebSocket support and prevent worker timeouts:
+
+```bash
+gunicorn -c gunicorn.conf.py run:app
+```
+
 ## Docker Setup
 
 The project includes a `Dockerfile` and a `docker-compose.yml` to make running
-the application in a container straightforward on Linux and Windows. Create a
-`.env` file containing the environment variables described above. You can also
-specify the port the app will use by adding a `PORT` variable to `.env` (or by
-exporting it in your shell) before starting the service:
+the application in a container straightforward on Linux and Windows. The image
+starts Gunicorn using the included `gunicorn.conf.py`, so no additional commands
+are required. Create a `.env` file containing the environment variables
+described above. You can also specify the port the app will use by adding a
+`PORT` variable to `.env` (or by exporting it in your shell) before starting the
+service:
 
 ```bash
 docker compose up --build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ PYTHON
 
 if [ "$1" = "gunicorn" ]; then
     shift
-    exec gunicorn --bind "0.0.0.0:${PORT}" "$@"
+    exec gunicorn "$@"
 fi
 
 exec "$@"

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,10 @@
+import os
+
+# Bind to the port provided via the PORT environment variable, defaulting to 5000.
+bind = f"0.0.0.0:{os.getenv('PORT', '5000')}"
+
+# Use eventlet workers to support WebSocket connections from Flask-SocketIO.
+worker_class = "eventlet"
+
+# Increase the timeout to avoid premature worker restarts while establishing Socket.IO connections.
+timeout = 60


### PR DESCRIPTION
## Summary
- start Gunicorn with the provided config in the Docker image
- drop hard-coded bind in entrypoint so config controls networking
- document that the container automatically uses the Gunicorn configuration

## Testing
- `pre-commit run --files Dockerfile entrypoint.sh README.md gunicorn.conf.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be0c00c0b88324bc5663c1f24b2aa9