### PR TITLE
Add event-level upload sales button

### DIFF
--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -10,6 +10,7 @@
 <a class="btn btn-secondary" href="{{ url_for('event.bulk_count_sheets', event_id=event.id) }}">Count Sheets</a>
 {% endif %}
 {% if not event.closed %}
+<a class="btn btn-secondary" href="{{ url_for('event.upload_terminal_sales', event_id=event.id) }}">Upload Sales</a>
 <a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
 {% endif %}
 <ul class="mt-3">
@@ -19,7 +20,6 @@
             <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a>
             {% if event.event_type == 'inventory' %}| <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a>{% endif %} |
             <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> |
-            <a href="{{ url_for('event.upload_terminal_sales', event_id=event.id) }}">Upload Sales</a> |
             <a href="{{ url_for('event.scan_stand_sheet') }}">Upload Stand Sheet</a> |
             <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>
         {% else %}


### PR DESCRIPTION
## Summary
- Add an "Upload Sales" button in event actions so sales can be uploaded once per event
- Remove per-location upload sales link inside event view

## Testing
- `pytest -q` *(fails: PluggyTeardownRaisedWarning: KeyError: <_pytest.stash.StashKey ...>)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5cc3885c832498f726217ecf68d0