### PR TITLE
Show item cost in default unit and ensure updates

### DIFF
--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -1,7 +1,8 @@
 <tr id="item-row-{{ item.id }}">
     <td><input type="checkbox" name="item_ids" value="{{ item.id }}" style="transform: scale(1.5);"></td>
     <td>{{ item.name }}</td>
-    <td>{{ '%.6f'|format(item.cost) }} / {{ item.base_unit }}</td>
+    {% set default_unit = (item.units | selectattr('receiving_default') | first) %}
+    <td>{{ '%.6f'|format(item.cost) }} / {{ item.base_unit }}{% if default_unit and default_unit.factor and default_unit.factor != 1 %} ({{ '%.6f'|format(item.cost * default_unit.factor) }} / {{ default_unit.name }}){% endif %}</td>
     <td>
         <a href="{{ url_for('item.view_item', item_id=item.id) }}" class="btn btn-primary">View</a>
         <button type="button" class="btn btn-secondary edit-item-btn ms-1" data-item-id="{{ item.id }}">Edit</button>

--- a/app/templates/items/view_item.html
+++ b/app/templates/items/view_item.html
@@ -3,6 +3,8 @@
 <div class="container mt-5">
     <h2>{{ item.name }}</h2>
     <p><strong>Base Unit:</strong> {{ item.base_unit }}</p>
+    {% set default_unit = (item.units | selectattr('receiving_default') | first) %}
+    <p><strong>Current Cost:</strong> {{ '%.6f'|format(item.cost) }} / {{ item.base_unit }}{% if default_unit and default_unit.factor and default_unit.factor != 1 %} ({{ '%.6f'|format(item.cost * default_unit.factor) }} / {{ default_unit.name }}){% endif %}</p>
     <div class="row">
         <div class="col-12">
             <h4>Recent Purchase Invoices</h4>
@@ -22,7 +24,7 @@
                             <td>{{ pii.invoice.received_date }}</td>
                             <td><a href="{{ url_for('purchase.view_purchase_invoice', invoice_id=pii.invoice_id) }}">{{ pii.invoice_id }}</a></td>
                             <td>{{ pii.quantity }} {{ pii.unit.name if pii.unit else pii.unit_name or item.base_unit }}</td>
-                            <td>{{ '%.6f'|format(pii.cost) }}</td>
+                            <td>{{ '%.6f'|format((pii.cost|abs) / (pii.unit.factor if pii.unit and pii.unit.factor else 1)) }} / {{ item.base_unit }}</td>
                         </tr>
                         {% else %}
                         <tr><td colspan="4">No purchase invoices found.</td></tr>


### PR DESCRIPTION
## Summary
- Calculate item cost using base-unit pricing when receiving invoices
- Display current cost in both base and default receiving units on item pages
- Test that items page reflects updated default-unit cost after receiving an invoice

## Testing
- `pre-commit run --files app/routes/purchase_routes.py app/templates/items/_item_row.html app/templates/items/view_item.html tests/test_purchase_flow.py`
- `pytest tests/test_purchase_flow.py::test_item_cost_visible_on_items_page tests/test_purchase_flow.py::test_item_cost_visible_on_item_page tests/test_purchase_flow.py::test_items_page_shows_default_unit_cost -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d8e60e8c8324bd800a2d9450fb14