### PR TITLE
refactor: scope standsheet styles

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -4,7 +4,7 @@
 @page {
   margin: 0.5in;
 }
-body {
+.standsheet-content {
   font-family: system-ui, sans-serif;
   font-size: 12px;
   margin: 0;
@@ -117,6 +117,7 @@ body {
   .no-print { display: none; }
 }
 </style>
+<div class="standsheet-content">
 {% for entry in data %}
 <section class="report standsheet-page">
   <div class="header">
@@ -219,4 +220,5 @@ body {
   <div>1 of 1</div>
   <div></div>
 </footer>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- avoid global body style bleeding into navbar
- wrap standsheet content in dedicated `.standsheet-content` container with size and margin rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf62e976948324ac3d5d4cb780df9b