### PR TITLE
Show event info on stand sheet templates

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -46,6 +46,11 @@
 <div class="standsheet-page">
     <h3>{{ entry.location.name }}</h3>
     <img src="data:image/png;base64,{{ entry.qr }}" alt="QR Code" class="mb-2"/>
+    <div class="mb-3">
+        <div>Location: {{ entry.location.name }}</div>
+        <div>Event: {{ event.name }}</div>
+        <div>Event Date/Time: {{ event.start_date }}</div>
+    </div>
     <div class="table-responsive">
     <table class="table table-bordered">
         <thead>

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -12,6 +12,11 @@
     </form>
     <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+        <div class="mb-3">
+            <div>Location: {{ location.name }}</div>
+            <div>Event: {{ event.name }}</div>
+            <div>Event Date/Time: {{ event.start_date }}</div>
+        </div>
     <div class="table-responsive">
     <table class="table table-bordered">
         <thead>


### PR DESCRIPTION
## Summary
- Display location, event name, and start date/time above stand sheet tables
- Include event details on each page of bulk stand sheets for printing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be5ad9c8b08324a208ce1c8f27c521