### PR TITLE
Add filter modals for GL codes and customers

### DIFF
--- a/app/routes/glcode_routes.py
+++ b/app/routes/glcode_routes.py
@@ -21,7 +21,16 @@ glcode_bp = Blueprint("glcode", __name__)
 def view_gl_codes():
     """List GL codes."""
     page = request.args.get("page", 1, type=int)
-    codes = GLCode.query.order_by(GLCode.code).paginate(page=page, per_page=20)
+    code_query = request.args.get("code_query", "")
+    description_query = request.args.get("description_query", "")
+
+    query = GLCode.query
+    if code_query:
+        query = query.filter(GLCode.code.ilike(f"%{code_query}%"))
+    if description_query:
+        query = query.filter(GLCode.description.ilike(f"%{description_query}%"))
+
+    codes = query.order_by(GLCode.code).paginate(page=page, per_page=20)
     delete_form = DeleteForm()
     form = GLCodeForm()
     return render_template(
@@ -29,6 +38,8 @@ def view_gl_codes():
         codes=codes,
         delete_form=delete_form,
         form=form,
+        code_query=code_query,
+        description_query=description_query,
     )
 
 

--- a/app/templates/customers/view_customers.html
+++ b/app/templates/customers/view_customers.html
@@ -5,7 +5,74 @@
 {% block content %}
 <div class="container mt-5">
     <h2>Customers</h2>
-    <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createCustomerModal">Create Customer</button>
+    <div class="row justify-content-between">
+        <div class="col-auto">
+            <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createCustomerModal">Create Customer</button>
+        </div>
+        <div class="col-auto">
+            <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">Filters</button>
+        </div>
+    </div>
+
+    <!-- Filter Modal -->
+    <div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="filterModalLabel">Filters</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="filter-form" method="get">
+                        <div class="mb-3">
+                            <label for="name_query" class="form-label">Name</label>
+                            <input type="text" id="name_query" name="name_query" class="form-control" placeholder="Search name" value="{{ name_query or '' }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="match_mode" class="form-label">Match Mode</label>
+                            <select id="match_mode" name="match_mode" class="form-select">
+                                <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
+                                <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
+                                <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
+                                <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="gst_exempt" class="form-label">GST Exempt</label>
+                            <select id="gst_exempt" name="gst_exempt" class="form-select">
+                                <option value="all" {% if gst_exempt == 'all' %}selected{% endif %}>All</option>
+                                <option value="yes" {% if gst_exempt == 'yes' %}selected{% endif %}>Yes</option>
+                                <option value="no" {% if gst_exempt == 'no' %}selected{% endif %}>No</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="pst_exempt" class="form-label">PST Exempt</label>
+                            <select id="pst_exempt" name="pst_exempt" class="form-select">
+                                <option value="all" {% if pst_exempt == 'all' %}selected{% endif %}>All</option>
+                                <option value="yes" {% if pst_exempt == 'yes' %}selected{% endif %}>Yes</option>
+                                <option value="no" {% if pst_exempt == 'no' %}selected{% endif %}>No</option>
+                            </select>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <a href="{{ url_for('customer.view_customers') }}" class="btn btn-outline-secondary">Reset</a>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if name_query %}
+    <p>Filtering by Name: {{ name_query }}</p>
+    {% endif %}
+    {% if gst_exempt != 'all' %}
+    <p>Filtering by GST Exempt: {{ 'Yes' if gst_exempt == 'yes' else 'No' }}</p>
+    {% endif %}
+    {% if pst_exempt != 'all' %}
+    <p>Filtering by PST Exempt: {{ 'Yes' if pst_exempt == 'yes' else 'No' }}</p>
+    {% endif %}
     <div class="table-responsive">
     <table class="table">
         <thead>
@@ -38,7 +105,7 @@
         <ul class="pagination">
             {% if customers.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.prev_num) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.prev_num, name_query=name_query, match_mode=match_mode, gst_exempt=gst_exempt, pst_exempt=pst_exempt) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -46,7 +113,7 @@
             </li>
             {% if customers.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.next_num) }}">Next</a>
+                <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.next_num, name_query=name_query, match_mode=match_mode, gst_exempt=gst_exempt, pst_exempt=pst_exempt) }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/app/templates/gl_codes/view_gl_codes.html
+++ b/app/templates/gl_codes/view_gl_codes.html
@@ -3,7 +3,50 @@
 {% block content %}
 <div class="container mt-5">
     <h2>GL Codes</h2>
