### PR TITLE
Require login for report routes

### DIFF
--- a/app/routes/report_routes.py
+++ b/app/routes/report_routes.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, redirect, render_template, request, url_for
+from flask_login import login_required
 
 from app import db
 from app.forms import (
@@ -12,6 +13,7 @@ report = Blueprint("report", __name__)
 
 
 @report.route("/reports/vendor-invoices", methods=["GET", "POST"])
+@login_required
 def vendor_invoice_report():
     """Form to select vendor invoice report parameters."""
     form = VendorInvoiceReportForm()
@@ -33,6 +35,7 @@ def vendor_invoice_report():
 
 
 @report.route("/reports/vendor-invoices/results")
+@login_required
 def vendor_invoice_report_results():
     """Show vendor invoice report based on query parameters."""
     customer_ids = request.args.get("customer_ids")
@@ -90,6 +93,7 @@ def vendor_invoice_report_results():
 
 
 @report.route("/reports/product-sales", methods=["GET", "POST"])
+@login_required
 def product_sales_report():
     """Generate a report on product sales and profit."""
     form = ProductSalesReportForm()
@@ -140,6 +144,7 @@ def product_sales_report():
 
 
 @report.route("/reports/product-recipes", methods=["GET", "POST"])
+@login_required
 def product_recipe_report():
     """List products with their recipe items, price and cost."""
     search = request.args.get("search")

--- a/tests/test_product_recipe_report.py
+++ b/tests/test_product_recipe_report.py
@@ -2,6 +2,7 @@ from werkzeug.security import generate_password_hash
 
 from app import db
 from app.models import Item, ItemUnit, Product, ProductRecipeItem, User
+from tests.utils import login
 
 
 def setup_products(app):
@@ -63,6 +64,7 @@ def setup_products(app):
 
 def test_recipe_report_select_all(client, app):
     p1, p2 = setup_products(app)
+    login(client, "rep@example.com", "pass")
     resp = client.post(
         "/reports/product-recipes",
         data={"select_all": "y"},
@@ -80,6 +82,7 @@ def test_recipe_report_select_all(client, app):
 
 def test_recipe_report_specific_products(client, app):
     p1, p2 = setup_products(app)
+    login(client, "rep@example.com", "pass")
     resp = client.post(
         "/reports/product-recipes",
         data={"products": [str(p1)]},

--- a/tests/test_report_routes.py
+++ b/tests/test_report_routes.py
@@ -4,6 +4,7 @@ from werkzeug.security import generate_password_hash
 
 from app import db
 from app.models import Customer, Invoice, InvoiceProduct, Product, User
+from tests.utils import login
 
 
 def setup_invoice(app):
@@ -43,6 +44,7 @@ def setup_invoice(app):
 
 def test_vendor_and_sales_reports(client, app):
     cid = setup_invoice(app)
+    login(client, "report@example.com", "pass")
     resp = client.get("/reports/vendor-invoices")
     assert resp.status_code == 200
     resp = client.post(


### PR DESCRIPTION
## Summary
- secure all reporting endpoints with `login_required`
- adjust report-related tests to authenticate before requests

## Testing
- `pytest tests/test_report_routes.py tests/test_product_recipe_report.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c08853de888324a77dbf089fcf2916