### PR TITLE
Add product last sold filtering

### DIFF
--- a/app/templates/products/_product_row.html
+++ b/app/templates/products/_product_row.html
@@ -3,6 +3,7 @@
     <td>{{ product.price }}</td>
     <td>{{ product.cost }}</td>
     <td>{{ '{:.2f}%'.format(product.food_cost_percentage) }}</td>
+    <td>{{ product.last_sold_at.strftime('%Y-%m-%d') if product.last_sold_at else 'Never' }}</td>
     <td>
         <a href="{{ url_for('product.edit_product', product_id=product.id) }}" class="btn btn-primary mr-2">Edit</a>
         <form action="{{ url_for('product.delete_product', product_id=product.id) }}" method="post" class="d-inline">

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -82,6 +82,18 @@
                                 <input type="number" step="0.01" id="price_max" name="price_max" class="form-control" value="{{ price_max if price_max is not none else '' }}">
                             </div>
                         </div>
+                        <div class="row g-3 mb-3">
+                            <div class="col-md-6">
+                                <label for="last_sold_before" class="form-label">Last Sold Before</label>
+                                <input type="date" id="last_sold_before" name="last_sold_before" class="form-control" value="{{ last_sold_before or '' }}">
+                            </div>
+                            <div class="col-md-6 d-flex align-items-end">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="include_unsold" name="include_unsold" value="1" {% if include_unsold %}checked{% endif %}>
+                                    <label class="form-check-label" for="include_unsold">Include Unsold</label>
+                                </div>
+                            </div>
+                        </div>
                     </form>
                 </div>
                 <div class="modal-footer">
@@ -122,6 +134,7 @@
                 <th>Price</th>
                 <th>Cost</th>
                 <th>Food Cost %</th>
+                <th>Last Sold</th>
                 <th>Action</th>
             </tr>
         </thead>
@@ -136,7 +149,7 @@
         <ul class="pagination">
             {% if products.has_prev %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_ids, customer_id=customer_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max) }}">Previous</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_ids, customer_id=customer_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max, last_sold_before=last_sold_before, include_unsold=1 if include_unsold else None) }}">Previous</a>
             </li>
             {% endif %}
             <li class="page-item disabled">
@@ -144,7 +157,7 @@
             </li>
             {% if products.has_next %}
             <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_ids, customer_id=customer_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max) }}">Next</a>
+                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_ids, customer_id=customer_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max, last_sold_before=last_sold_before, include_unsold=1 if include_unsold else None) }}">Next</a>
             </li>
             {% endif %}
         </ul>

--- a/tests/test_product_last_sold_filter.py
+++ b/tests/test_product_last_sold_filter.py
@@ -1,0 +1,100 @@
+import os
+from datetime import datetime, timedelta, date
+
+from app import db
+from app.models import (
+    Customer,
+    Event,
+    EventLocation,
+    Invoice,
+    InvoiceProduct,
+    Location,
+    Product,
+    TerminalSale,
+    User,
+)
+from werkzeug.security import generate_password_hash
+from tests.utils import login
+
+
+def setup_sales_data(app):
+    with app.app_context():
+        user = User(
+            email="sales@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        cust = Customer(first_name="Test", last_name="Customer")
+        p_old = Product(name="OldProd", price=1.0, cost=0.5)
+        p_recent = Product(name="RecentProd", price=1.0, cost=0.5)
+        p_unsold = Product(name="UnsoldProd", price=1.0, cost=0.5)
+        loc = Location(name="Loc1")
+        event = Event(name="Event1", start_date=date.today(), end_date=date.today())
+        ev_loc = EventLocation(event=event, location=loc)
+        db.session.add_all([
+            user,
+            cust,
+            p_old,
+            p_recent,
+            p_unsold,
+            loc,
+            event,
+            ev_loc,
+        ])
+        db.session.commit()
+        inv = Invoice(
+            id="INV1",
+            user_id=user.id,
+            customer_id=cust.id,
+            date_created=datetime.utcnow() - timedelta(days=10),
+        )
+        db.session.add(inv)
+        db.session.commit()
+        ip = InvoiceProduct(
+            invoice_id=inv.id,
+            quantity=1,
+            product_id=p_old.id,
+            product_name=p_old.name,
+            unit_price=1,
+            line_subtotal=1,
+            line_gst=0,
+            line_pst=0,
+        )
+        ts = TerminalSale(
+            event_location_id=ev_loc.id,
+            product_id=p_recent.id,
+            quantity=1,
+            sold_at=datetime.utcnow() - timedelta(days=1),
+        )
+        db.session.add_all([ip, ts])
+        db.session.commit()
+        return p_old.name, p_recent.name, p_unsold.name
+
+
+def test_last_sold_before_filter(client, app):
+    old_name, recent_name, _ = setup_sales_data(app)
+    with client:
+        admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+        admin_pass = os.getenv("ADMIN_PASS", "adminpass")
+        login(client, admin_email, admin_pass)
+        cutoff = (datetime.utcnow() - timedelta(days=5)).strftime("%Y-%m-%d")
+        resp = client.get(f"/products?last_sold_before={cutoff}")
+        assert resp.status_code == 200
+        assert old_name.encode() in resp.data
+        assert recent_name.encode() not in resp.data
+
+
+def test_include_unsold_products(client, app):
+    old_name, recent_name, unsold_name = setup_sales_data(app)
+    with client:
+        admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+        admin_pass = os.getenv("ADMIN_PASS", "adminpass")
+        login(client, admin_email, admin_pass)
+        cutoff = (datetime.utcnow() - timedelta(days=5)).strftime("%Y-%m-%d")
+        resp = client.get(
+            f"/products?last_sold_before={cutoff}&include_unsold=1"
+        )
+        assert resp.status_code == 200
+        assert old_name.encode() in resp.data
+        assert unsold_name.encode() in resp.data
+        assert recent_name.encode() not in resp.data


### PR DESCRIPTION
## Summary
- compute latest sale date on Product from invoices and terminal sales
- filter products by last sold date with optional unsold inclusion
- expose last-sold filters and column in product listing

## Testing
- `pytest tests/test_product_last_sold_filter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1be04782483248ff9b0386b605179