### PR TITLE
Clean up stand sheet templates by removing upload/QR elements

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>{{ event.name }} - Stand Sheets</h2>
 <style>
 @media print {
   @page {
@@ -12,8 +11,7 @@
   .navbar-nav,
   .navbar-toggler,
   .offcanvas,
-  .alert,
-  h2 {
+  .alert {
     display: none !important;
   }
 
@@ -44,8 +42,6 @@
 </style>
 {% for entry in data %}
 <div class="standsheet-page">
-    <h3>{{ entry.location.name }}</h3>
-    <img src="data:image/png;base64,{{ entry.qr }}" alt="QR Code" class="mb-2"/>
     <div class="mb-3">
         <div>Location: {{ entry.location.name }}</div>
         <div>Event: {{ event.name }}</div>

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -2,14 +2,6 @@
 
 {% block content %}
 <div class="container mt-4">
-    <h2>Stand Sheet - {{ location.name }}</h2>
-    <form action="{{ url_for('event.scan_stand_sheet') }}" method="post" enctype="multipart/form-data" class="mb-3">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-        <div class="input-group">
-            <input type="file" class="form-control" name="file" required>
-            <button class="btn btn-secondary" type="submit">Upload Scanned Sheet</button>
-        </div>
-    </form>
     <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
         <div class="mb-3">


### PR DESCRIPTION
## Summary
- Remove scan upload form and headings from stand sheet template
- Drop QR code and redundant headings from bulk stand sheets
- Preserve only header details and table for cleaner layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytesseract')*
- `pytest tests/test_event_flow.py::test_bulk_stand_sheet -q`

------
https://chatgpt.com/codex/tasks/task_e_68be6058af908324a7b1f1bdbc3e0acb