### PR TITLE
Add filter modal for locations

### DIFF
--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -3,8 +3,25 @@
 {% block content %}
 <div class="container mt-5">
     <h2>Locations</h2>
-    <button id="addLocationBtn" class="btn btn-primary mb-3" type="button">Add New Location</button>
+    <div class="row justify-content-between">
+        <div class="col-auto">
+            <button id="addLocationBtn" class="btn btn-primary mb-3" type="button">Add New Location</button>
+        </div>
+        <div class="col-auto">
+            <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
+                Filters
+            </button>
+        </div>
+    </div>
     <input type="hidden" id="csrf_token" value="{{ csrf_token() }}" />
+    {% if name_query %}
+    <div class="mb-3"><strong>Filtering by Name:</strong> {{ name_query }}</div>
+    {% endif %}
+    {% if archived == 'archived' %}
+    <div class="mb-3"><strong>Viewing:</strong> Archived locations</div>
+    {% elif archived == 'all' %}
+    <div class="mb-3"><strong>Viewing:</strong> All locations</div>
+    {% endif %}
     <div class="table-responsive">
     <table class="table">
         <thead>
@@ -34,7 +51,7 @@
         <ul class="pagination">
             {% if locations.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.prev_num) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.prev_num, name_query=name_query, match_mode=match_mode, archived=archived) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -42,11 +59,56 @@
             </li>
             {% if locations.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.next_num) }}">Next</a>
+                <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.next_num, name_query=name_query, match_mode=match_mode, archived=archived) }}">Next</a>
             </li>
             {% endif %}
         </ul>
     </nav>
+</div>
+<!-- Filter Modal -->
+<div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="filterModalLabel">Filters</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="filter-form" method="get">
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6">
+                            <label for="name_query" class="form-label">Name</label>
+                            <input type="text" id="name_query" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+                        </div>
+                        <div class="col-md-6">
+                            <label for="match_mode" class="form-label">Match Mode</label>
+                            <select id="match_mode" name="match_mode" class="form-select">
+                                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
+                                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
+                                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
+                                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row g-3 mb-3">
+                        <div class="col-md-6">
+                            <label for="archived" class="form-label">Status</label>
+                            <select id="archived" name="archived" class="form-select">
+                                <option value="active" {% if archived == 'active' %}selected{% endif %}>Active</option>
+                                <option value="archived" {% if archived == 'archived' %}selected{% endif %}>Archived</option>
+                                <option value="all" {% if archived == 'all' %}selected{% endif %}>All</option>
+                            </select>
+                        </div>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <a href="{{ url_for('locations.view_locations') }}" class="btn btn-outline-secondary">Reset</a>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
+            </div>
+        </div>
+    </div>
 </div>
 <div class="modal fade" id="locationModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg">


### PR DESCRIPTION
## Summary
- enable filtering locations by name and archived status
- add filter modal with options for name matching and status
- test location filters for active, archived, and name matching

## Testing
- `pytest tests/test_location_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf9079ab7c8324bd2153753c6f69cf