### PR TITLE
Add item detail page and responsive enhancements

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -101,6 +101,16 @@
             .offcanvas-body .nav-item .nav-link {
                 margin-bottom: .25rem;
             }
+            .btn {
+                width: 100%;
+                margin-bottom: .25rem;
+            }
+            .btn + .btn {
+                margin-left: 0;
+            }
+            .table {
+                font-size: 0.9rem;
+            }
         }
     </style>
 </head>

--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -1,7 +1,7 @@
 <tr id="item-row-{{ item.id }}">
     <td><input type="checkbox" name="item_ids" value="{{ item.id }}" style="transform: scale(1.5);"></td>
-    <td>{{ item.name }}</td>
-    <td>{{ item.cost }}</td>
+    <td><a href="{{ url_for('item.view_item', item_id=item.id) }}">{{ item.name }}</a></td>
+    <td>{{ '%.2f'|format(item.cost) }} / {{ item.base_unit }}</td>
     <td>
         <button type="button" class="btn btn-secondary edit-item-btn" data-item-id="{{ item.id }}">Edit</button>
         <a href="{{ url_for('item.item_locations', item_id=item.id) }}" class="btn btn-info ms-1">Locations</a>

--- a/app/templates/items/view_item.html
+++ b/app/templates/items/view_item.html
@@ -1,0 +1,92 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-5">
+    <h2>{{ item.name }}</h2>
+    <p><strong>Base Unit:</strong> {{ item.base_unit }}</p>
+    <div class="row">
+        <div class="col-12">
+            <h4>Recent Purchase Invoices</h4>
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Invoice #</th>
+                            <th>Quantity</th>
+                            <th>Cost</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for pii in purchase_items %}
+                        <tr>
+                            <td>{{ pii.invoice.received_date }}</td>
+                            <td><a href="{{ url_for('purchase.view_purchase_invoice', invoice_id=pii.invoice_id) }}">{{ pii.invoice_id }}</a></td>
+                            <td>{{ pii.quantity }} {{ pii.unit.name if pii.unit else pii.unit_name or item.base_unit }}</td>
+                            <td>{{ '%.2f'|format(pii.cost) }}</td>
+                        </tr>
+                        {% else %}
+                        <tr><td colspan="4">No purchase invoices found.</td></tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="col-12 mt-4">
+            <h4>Recent Sales Invoices</h4>
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Invoice #</th>
+                            <th>Product</th>
+                            <th>Quantity</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for ip in sales_items %}
+                        <tr>
+                            <td>{{ ip.invoice.date_created.date() }}</td>
+                            <td><a href="{{ url_for('invoice.view_invoice', invoice_id=ip.invoice_id) }}">{{ ip.invoice_id }}</a></td>
+                            <td>{{ ip.product.name if ip.product else ip.product_name }}</td>
+                            <td>{{ ip.quantity }}</td>
+                        </tr>
+                        {% else %}
+                        <tr><td colspan="4">No sales invoices found.</td></tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="col-12 mt-4">
+            <h4>Recent Transfers</h4>
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Transfer #</th>
+                            <th>From</th>
+                            <th>To</th>
+                            <th>Quantity</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for ti in transfer_items %}
+                        <tr>
+                            <td>{{ ti.transfer.date_created.date() }}</td>
+                            <td><a href="{{ url_for('transfer.view_transfer', transfer_id=ti.transfer_id) }}">{{ ti.transfer_id }}</a></td>
+                            <td>{{ ti.transfer.from_location_name }}</td>
+                            <td>{{ ti.transfer.to_location_name }}</td>
+                            <td>{{ ti.quantity }}</td>
+                        </tr>
+                        {% else %}
+                        <tr><td colspan="5">No transfers found.</td></tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_item_detail_page.py
+++ b/tests/test_item_detail_page.py
@@ -1,0 +1,64 @@
+from datetime import date
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import (
+    Customer,
+    Invoice,
+    InvoiceProduct,
+    Item,
+    ItemUnit,
+    Location,
+    Product,
+    ProductRecipeItem,
+    PurchaseInvoice,
+    PurchaseInvoiceItem,
+    PurchaseOrder,
+    Transfer,
+    TransferItem,
+    User,
+    Vendor,
+)
+from tests.utils import login
+
+
+def setup_history(app):
+    with app.app_context():
+        user = User(email="hist@example.com", password=generate_password_hash("pass"), active=True)
+        customer = Customer(first_name="Cust", last_name="Omer")
+        vendor = Vendor(first_name="Vend", last_name="Or")
+        item = Item(name="Widget", base_unit="each", cost=10)
+        unit = ItemUnit(item=item, name="each", factor=1, receiving_default=True, transfer_default=True)
+        loc1 = Location(name="L1")
+        loc2 = Location(name="L2")
+        product = Product(name="WidgetProd", gl_code="5000", price=5, cost=0)
+        pri = ProductRecipeItem(product=product, item=item, quantity=1)
+        db.session.add_all([user, customer, vendor, item, unit, loc1, loc2, product, pri])
+        db.session.commit()
+        po = PurchaseOrder(vendor_id=vendor.id, user_id=user.id, vendor_name="Vend Or", order_date=date.today(), expected_date=date.today(), delivery_charge=0, received=True)
+        db.session.add(po)
+        db.session.commit()
+        pi = PurchaseInvoice(purchase_order_id=po.id, user_id=user.id, location_id=loc1.id, vendor_name="Vend Or", location_name=loc1.name, received_date=date.today(), invoice_number="PI1", gst=0, pst=0, delivery_charge=0)
+        pii = PurchaseInvoiceItem(invoice=pi, item=item, item_name=item.name, unit=unit, unit_name=unit.name, quantity=5, cost=2.5)
+        inv = Invoice(id="INV1", user_id=user.id, customer_id=customer.id)
+        ip = InvoiceProduct(invoice=inv, product=product, product_name=product.name, quantity=2, unit_price=5, line_subtotal=10, line_gst=0, line_pst=0)
+        transfer = Transfer(from_location_id=loc1.id, to_location_id=loc2.id, user_id=user.id, from_location_name=loc1.name, to_location_name=loc2.name)
+        ti = TransferItem(transfer=transfer, item=item, item_name=item.name, quantity=3)
+        db.session.add_all([pi, pii, inv, ip, transfer, ti])
+        db.session.commit()
+        return user.email, item.id, pi.id, inv.id, transfer.id
+
+
+def test_item_detail_page(client, app):
+    email, item_id, pi_id, inv_id, transfer_id = setup_history(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.get("/items")
+        text = resp.get_data(as_text=True)
+        assert f"/items/{item_id}" in text
+        resp = client.get(f"/items/{item_id}")
+        page = resp.get_data(as_text=True)
+        assert str(pi_id) in page
+        assert inv_id in page
+        assert str(transfer_id) in page
+        assert "WidgetProd" in page


### PR DESCRIPTION
## Summary
- add item detail view showing recent purchase and sales invoices and transfers
- show base unit with cost and link items to detail page
- improve mobile responsiveness with small-screen CSS tweaks

## Testing
- `pytest tests/test_item_detail_page.py::test_item_detail_page -q`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c052a30fd88324b44dc089abfa2f90