### PR TITLE
Add configurable automatic backups

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -13,6 +13,7 @@ from wtforms import (
     FileField,
     FormField,
     HiddenField,
+    IntegerField,
     PasswordField,
     SelectField,
     SelectMultipleField,
@@ -46,6 +47,7 @@ def load_item_choices():
 def load_unit_choices():
     """Return a list of item unit choices."""
     return [(u.id, u.name) for u in ItemUnit.query.all()]
+
 
 @lru_cache(maxsize=1)
 def get_timezone_choices():
@@ -232,7 +234,10 @@ class SpoilageFilterForm(FlaskForm):
     start_date = DateField("Start Date", validators=[Optional()])
     end_date = DateField("End Date", validators=[Optional()])
     purchase_gl_code = SelectField(
-        "Purchase GL Code", coerce=int, validators=[Optional()], validate_choice=False
+        "Purchase GL Code",
+        coerce=int,
+        validators=[Optional()],
+        validate_choice=False,
     )
     items = SelectMultipleField(
         "Items", coerce=int, validators=[Optional()], validate_choice=False
@@ -571,6 +576,25 @@ class SettingsForm(FlaskForm):
         "GST Number", validators=[Optional(), Length(max=50)]
     )
     default_timezone = SelectField("Default Timezone")
+    auto_backup_enabled = BooleanField("Enable Automatic Backups")
+    auto_backup_interval_value = IntegerField(
+        "Backup Interval",
+        validators=[DataRequired(), NumberRange(min=1)],
+    )
+    auto_backup_interval_unit = SelectField(
+        "Interval Unit",
+        choices=[
+            ("hour", "Hour"),
+            ("day", "Day"),
+            ("week", "Week"),
+            ("month", "Month"),
+            ("year", "Year"),
+        ],
+    )
+    max_backups = IntegerField(
+        "Max Stored Backups",
+        validators=[DataRequired(), NumberRange(min=1)],
+    )
     submit = SubmitField("Update")
 
     def __init__(self, *args, **kwargs):
@@ -586,9 +610,9 @@ class TimezoneForm(FlaskForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.timezone.choices = [
-            ("", "Use Default")
-        ] + [(tz, tz) for tz in get_timezone_choices()]
+        self.timezone.choices = [("", "Use Default")] + [
+            (tz, tz) for tz in get_timezone_choices()
+        ]
 
 
 class NotificationForm(FlaskForm):

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -13,6 +13,24 @@
             {{ form.default_timezone.label }}
             {{ form.default_timezone(class='form-control') }}
         </div>
+        <div class="form-check form-switch mt-2">
+            {{ form.auto_backup_enabled(class='form-check-input') }}
+            {{ form.auto_backup_enabled.label(class='form-check-label') }}
+        </div>
+        <div class="row mt-2">
+            <div class="col">
+                {{ form.auto_backup_interval_value.label }}
+                {{ form.auto_backup_interval_value(class='form-control') }}
+            </div>
+            <div class="col">
+                {{ form.auto_backup_interval_unit.label }}
+                {{ form.auto_backup_interval_unit(class='form-control') }}
+            </div>
+        </div>
+        <div class="form-group mt-2">
+            {{ form.max_backups.label }}
+            {{ form.max_backups(class='form-control') }}
+        </div>
         {{ form.submit(class='btn btn-primary') }}
     </form>
 </div>


### PR DESCRIPTION
## Summary
- allow enabling/disabling periodic database backups with user-defined interval and retention limit
- remove oldest backups beyond configured maximum before creating a new archive

## Testing
- `pre-commit run --files app/utils/backup.py app/forms.py app/templates/admin/settings.html app/routes/auth_routes.py app/__init__.py tests/test_backup_restore.py tests/test_settings.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c073969b848324a29f366e9693da6b