### PR TITLE
Add filtering controls for purchase orders

### DIFF
--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -2,7 +2,81 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Purchase Orders</h2>
-    <a class="btn btn-primary mb-3" href="{{ url_for('purchase.create_purchase_order') }}">Create Purchase Order</a>
+    <div class="row justify-content-between">
+        <div class="col-auto">
+            <a class="btn btn-primary mb-3" href="{{ url_for('purchase.create_purchase_order') }}">Create Purchase Order</a>
+        </div>
+        <div class="col-auto">
+            <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
+                Filters
+            </button>
+        </div>
+    </div>
+
+    <!-- Filter Modal -->
+    <div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="filterModalLabel">Filters</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="filter-form" method="get">
+                        <div class="mb-3">
+                            <label for="vendor_id" class="form-label">Vendor</label>
+                            <select id="vendor_id" name="vendor_id" class="form-select">
+                                <option value="">All Vendors</option>
+                                {% for v in vendors %}
+                                <option value="{{ v.id }}" {% if vendor_id == v.id %}selected{% endif %}>{{ v.first_name }} {{ v.last_name }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <label for="start_date" class="form-label">Start Date</label>
+                                <input type="date" id="start_date" name="start_date" class="form-control" value="{{ start_date }}">
+                            </div>
+                            <div class="col-md-6">
+                                <label for="end_date" class="form-label">End Date</label>
+                                <input type="date" id="end_date" name="end_date" class="form-control" value="{{ end_date }}">
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="status" class="form-label">Status</label>
+                            <select id="status" name="status" class="form-select">
+                                <option value="pending" {% if status == 'pending' %}selected{% endif %}>Pending</option>
+                                <option value="completed" {% if status == 'completed' %}selected{% endif %}>Completed</option>
+                                <option value="all" {% if status == 'all' %}selected{% endif %}>All</option>
+                            </select>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <a href="{{ url_for('purchase.view_purchase_orders') }}" class="btn btn-outline-secondary">Reset</a>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if selected_vendor %}
+    <div class="mb-3">
+        <strong>Filtering by Vendor:</strong> {{ selected_vendor.first_name }} {{ selected_vendor.last_name }}
+    </div>
+    {% endif %}
+    {% if start_date or end_date %}
+    <div class="mb-3">
+        <strong>Filtering by Date:</strong> {{ start_date or '...' }} - {{ end_date or '...' }}
+    </div>
+    {% endif %}
+    {% if status != 'pending' %}
+    <div class="mb-3">
+        <strong>Status:</strong> {% if status == 'completed' %}Completed{% elif status == 'all' %}All{% else %}Pending{% endif %}
+    </div>
+    {% endif %}
+
     <div class="table-responsive">
     <table class="table">
         <thead>
@@ -40,7 +114,7 @@
         <ul class="pagination">
             {% if orders.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.prev_num) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.prev_num, vendor_id=vendor_id, start_date=start_date, end_date=end_date, status=status) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -48,7 +122,7 @@
             </li>
             {% if orders.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.next_num) }}">Next</a>
+                <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.next_num, vendor_id=vendor_id, start_date=start_date, end_date=end_date, status=status) }}">Next</a>
             </li>
             {% endif %}
         </ul>


### PR DESCRIPTION
## Summary
- add filter modal to purchase orders view
- allow filtering purchase orders by vendor, date range, and status

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf5cda5a388324a5cd4ae90211cf25