### PR TITLE
Fix Windows-incompatible strftime format

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -584,7 +584,10 @@ def bulk_stand_sheets(event_id):
         loc, items = _get_stand_items(el.location_id, event_id)
         qr = generate_qr_code({"event_id": event_id, "location_id": loc.id})
         data.append({"location": loc, "stand_items": items, "qr": qr})
-    generated_at_local = datetime.now().strftime("%-m/%-d/%Y %-I:%M %p")
+    dt = datetime.now()
+    generated_at_local = (
+        f"{dt.month}/{dt.day}/{dt.year} {dt.strftime('%I:%M %p').lstrip('0')}"
+    )
     return render_template(
         "events/bulk_stand_sheets.html",
         event=ev,


### PR DESCRIPTION
## Summary
- ensure stand sheet generation timestamp formatting works on Windows

## Testing
- `pre-commit run --files app/routes/event_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf2dbbfe748324899edf5fa268197a