### PR TITLE
feat: support persistent rate limiter backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ SMTP_USE_TLS=false
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 TWILIO_PHONE_NUMBER=
+# Storage backend for rate limiting; use Redis in production
+RATELIMIT_STORAGE_URI=memory://

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ The application requires several variables to be present in your environment:
 - `SMTP_PASSWORD` – password for SMTP authentication.
 - `SMTP_SENDER` – email address used as the sender.
 - `SMTP_USE_TLS` – set to `true` to enable TLS.
+- `RATELIMIT_STORAGE_URI` – URI for the rate limiting backend. Use a
+  persistent store such as Redis in production (e.g., `redis://redis:6379/0`).
+
+A persistent backing store is required for rate limiting in production. Set
+`RATELIMIT_STORAGE_URI` to a supported service so that limits are shared
+across workers.
 
 These SMTP variables enable password reset emails. Configure them in your `.env` file if you want users to reset forgotten passwords.
 
@@ -85,8 +91,10 @@ The project includes a `Dockerfile` and a `docker-compose.yml` to make running
 the application in a container straightforward on Linux and Windows. The image
 starts Gunicorn using the included `gunicorn.conf.py`, so no additional commands
 are required. Create a `.env` file containing the environment variables
-described above. You can also specify the port the app will use by adding a
-`PORT` variable to `.env` (or by exporting it in your shell) before starting the
+described above. A persistent backing service such as Redis is required for
+rate limiting in production; set `RATELIMIT_STORAGE_URI` to its connection
+string. You can also specify the port the app will use by adding a `PORT`
+variable to `.env` (or by exporting it in your shell) before starting the
 service:
 
 ```bash

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -19,7 +19,8 @@ load_dotenv()
 db = SQLAlchemy()
 login_manager = LoginManager()
 login_manager.login_view = "auth.login"
-limiter = Limiter(key_func=get_remote_address, storage_uri="memory://")
+storage_uri = os.getenv("RATELIMIT_STORAGE_URI", "memory://")
+limiter = Limiter(key_func=get_remote_address, storage_uri=storage_uri)
 socketio = None
 GST = ""
 DEFAULT_TIMEZONE = "UTC"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ Flask-Migrate==4.1.0
 Flask-SocketIO==5.5.1
 gunicorn==23.0.0
 eventlet==0.40.3
+redis==5.0.7
 
 email_validator==2.2.0
 openpyxl==3.1.5


### PR DESCRIPTION
## Summary
- allow configuring rate limiter storage via `RATELIMIT_STORAGE_URI`
- document requirement for persistent backend and provide example env var
- add redis dependency for production rate limiting

## Testing
- `pre-commit run --files .env.example README.md app/__init__.py requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c08a9d564c83248d13fbacb8d7a396