### PR TITLE
Use batch operation for terminal_sale migration

### DIFF
--- a/migrations/versions/c2f321f4c8b5_add_sold_at_to_terminal_sale.py
+++ b/migrations/versions/c2f321f4c8b5_add_sold_at_to_terminal_sale.py
@@ -17,11 +17,16 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column(
-        "terminal_sale",
-        sa.Column("sold_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
-    )
-    op.alter_column("terminal_sale", "sold_at", server_default=None)
+    with op.batch_alter_table("terminal_sale", recreate="always") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "sold_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.text("CURRENT_TIMESTAMP"),
+            )
+        )
+        batch_op.alter_column("sold_at", server_default=None)
 
 
 def downgrade():


### PR DESCRIPTION
## Summary
- Recreate `terminal_sale` table when adding `sold_at` so SQLite can drop the default

## Testing
- `flask db upgrade`
- `pytest -q` *(fails: OperationalError ambiguous column name `invoice.customer_id`)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cac4206c83249112eb7d72ba2cbe