### PR TITLE
Revise stand sheet columns and variance

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -52,12 +52,11 @@
         <thead>
             <tr>
                 <th>Item</th>
-                <th>Expected Opening</th>
-                <th>Opening Count</th>
+                <th>Prior Event Close</th>
+                <th>Pre-Event Count</th>
                 <th>Transferred In</th>
                 <th>Transferred Out</th>
-                <th>Eaten</th>
-                <th>Spoiled</th>
+                <th>Sales</th>
                 <th>Closing Count</th>
                 <th>Variance</th>
             </tr>
@@ -67,7 +66,6 @@
             <tr>
                 <td>{{ s.item.name }}</td>
                 <td>{{ s.expected }}</td>
-                <td></td>
                 <td></td>
                 <td></td>
                 <td></td>

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -14,13 +14,11 @@
         <thead>
             <tr>
                 <th>Item</th>
-                <th>Expected Opening</th>
-                <th>Opening Count</th>
+                <th>Prior Event Close</th>
+                <th>Pre-Event Count</th>
                 <th>Transferred In</th>
                 <th>Transferred Out</th>
-                <th>Eaten</th>
-                <th>Spoiled</th>
-                <th>Terminal Sales</th>
+                <th>Sales</th>
                 <th>Closing Count</th>
                 <th>Variance</th>
             </tr>
@@ -33,8 +31,6 @@
                 <td><input type="number" class="form-control" name="open_{{ entry.item.id }}" value="{{ entry.sheet.opening_count if entry.sheet else '' }}"></td>
                 <td><input type="number" class="form-control" name="in_{{ entry.item.id }}" value="{{ entry.sheet.transferred_in if entry.sheet else '' }}"></td>
                 <td><input type="number" class="form-control" name="out_{{ entry.item.id }}" value="{{ entry.sheet.transferred_out if entry.sheet else '' }}"></td>
-                <td><input type="number" class="form-control" name="eaten_{{ entry.item.id }}" value="{{ entry.sheet.eaten if entry.sheet else '' }}"></td>
-                <td><input type="number" class="form-control" name="spoiled_{{ entry.item.id }}" value="{{ entry.sheet.spoiled if entry.sheet else '' }}"></td>
                 <td class="sales" data-sales="{{ entry.sales }}">{{ entry.sales }}</td>
                 <td><input type="number" class="form-control" name="close_{{ entry.item.id }}" value="{{ entry.sheet.closing_count if entry.sheet else '' }}"></td>
                 <td class="variance">0</td>
@@ -49,13 +45,11 @@
 <script>
     function calcVariance(row) {
         const sales = parseFloat(row.querySelector('.sales').dataset.sales) || 0;
-        const open = parseFloat(row.querySelector('input[name^="open_"]').value) || 0;
+        const pre = parseFloat(row.querySelector('input[name^="open_"]').value) || 0;
         const tin = parseFloat(row.querySelector('input[name^="in_"]').value) || 0;
         const tout = parseFloat(row.querySelector('input[name^="out_"]').value) || 0;
-        const eaten = parseFloat(row.querySelector('input[name^="eaten_"]').value) || 0;
-        const spoiled = parseFloat(row.querySelector('input[name^="spoiled_"]').value) || 0;
         const close = parseFloat(row.querySelector('input[name^="close_"]').value) || 0;
-        const variance = open + tin - tout - eaten - spoiled - sales - close;
+        const variance = pre + tin - tout - sales - close;
         row.querySelector('.variance').textContent = variance.toFixed(2);
     }
 


### PR DESCRIPTION
## Summary
- Streamline stand sheet and bulk stand sheet templates to show only prior close, pre-event count, transfers, sales, closing count, and variance
- Drop unused eaten/spoiled fields and adjust variance calculation accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be62f2df888324aaad447b6fcb7f6f