### PR TITLE
Pre-populate variance fields on stand sheet

### DIFF
--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -53,9 +53,12 @@
         row.querySelector('.variance').textContent = variance.toFixed(2);
     }
 
-    document.querySelectorAll('tbody tr').forEach(function(row){
-        row.querySelectorAll('input').forEach(function(inp){
-            inp.addEventListener('input', function(){ calcVariance(row); });
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('tbody tr').forEach(function(row){
+            row.querySelectorAll('input').forEach(function(inp){
+                inp.addEventListener('input', function(){ calcVariance(row); });
+            });
+            calcVariance(row);
         });
     });
 </script>


### PR DESCRIPTION
## Summary
- Pre-populate variance calculations for each stand sheet row on load
- Initialize variance listeners after DOMContentLoaded to ensure inputs are ready

## Testing
- `pre-commit run --files app/templates/events/stand_sheet.html`


------
https://chatgpt.com/codex/tasks/task_e_68bf5fbb89688324a244a3dee7b3b47d