### PR TITLE
Add product location sales report

### DIFF
--- a/app/templates/report_product_location_sales.html
+++ b/app/templates/report_product_location_sales.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-5">
+    <h2>Product Location Sales Report</h2>
+    <form method="POST" class="mb-4">
+        {{ form.hidden_tag() }}
+        <div class="form-group">{{ form.start_date.label }} {{ form.start_date(class="form-control") }}</div>
+        <div class="form-group">{{ form.end_date.label }} {{ form.end_date(class="form-control") }}</div>
+        <button type="submit" class="btn btn-primary">Generate Report</button>
+    </form>
+    {% if report %}
+    <div class="table-responsive">
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Product</th>
+                <th>Last Sale Date</th>
+                <th>Locations</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in report %}
+            <tr>
+                <td>{{ row.name }}</td>
+                <td>{{ row.last_sale.strftime("%Y-%m-%d") if row.last_sale else "No sales" }}</td>
+                <td>
+                    {% if row.locations %}
+                        {% for loc in row.locations %}
+                            {{ loc.name }} ({{ loc.quantity }}){% if not loop.last %}<br>{% endif %}
+                        {% endfor %}
+                    {% else %}
+                        No location sales
+                    {% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/tests/test_product_location_sales_report.py
+++ b/tests/test_product_location_sales_report.py
@@ -1,0 +1,107 @@
+from datetime import date, datetime
+
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import (
+    Customer,
+    Event,
+    EventLocation,
+    Invoice,
+    InvoiceProduct,
+    Location,
+    Product,
+    TerminalSale,
+    User,
+)
+from tests.utils import login
+
+
+def setup_data(app):
+    with app.app_context():
+        user = User(
+            email="plr@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        customer = Customer(first_name="Jane", last_name="Doe")
+        p1 = Product(name="Prod1", price=10.0, cost=5.0)
+        p2 = Product(name="Prod2", price=8.0, cost=4.0)
+        p3 = Product(name="Prod3", price=5.0, cost=2.0)
+        loc1 = Location(name="LocA")
+        loc2 = Location(name="LocB")
+        db.session.add_all([user, customer, p1, p2, p3, loc1, loc2])
+        db.session.commit()
+
+        invoice = Invoice(
+            id="INV001",
+            user_id=user.id,
+            customer_id=customer.id,
+            date_created=date(2023, 1, 5),
+        )
+        db.session.add(invoice)
+        db.session.commit()
+        db.session.add(
+            InvoiceProduct(
+                invoice_id=invoice.id,
+                quantity=3,
+                product_id=p1.id,
+                product_name=p1.name,
+                unit_price=p1.price,
+                line_subtotal=30,
+                line_gst=0,
+                line_pst=0,
+            )
+        )
+        db.session.commit()
+
+        event = Event(name="Ev", start_date=date(2023, 1, 1), end_date=date(2023, 1, 10))
+        db.session.add(event)
+        db.session.commit()
+        el1 = EventLocation(event_id=event.id, location_id=loc1.id)
+        el2 = EventLocation(event_id=event.id, location_id=loc2.id)
+        db.session.add_all([el1, el2])
+        db.session.commit()
+
+        db.session.add_all(
+            [
+                TerminalSale(
+                    event_location_id=el1.id,
+                    product_id=p1.id,
+                    quantity=5,
+                    sold_at=datetime(2023, 1, 7, 12, 0),
+                ),
+                TerminalSale(
+                    event_location_id=el2.id,
+                    product_id=p1.id,
+                    quantity=2,
+                    sold_at=datetime(2023, 1, 8, 12, 0),
+                ),
+                TerminalSale(
+                    event_location_id=el1.id,
+                    product_id=p2.id,
+                    quantity=4,
+                    sold_at=datetime(2023, 1, 9, 12, 0),
+                ),
+            ]
+        )
+        db.session.commit()
+
+        return user.email
+
+
+def test_product_location_sales_report(client, app):
+    email = setup_data(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.post(
+            "/reports/product-location-sales",
+            data={"start_date": "2023-01-01", "end_date": "2023-01-31"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert b"Prod1" in resp.data
+        assert b"Prod2" in resp.data
+        assert b"Prod3" not in resp.data
+        assert b"LocA" in resp.data
+        assert b"LocB" in resp.data


### PR DESCRIPTION
## Summary
- add `/reports/product-location-sales` route aggregating invoice and terminal sales by location
- render new `report_product_location_sales.html` with last sale dates and per-location totals
- test multi-location aggregation and omission of unsold products

## Testing
- `pytest tests/test_product_location_sales_report.py tests/test_report_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1c3fa96b083249bcb7b62fb15f996