### PR TITLE
style: align location stand sheet with bulk format

### DIFF
--- a/app/templates/locations/stand_sheet.html
+++ b/app/templates/locations/stand_sheet.html
@@ -1,37 +1,171 @@
 {% extends 'base.html' %}
 
 {% block content %}
-<div class="container mt-4">
-    <h2>Stand Sheet - {{ location.name }}</h2>
-    <div class="table-responsive">
-    <table class="table table-bordered">
-        <thead>
-            <tr>
-                <th>Item</th>
-                <th>Expected Opening</th>
-                <th>Opening Count</th>
-                <th>Transferred In</th>
-                <th>Transferred Out</th>
-                <th>Eaten</th>
-                <th>Spoiled</th>
-                <th>Closing Count</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for entry in stand_items %}
-            <tr>
-                <td>{{ entry.item.name }}</td>
-                <td>{{ entry.expected }}</td>
-                <td><input type="number" class="form-control" name="open_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="in_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="out_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="eaten_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="spoiled_{{ entry.item.id }}"></td>
-                <td><input type="number" class="form-control" name="close_{{ entry.item.id }}"></td>
-            </tr>
+<style>
+@page {
+  margin: 0.5in;
+}
+body {
+  font-family: system-ui, sans-serif;
+  font-size: 12px;
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+.report {
+  width: 100%;
+}
+.table table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+.table th,
+.table td {
+  border: 1px solid #000;
+  padding: 2px 4px;
+}
+.table th {
+  text-align: center;
+}
+.table td:first-child {
+  text-align: left;
+}
+.table td:not(:first-child) {
+  text-align: right;
+}
+.table .border-right {
+  border-right: 1px solid #000;
+}
+.table tbody tr:nth-child(even) {
+  background: #fafafa;
+}
+.signoffs {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+}
+.signoffs .left,
+.signoffs .right {
+  width: 48%;
+}
+.signoffs .left div,
+.signoffs .right div {
+  margin-bottom: 8px;
+}
+.footer {
+  position: fixed;
+  bottom: 0.25in;
+  left: 0.5in;
+  right: 0.5in;
+  display: flex;
+  font-size: 11px;
+}
+.footer div:nth-child(1) {
+  flex: 1;
+  text-align: left;
+}
+.footer div:nth-child(2) {
+  flex: 1;
+  text-align: center;
+}
+.footer div:nth-child(3) {
+  flex: 1;
+  text-align: right;
+}
+.standsheet-page {
+  page-break-after: always;
+}
+.standsheet-page:last-child {
+  page-break-after: auto;
+}
+@media print {
+  .no-print { display: none; }
+}
+</style>
+
+<section class="report standsheet-page">
+  <div class="table">
+    <table>
+      <colgroup>
+        <col style="width:35%">
+        <col style="width:7%">
+        <col style="width:7%">
+        <col style="width:5%">
+        <col style="width:5%">
+        <col style="width:7%">
+        <col style="width:7%">
+        <col style="width:7%">
+        <col style="width:7%">
+        <col style="width:6%">
+        <col style="width:7%">
+      </colgroup>
+      <thead>
+        <tr>
+          <th rowspan="2">Stock Item (Base Unit)</th>
+          <th rowspan="2">Expected Opening Count</th>
+          <th rowspan="2">Opening Count</th>
+          <th colspan="2" class="border-right">Event Transfers</th>
+          <th rowspan="2">Eaten</th>
+          <th rowspan="2" class="border-right">Spoilage</th>
+          <th rowspan="2">Closing Count</th>
+          <th rowspan="2">Units Sold</th>
+          <th rowspan="2">Price</th>
+          <th rowspan="2">Variance</th>
+        </tr>
+        <tr>
+          <th class="border-right">In</th>
+          <th>Out</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for s in stand_items %}
+        {% set price = namespace(value=None) %}
+        {% for product in location.products %}
+          {% if price.value is none %}
+            {% for ri in product.recipe_items %}
+              {% if price.value is none and ri.item_id == s.item.id %}
+                {% set price.value = product.price %}
+              {% endif %}
             {% endfor %}
-        </tbody>
+          {% endif %}
+        {% endfor %}
+        <tr>
+          <td>{{ s.item.name }} ({{ s.item.base_unit }})</td>
+          <td>{{ s.expected }}</td>
+          <td></td>
+          <td class="border-right"></td>
+          <td></td>
+          <td></td>
+          <td class="border-right"></td>
+          <td></td>
+          <td></td>
+          <td>{% if price.value is not none %}${{ '%.2f'|format(price.value) }}{% endif %}</td>
+          <td></td>
+        </tr>
+        {% endfor %}
+      </tbody>
     </table>
+  </div>
+  <div class="signoffs">
+    <div class="left">
+      <div>Opening Stand Manager  ______________________________</div>
+      <div>Opening Supervisor     ______________________________</div>
+      <div>Closing Stand Manager  ______________________________</div>
+      <div>Closing Supervisor     ______________________________</div>
+      <div>Audit/Review Signature ______________________________</div>
     </div>
-</div>
+    <div class="right">
+      <div>Total Sales  ______________________________</div>
+      <div>Total Cash   ______________________________</div>
+      <div>Credit Cards ______________________________</div>
+      <div>Coupons      ______________________________</div>
+      <div>Over/Short   ______________________________</div>
+    </div>
+  </div>
+</section>
+<footer class="footer">
+  <div>Standsheet</div>
+  <div>1 of 1</div>
+  <div></div>
+</footer>
 {% endblock %}


### PR DESCRIPTION
## Summary
- adopt bulk stand sheet CSS and layout for location stand sheet
- remove QR code and event-specific metadata
- provide printable table and sign-off sections for a single location

## Testing
- `pre-commit run --files app/templates/locations/stand_sheet.html`
- `pytest tests/test_item_transfer_invoice.py::test_stand_sheet_shows_expected_counts -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf5fc9eb6c83248b69a7cf395d1a83