### PR TITLE
Handle missing units in purchase invoice and default unit selection

### DIFF
--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -357,9 +357,15 @@ def receive_invoice(po_id):
                 )
 
                 if item_obj:
-                    factor = (
-                        unit_obj.factor if unit_obj and unit_obj.factor else 1
-                    )
+                    if unit_obj and unit_obj.factor:
+                        factor = unit_obj.factor
+                    else:
+                        default_unit = (
+                            ItemUnit.query.filter_by(
+                                item_id=item_obj.id, receiving_default=True
+                            ).first()
+                        )
+                        factor = default_unit.factor if default_unit else 1
                     prev_qty = item_obj.quantity or 0
                     prev_cost = item_obj.cost or 0
                     new_qty = quantity * factor
@@ -376,6 +382,8 @@ def receive_invoice(po_id):
 
                     # Explicitly mark the item as dirty so cost updates persist
                     db.session.add(item_obj)
+                    db.session.flush()
+                    db.session.refresh(item_obj)
 
                     record = LocationStandItem.query.filter_by(
                         location_id=invoice.location_id, item_id=item_obj.id

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -33,7 +33,16 @@
         {% for item in form.items %}
         <div class="row g-2 item-row mb-2 align-items-center">
             <div class="col">{{ item.item(class="form-control item-select") }}</div>
-            <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
+            <div class="col">
+                <select name="items-{{ loop.index0 }}-unit" class="form-control unit-select">
+                {% set poi = po.items[loop.index0] if loop.index0 < po.items|length else None %}
+                {% if poi %}
+                    {% for u in poi.item.units %}
+                        <option value="{{ u.id }}" {% if u.id == poi.unit_id %}selected{% endif %}>{{ u.name }}</option>
+                    {% endfor %}
+                {% endif %}
+                </select>
+            </div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col">{{ item.cost(class="form-control cost") }}</div>
             <div class="col"><span class="line-total">0.00</span></div>
@@ -167,7 +176,7 @@
         }
     });
 
-    document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
+    document.querySelectorAll('#items .item-row').forEach(row => fetchCost(row));
     document.getElementById('gst').addEventListener('input', updateTotals);
     document.getElementById('pst').addEventListener('input', updateTotals);
     document.getElementById('delivery_charge').addEventListener('input', updateTotals);

--- a/tests/test_purchase_flow.py
+++ b/tests/test_purchase_flow.py
@@ -508,6 +508,63 @@ def test_receive_invoice_base_unit_cost(client, app):
         assert lsi.expected_count == 24
 
 
+def test_receive_invoice_missing_unit_defaults(client, app):
+    """Omitting unit should use receiving default factor."""
+    email, vendor_id, item_id, location_id, case_unit_id = (
+        setup_purchase_with_case(app)
+    )
+    # Make case unit the receiving default
+    with app.app_context():
+        case_unit = db.session.get(ItemUnit, case_unit_id)
+        each_unit = ItemUnit.query.filter_by(item_id=item_id, name="each").first()
+        each_unit.receiving_default = False
+        case_unit.receiving_default = True
+        db.session.commit()
+
+    with client:
+        login(client, email, "pass")
+        resp = client.post(
+            "/purchase_orders/create",
+            data={
+                "vendor": vendor_id,
+                "order_date": "2023-08-01",
+                "expected_date": "2023-08-05",
+                "items-0-item": item_id,
+                "items-0-unit": case_unit_id,
+                "items-0-quantity": 1,
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+    with app.app_context():
+        po = PurchaseOrder.query.first()
+        po_id = po.id
+
+    with client:
+        login(client, email, "pass")
+        resp = client.post(
+            f"/purchase_orders/{po_id}/receive",
+            data={
+                "received_date": "2023-08-06",
+                "location_id": location_id,
+                "gst": 0,
+                "pst": 0,
+                "delivery_charge": 0,
+                "items-0-item": item_id,
+                # intentionally omit unit
+                "items-0-quantity": 1,
+                "items-0-cost": 24,
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+    with app.app_context():
+        item = db.session.get(Item, item_id)
+        assert item.quantity == 24
+        assert item.cost == 1
+
 def test_item_cost_is_average(client, app):
     email, vendor_id, item_id, location_id, unit_id = setup_purchase(app)
 


### PR DESCRIPTION
## Summary
- Pre-render unit selectors on receive invoice form with PO units so unit_id always posted
- Use item's receiving default unit factor when unit_id omitted and flush item updates to persist cost
- Add regression test verifying cost conversion without unit field

## Testing
- `pytest tests/test_purchase_flow.py::test_receive_invoice_base_unit_cost tests/test_purchase_flow.py::test_receive_invoice_missing_unit_defaults -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e34fef508324b0333fb7d26a239b