-    <button id="add-gl-code" type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#glCodeModal">Add GL Code</button>
+    <div class="row justify-content-between">
+        <div class="col-auto">
+            <button id="add-gl-code" type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#glCodeModal">Add GL Code</button>
+        </div>
+        <div class="col-auto">
+            <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">Filters</button>
+        </div>
+    </div>
+
+    <!-- Filter Modal -->
+    <div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="filterModalLabel">Filters</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="filter-form" method="get">
+                        <div class="mb-3">
+                            <label for="code_query" class="form-label">Code</label>
+                            <input type="text" id="code_query" name="code_query" class="form-control" value="{{ code_query or '' }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="description_query" class="form-label">Description</label>
+                            <input type="text" id="description_query" name="description_query" class="form-control" value="{{ description_query or '' }}">
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <a href="{{ url_for('glcode.view_gl_codes') }}" class="btn btn-outline-secondary">Reset</a>
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% if code_query %}
+    <p>Filtering by Code: {{ code_query }}</p>
+    {% endif %}
+    {% if description_query %}
+    <p>Filtering by Description: {{ description_query }}</p>
+    {% endif %}
     <div class="table-responsive">
     <table class="table" id="gl-codes-table">
         <thead>
@@ -34,7 +77,7 @@
         <ul class="pagination">
             {% if codes.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.prev_num) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.prev_num, code_query=code_query, description_query=description_query) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -42,7 +85,7 @@
             </li>
             {% if codes.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.next_num) }}">Next</a>
+                <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.next_num, code_query=code_query, description_query=description_query) }}">Next</a>
             </li>
             {% endif %}
         </ul>
@@ -83,7 +126,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const modal = new bootstrap.Modal(modalEl);
     const form = document.getElementById('gl-code-form');
     const title = document.getElementById('glCodeModalLabel');
-    const csrfToken = '{{ delete_form.csrf_token._value() }}';
+    const csrfToken = '{{ delete_form.csrf_token._value() if delete_form.csrf_token is defined else '' }}';
 
     document.getElementById('add-gl-code').addEventListener('click', () => {
         form.reset();

--- a/tests/test_customer_filter.py
+++ b/tests/test_customer_filter.py
@@ -1,0 +1,39 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import Customer, User
+from tests.utils import login
+
+
+def setup_data(app):
+    with app.app_context():
+        user = User(
+            email="custfilter@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        c1 = Customer(first_name="Alice", last_name="Smith", gst_exempt=True, pst_exempt=False)
+        c2 = Customer(first_name="Bob", last_name="Brown", gst_exempt=False, pst_exempt=True)
+        db.session.add_all([user, c1, c2])
+        db.session.commit()
+        return user.email
+
+
+def test_view_customers_filter_by_name(client, app):
+    email = setup_data(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get("/customers?name_query=Alice")
+        assert resp.status_code == 200
+        assert b"Alice Smith" in resp.data
+        assert b"Bob Brown" not in resp.data
+
+
+def test_view_customers_filter_by_gst(client, app):
+    email = setup_data(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get("/customers?gst_exempt=yes")
+        assert resp.status_code == 200
+        assert b"Alice Smith" in resp.data
+        assert b"Bob Brown" not in resp.data

--- a/tests/test_gl_code_filter.py
+++ b/tests/test_gl_code_filter.py
@@ -1,0 +1,28 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import GLCode, User
+from tests.utils import login
+
+def setup_data(app):
+    with app.app_context():
+        user = User(
+            email="glfilter@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        gl1 = GLCode(code="1000", description="Food")
+        gl2 = GLCode(code="2000", description="Drink")
+        db.session.add_all([user, gl1, gl2])
+        db.session.commit()
+        return user.email
+
+
+def test_view_gl_codes_filter_by_code(client, app):
+    email = setup_data(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get("/gl_codes?code_query=100")
+        assert resp.status_code == 200
+        assert b"1000" in resp.data
+        assert b"2000" not in resp.data


### PR DESCRIPTION
## Summary
- add query-based filters for GL codes and customers
- include filter modals in GL code and customer pages
- test filtering behavior for both views

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf90af2f0c83248966d25154d6309e