### PR TITLE
Add view buttons and paginate item details

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -145,13 +145,15 @@ def view_item(item_id):
     item_obj = db.session.get(Item, item_id)
     if item_obj is None:
         abort(404)
+    purchase_page = request.args.get("purchase_page", 1, type=int)
+    sales_page = request.args.get("sales_page", 1, type=int)
+    transfer_page = request.args.get("transfer_page", 1, type=int)
     purchase_items = (
         PurchaseInvoiceItem.query
         .join(PurchaseInvoice)
         .filter(PurchaseInvoiceItem.item_id == item_id)
         .order_by(PurchaseInvoice.received_date.desc(), PurchaseInvoice.id.desc())
-        .limit(5)
-        .all()
+        .paginate(page=purchase_page, per_page=10)
     )
     sales_items = (
         InvoiceProduct.query
@@ -160,16 +162,14 @@ def view_item(item_id):
         .join(ProductRecipeItem, ProductRecipeItem.product_id == Product.id)
         .filter(ProductRecipeItem.item_id == item_id)
         .order_by(Invoice.date_created.desc(), Invoice.id.desc())
-        .limit(5)
-        .all()
+        .paginate(page=sales_page, per_page=10)
     )
     transfer_items = (
         TransferItem.query
         .join(Transfer)
         .filter(TransferItem.item_id == item_id)
         .order_by(Transfer.date_created.desc(), Transfer.id.desc())
-        .limit(5)
-        .all()
+        .paginate(page=transfer_page, per_page=10)
     )
     return render_template(
         "items/view_item.html",

--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -1,9 +1,10 @@
 <tr id="item-row-{{ item.id }}">
     <td><input type="checkbox" name="item_ids" value="{{ item.id }}" style="transform: scale(1.5);"></td>
-    <td><a href="{{ url_for('item.view_item', item_id=item.id) }}">{{ item.name }}</a></td>
-    <td>{{ '%.2f'|format(item.cost) }} / {{ item.base_unit }}</td>
+    <td>{{ item.name }}</td>
+    <td>{{ '%.6f'|format(item.cost) }} / {{ item.base_unit }}</td>
     <td>
-        <button type="button" class="btn btn-secondary edit-item-btn" data-item-id="{{ item.id }}">Edit</button>
+        <a href="{{ url_for('item.view_item', item_id=item.id) }}" class="btn btn-primary">View</a>
+        <button type="button" class="btn btn-secondary edit-item-btn ms-1" data-item-id="{{ item.id }}">Edit</button>
         <a href="{{ url_for('item.item_locations', item_id=item.id) }}" class="btn btn-info ms-1">Locations</a>
     </td>
 </tr>

--- a/app/templates/items/item_form.html
+++ b/app/templates/items/item_form.html
@@ -19,7 +19,7 @@
         {% if item %}
         <div class="form-group">
             <label class="form-label">Cost</label>
-            <input type="text" class="form-control" value="{{ item.cost }}" readonly>
+            <input type="text" class="form-control" value="{{ '%.6f'|format(item.cost) }}" readonly>
         </div>
         {% endif %}
         <h4>Units</h4>

--- a/app/templates/items/view_item.html
+++ b/app/templates/items/view_item.html
@@ -17,12 +17,12 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for pii in purchase_items %}
+                        {% for pii in purchase_items.items %}
                         <tr>
                             <td>{{ pii.invoice.received_date }}</td>
                             <td><a href="{{ url_for('purchase.view_purchase_invoice', invoice_id=pii.invoice_id) }}">{{ pii.invoice_id }}</a></td>
                             <td>{{ pii.quantity }} {{ pii.unit.name if pii.unit else pii.unit_name or item.base_unit }}</td>
-                            <td>{{ '%.2f'|format(pii.cost) }}</td>
+                            <td>{{ '%.6f'|format(pii.cost) }}</td>
                         </tr>
                         {% else %}
                         <tr><td colspan="4">No purchase invoices found.</td></tr>
@@ -30,6 +30,21 @@
                     </tbody>
                 </table>
             </div>
+            <nav aria-label="Purchase invoice pagination">
+                <ul class="pagination">
+                    {% if purchase_items.has_prev %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.prev_num, sales_page=sales_items.page, transfer_page=transfer_items.page) }}">Previous</a>
+                    </li>
+                    {% endif %}
+                    <li class="page-item disabled"><span class="page-link">Page {{ purchase_items.page }} of {{ purchase_items.pages }}</span></li>
+                    {% if purchase_items.has_next %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.next_num, sales_page=sales_items.page, transfer_page=transfer_items.page) }}">Next</a>
+                    </li>
+                    {% endif %}
+                </ul>
+            </nav>
         </div>
         <div class="col-12 mt-4">
             <h4>Recent Sales Invoices</h4>
@@ -44,7 +59,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for ip in sales_items %}
+                        {% for ip in sales_items.items %}
                         <tr>
                             <td>{{ ip.invoice.date_created.date() }}</td>
                             <td><a href="{{ url_for('invoice.view_invoice', invoice_id=ip.invoice_id) }}">{{ ip.invoice_id }}</a></td>
@@ -57,6 +72,21 @@
                     </tbody>
                 </table>
             </div>
+            <nav aria-label="Sales invoice pagination">
+                <ul class="pagination">
+                    {% if sales_items.has_prev %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.page, sales_page=sales_items.prev_num, transfer_page=transfer_items.page) }}">Previous</a>
+                    </li>
+                    {% endif %}
+                    <li class="page-item disabled"><span class="page-link">Page {{ sales_items.page }} of {{ sales_items.pages }}</span></li>
+                    {% if sales_items.has_next %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.page, sales_page=sales_items.next_num, transfer_page=transfer_items.page) }}">Next</a>
+                    </li>
+                    {% endif %}
+                </ul>
+            </nav>
         </div>
         <div class="col-12 mt-4">
             <h4>Recent Transfers</h4>
@@ -72,7 +102,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for ti in transfer_items %}
+                        {% for ti in transfer_items.items %}
                         <tr>
                             <td>{{ ti.transfer.date_created.date() }}</td>
                             <td><a href="{{ url_for('transfer.view_transfer', transfer_id=ti.transfer_id) }}">{{ ti.transfer_id }}</a></td>
@@ -86,6 +116,21 @@
                     </tbody>
                 </table>
             </div>
+            <nav aria-label="Transfer pagination">
+                <ul class="pagination">
+                    {% if transfer_items.has_prev %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.page, sales_page=sales_items.page, transfer_page=transfer_items.prev_num) }}">Previous</a>
+                    </li>
+                    {% endif %}
+                    <li class="page-item disabled"><span class="page-link">Page {{ transfer_items.page }} of {{ transfer_items.pages }}</span></li>
+                    {% if transfer_items.has_next %}
+                    <li class="page-item">
+                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.page, sales_page=sales_items.page, transfer_page=transfer_items.next_num) }}">Next</a>
+                    </li>
+                    {% endif %}
+                </ul>
+            </nav>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- Replace item name links with dedicated view buttons
- Show item costs to six decimal places
- Paginate purchases, sales, and transfers on item detail page

## Testing
- `pytest` *(fails: command not found)*
- `apt-get install -y python3-pip` *(fails: Package 'python3-pip' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68c083df6fec8324813bf3617b4c2c3e