### PR TITLE
Add OCR confidence review workflow

### DIFF
--- a/app/templates/events/review_scanned_sheet.html
+++ b/app/templates/events/review_scanned_sheet.html
@@ -1,0 +1,78 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+    <div class="mb-3">
+      <div>Location: {{ location.name }}</div>
+      <div>Event: {{ event.name }}</div>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Item</th>
+            <th>Opening Count</th>
+            <th>Transferred In</th>
+            <th>Transferred Out</th>
+            <th>Eaten</th>
+            <th>Spoiled</th>
+            <th>Closing Count</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for entry in stand_items %}
+          {% set scan = scanned.get(entry.item.id|string) %}
+          <tr>
+            <td>{{ entry.item.name }}</td>
+            <td>
+              <div class="d-flex align-items-center">
+                <input type="number" class="form-control {% if scan and scan.flags.opening_count %}low-confidence{% endif %}" name="open_{{ entry.item.id }}" value="{{ scan.opening_count if scan else '' }}">
+                {% if scan and scan.flags.opening_count %}<span class="ms-1 text-warning">&#9888;</span>{% endif %}
+              </div>
+            </td>
+            <td>
+              <div class="d-flex align-items-center">
+                <input type="number" class="form-control {% if scan and scan.flags.transferred_in %}low-confidence{% endif %}" name="in_{{ entry.item.id }}" value="{{ scan.transferred_in if scan else '' }}">
+                {% if scan and scan.flags.transferred_in %}<span class="ms-1 text-warning">&#9888;</span>{% endif %}
+              </div>
+            </td>
+            <td>
+              <div class="d-flex align-items-center">
+                <input type="number" class="form-control {% if scan and scan.flags.transferred_out %}low-confidence{% endif %}" name="out_{{ entry.item.id }}" value="{{ scan.transferred_out if scan else '' }}">
+                {% if scan and scan.flags.transferred_out %}<span class="ms-1 text-warning">&#9888;</span>{% endif %}
+              </div>
+            </td>
+            <td>
+              <div class="d-flex align-items-center">
+                <input type="number" class="form-control {% if scan and scan.flags.eaten %}low-confidence{% endif %}" name="eaten_{{ entry.item.id }}" value="{{ scan.eaten if scan else '' }}">
+                {% if scan and scan.flags.eaten %}<span class="ms-1 text-warning">&#9888;</span>{% endif %}
+              </div>
+            </td>
+            <td>
+              <div class="d-flex align-items-center">
+                <input type="number" class="form-control {% if scan and scan.flags.spoiled %}low-confidence{% endif %}" name="spoiled_{{ entry.item.id }}" value="{{ scan.spoiled if scan else '' }}">
+                {% if scan and scan.flags.spoiled %}<span class="ms-1 text-warning">&#9888;</span>{% endif %}
+              </div>
+            </td>
+            <td>
+              <div class="d-flex align-items-center">
+                <input type="number" class="form-control {% if scan and scan.flags.closing_count %}low-confidence{% endif %}" name="close_{{ entry.item.id }}" value="{{ scan.closing_count if scan else '' }}">
+                {% if scan and scan.flags.closing_count %}<span class="ms-1 text-warning">&#9888;</span>{% endif %}
+              </div>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <button type="submit" class="btn btn-primary">Confirm</button>
+  </form>
+</div>
+<style>
+.low-confidence {
+  border-color: #ffc107;
+  box-shadow: 0 0 5px #ffc107;
+}
+</style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Use `pytesseract.image_to_data` to capture OCR confidence scores for stand sheets
- Store parsed OCR results in session and add review step with low-confidence highlights
- Persist stand sheet data only after user confirmation

## Testing
- `pytest tests/test_stand_sheet_scanning.py::test_scan_stand_sheet -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf473ba658832480f166d0986eec44