### PR TITLE
Label purchase order unit options with base unit factor

### DIFF
--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -120,7 +120,7 @@ document.addEventListener('DOMContentLoaded', function() {
         fetch(`/items/${itemId}/units`).then(r => r.json()).then(data => {
             let opts = '';
             data.units.forEach(u => {
-                opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name}</option>`;
+                opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name} of ${u.factor} ${data.base_unit}${u.factor != 1 ? 's' : ''}</option>`;
             });
             unitSelect.innerHTML = opts;
         });

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -120,7 +120,7 @@ document.addEventListener('DOMContentLoaded', function() {
         fetch(`/items/${itemId}/units`).then(r => r.json()).then(data => {
             let opts = '';
             data.units.forEach(u => {
-                opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name}</option>`;
+                opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name} of ${u.factor} ${data.base_unit}${u.factor != 1 ? 's' : ''}</option>`;
             });
             unitSelect.innerHTML = opts;
         });


### PR DESCRIPTION
## Summary
- include unit factor and base unit in purchase-order unit dropdowns
- ensure dynamically added items use consistent unit labeling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf5ccdba588324b57b568cb3831982