### PR TITLE
Display location on standsheet page

### DIFF
--- a/app/templates/locations/stand_sheet.html
+++ b/app/templates/locations/stand_sheet.html
@@ -14,6 +14,14 @@ body {
 .report {
   width: 100%;
 }
+.meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11px;
+  border-bottom: 1px solid #000;
+  padding-bottom: 4px;
+  margin-bottom: 10px;
+}
 .table table {
   width: 100%;
   border-collapse: collapse;
@@ -84,6 +92,9 @@ body {
 </style>
 
 <section class="report standsheet-page">
+  <div class="meta">
+    <div>Location: {{ location.name }}</div>
+  </div>
   <div class="table">
     <table>
       <colgroup>

--- a/tests/test_location_routes.py
+++ b/tests/test_location_routes.py
@@ -89,6 +89,7 @@ def test_location_flow(client, app):
         assert resp.status_code == 200
         resp = client.get(f"/locations/{lid}/stand_sheet")
         assert resp.status_code == 200
+        assert b"Location: Kitchen" in resp.data
         # edit to add second product triggers stand item creation
         resp = client.post(
             f"/locations/edit/{lid}",


### PR DESCRIPTION
## Summary
- Show location name on individual stand sheet for locations
- Add test ensuring stand sheet includes location

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf670c201083248b4053743b96d220