### PR TITLE
Ensure stand sheets render on Windows

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 import os
-from datetime import datetime, timedelta
+import sys
+from datetime import datetime, timedelta, date
 from datetime import timezone as dt_timezone
 from zoneinfo import ZoneInfo
 
@@ -152,8 +153,13 @@ def create_app(args: list):
             tz = ZoneInfo(tz_name)
         except Exception:
             tz = ZoneInfo("UTC")
-        if value.tzinfo is None:
+        if isinstance(value, date) and not isinstance(value, datetime):
+            value = datetime.combine(value, datetime.min.time())
             value = value.replace(tzinfo=dt_timezone.utc)
+        elif value.tzinfo is None:
+            value = value.replace(tzinfo=dt_timezone.utc)
+        if sys.platform.startswith("win"):
+            fmt = fmt.replace("%-", "%#")
         return value.astimezone(tz).strftime(fmt)
 
     app.jinja_env.filters["format_datetime"] = format_datetime

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -111,7 +111,7 @@ body {
   <div class="meta">
     <div>Location: {{ entry.location.name }}</div>
     <div>Event: {{ event.name }}</div>
-    <div>Event Date/Time: {{ event.start_date.strftime('%-m/%-d/%Y %-I:%M %p') }}</div>
+    <div>Event Date/Time: {{ event.start_date|format_datetime('%-m/%-d/%Y %-I:%M %p') }}</div>
   </div>
   <div class="table">
     <table>


### PR DESCRIPTION
## Summary
- handle Windows strftime quirks in format_datetime filter
- use cross-platform date formatting in bulk stand sheets template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf2fe9daf48324b7767ca2fe7694df