### PR TITLE
Handle missing units in purchase invoice and persist item cost

### DIFF
--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -1,3 +1,5 @@
+import datetime
+
 from flask import (
     Blueprint,
     abort,
@@ -30,8 +32,6 @@ from app.models import (
     Vendor,
 )
 from app.utils.activity import log_activity
-
-import datetime
 
 purchase = Blueprint("purchase", __name__)
 
@@ -106,10 +106,8 @@ def view_purchase_orders():
     if end_date:
         query = query.filter(PurchaseOrder.order_date <= end_date)
 
-    orders = (
-        query.order_by(PurchaseOrder.order_date.desc()).paginate(
-            page=page, per_page=20
-        )
+    orders = query.order_by(PurchaseOrder.order_date.desc()).paginate(
+        page=page, per_page=20
     )
 
     vendors = Vendor.query.filter_by(archived=False).all()
@@ -343,6 +341,17 @@ def receive_invoice(po_id):
                 unit_obj = (
                     db.session.get(ItemUnit, unit_id) if unit_id else None
                 )
+                factor = 1
+                if item_obj:
+                    if unit_obj and unit_obj.factor:
+                        factor = unit_obj.factor
+                    else:
+                        default_unit = ItemUnit.query.filter_by(
+                            item_id=item_obj.id, receiving_default=True
+                        ).first()
+                        if default_unit:
+                            unit_obj = default_unit
+                            factor = default_unit.factor or 1
 
                 db.session.add(
                     PurchaseInvoiceItem(
@@ -357,9 +366,6 @@ def receive_invoice(po_id):
                 )
 
                 if item_obj:
-                    factor = (
-                        unit_obj.factor if unit_obj and unit_obj.factor else 1
-                    )
                     prev_qty = item_obj.quantity or 0
                     prev_cost = item_obj.cost or 0
                     new_qty = quantity * factor
@@ -374,8 +380,9 @@ def receive_invoice(po_id):
                     else:
                         item_obj.cost = 0.0
 
-                    # Explicitly mark the item as dirty so cost updates persist
+                    # Persist the updated cost and quantity
                     db.session.add(item_obj)
+                    db.session.flush()
 
                     record = LocationStandItem.query.filter_by(
                         location_id=invoice.location_id, item_id=item_obj.id
@@ -446,7 +453,9 @@ def view_purchase_invoices():
     if po_number:
         query = query.filter(PurchaseInvoice.purchase_order_id == po_number)
     if vendor_id:
-        query = query.join(PurchaseOrder).filter(PurchaseOrder.vendor_id == vendor_id)
+        query = query.join(PurchaseOrder).filter(
+            PurchaseOrder.vendor_id == vendor_id
+        )
     if location_id:
         query = query.filter(PurchaseInvoice.location_id == location_id)
     if start_date:
@@ -461,7 +470,9 @@ def view_purchase_invoices():
     vendors = Vendor.query.order_by(Vendor.first_name, Vendor.last_name).all()
     locations = Location.query.order_by(Location.name).all()
     active_vendor = db.session.get(Vendor, vendor_id) if vendor_id else None
-    active_location = db.session.get(Location, location_id) if location_id else None
+    active_location = (
+        db.session.get(Location, location_id) if location_id else None
+    )
 
     return render_template(
         "purchase_invoices/view_purchase_invoices.html",
@@ -584,7 +595,9 @@ def reverse_purchase_invoice(invoice_id):
         qty_before = itm.quantity
         itm.quantity = qty_before - removed_qty
 
-        base_cost = abs(inv_item.cost) / factor if factor else abs(inv_item.cost)
+        base_cost = (
+            abs(inv_item.cost) / factor if factor else abs(inv_item.cost)
+        )
         total_cost_before = (itm.cost or 0) * qty_before
         total_cost_after = total_cost_before - base_cost * removed_qty
 

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -33,7 +33,16 @@
         {% for item in form.items %}
         <div class="row g-2 item-row mb-2 align-items-center">
             <div class="col">{{ item.item(class="form-control item-select") }}</div>
-            <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
+            <div class="col">
+                <select name="items-{{ loop.index0 }}-unit" class="form-control unit-select">
+                {% set poi = po.items[loop.index0] if loop.index0 < po.items|length else None %}
+                {% if poi %}
+                    {% for u in poi.item.units %}
+                        <option value="{{ u.id }}" {% if u.id == poi.unit_id %}selected{% endif %}>{{ u.name }}</option>
+                    {% endfor %}
+                {% endif %}
+                </select>
+            </div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col">{{ item.cost(class="form-control cost") }}</div>
             <div class="col"><span class="line-total">0.00</span></div>
@@ -167,7 +176,7 @@
         }
     });
 
-    document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
+    document.querySelectorAll('#items .item-row').forEach(row => fetchCost(row));
     document.getElementById('gst').addEventListener('input', updateTotals);
     document.getElementById('pst').addEventListener('input', updateTotals);
     document.getElementById('delivery_charge').addEventListener('input', updateTotals);

--- a/tests/test_purchase_flow.py
+++ b/tests/test_purchase_flow.py
@@ -508,6 +508,166 @@ def test_receive_invoice_base_unit_cost(client, app):
         assert lsi.expected_count == 24
 
 
+def test_receive_invoice_missing_unit_defaults(client, app):
+    """Omitting unit should use receiving default factor."""
+    email, vendor_id, item_id, location_id, case_unit_id = (
+        setup_purchase_with_case(app)
+    )
+    # Make case unit the receiving default
+    with app.app_context():
+        case_unit = db.session.get(ItemUnit, case_unit_id)
+        each_unit = ItemUnit.query.filter_by(
+            item_id=item_id, name="each"
+        ).first()
+        each_unit.receiving_default = False
+        case_unit.receiving_default = True
+        db.session.commit()
+
+    with client:
+        login(client, email, "pass")
+        resp = client.post(
+            "/purchase_orders/create",
+            data={
+                "vendor": vendor_id,
+                "order_date": "2023-08-01",
+                "expected_date": "2023-08-05",
+                "items-0-item": item_id,
+                "items-0-unit": case_unit_id,
+                "items-0-quantity": 1,
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+    with app.app_context():
+        po = PurchaseOrder.query.first()
+        po_id = po.id
+
+    with client:
+        login(client, email, "pass")
+        resp = client.post(
+            f"/purchase_orders/{po_id}/receive",
+            data={
+                "received_date": "2023-08-06",
+                "location_id": location_id,
+                "gst": 0,
+                "pst": 0,
+                "delivery_charge": 0,
+                "items-0-item": item_id,
+                # intentionally omit unit
+                "items-0-quantity": 1,
+                "items-0-cost": 24,
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+
+    with app.app_context():
+        item = db.session.get(Item, item_id)
+        assert item.quantity == 24
+        assert item.cost == 1
+
+
+def test_receive_invoice_missing_unit_shows_on_items_page(client, app):
+    """Missing unit still updates cost displayed on items page."""
+    email, vendor_id, item_id, location_id, case_unit_id = (
+        setup_purchase_with_case(app)
+    )
+    # Make case unit the receiving default
+    with app.app_context():
+        case_unit = db.session.get(ItemUnit, case_unit_id)
+        each_unit = ItemUnit.query.filter_by(
+            item_id=item_id, name="each"
+        ).first()
+        each_unit.receiving_default = False
+        case_unit.receiving_default = True
+        db.session.commit()
+
+    with client:
+        login(client, email, "pass")
+        client.post(
+            "/purchase_orders/create",
+            data={
+                "vendor": vendor_id,
+                "order_date": "2023-09-01",
+                "expected_date": "2023-09-05",
+                "items-0-item": item_id,
+                "items-0-unit": case_unit_id,
+                "items-0-quantity": 1,
+            },
+            follow_redirects=True,
+        )
+
+    with app.app_context():
+        po_id = PurchaseOrder.query.first().id
+
+    with client:
+        login(client, email, "pass")
+        client.post(
+            f"/purchase_orders/{po_id}/receive",
+            data={
+                "received_date": "2023-09-06",
+                "location_id": location_id,
+                "gst": 0,
+                "pst": 0,
+                "delivery_charge": 0,
+                "items-0-item": item_id,
+                # omit unit field
+                "items-0-quantity": 1,
+                "items-0-cost": 24,
+            },
+            follow_redirects=True,
+        )
+        resp = client.get("/items")
+        assert "1.000000 / each" in resp.get_data(as_text=True)
+
+
+def test_receive_invoice_selected_unit_shows_on_items_page(client, app):
+    """Cost updates when the unit is provided explicitly."""
+    email, vendor_id, item_id, location_id, case_unit_id = (
+        setup_purchase_with_case(app)
+    )
+
+    with client:
+        login(client, email, "pass")
+        client.post(
+            "/purchase_orders/create",
+            data={
+                "vendor": vendor_id,
+                "order_date": "2023-10-01",
+                "expected_date": "2023-10-05",
+                "items-0-item": item_id,
+                "items-0-unit": case_unit_id,
+                "items-0-quantity": 1,
+            },
+            follow_redirects=True,
+        )
+
+    with app.app_context():
+        po_id = PurchaseOrder.query.first().id
+
+    with client:
+        login(client, email, "pass")
+        client.post(
+            f"/purchase_orders/{po_id}/receive",
+            data={
+                "received_date": "2023-10-06",
+                "location_id": location_id,
+                "gst": 0,
+                "pst": 0,
+                "delivery_charge": 0,
+                "items-0-item": item_id,
+                "items-0-unit": case_unit_id,
+                "items-0-quantity": 1,
+                "items-0-cost": 24,
+            },
+            follow_redirects=True,
+        )
+
+        resp = client.get("/items")
+        assert "1.000000 / each" in resp.get_data(as_text=True)
+
+
 def test_item_cost_is_average(client, app):
     email, vendor_id, item_id, location_id, unit_id = setup_purchase(app)
 
@@ -673,12 +833,16 @@ def test_reverse_invoice_restores_average(client, app):
         )
 
     with app.app_context():
-        invoice = PurchaseInvoice.query.order_by(PurchaseInvoice.id.desc()).first()
+        invoice = PurchaseInvoice.query.order_by(
+            PurchaseInvoice.id.desc()
+        ).first()
         inv_id = invoice.id
 
     with client:
         login(client, email, "pass")
-        client.get(f"/purchase_invoices/{inv_id}/reverse", follow_redirects=True)
+        client.get(
+            f"/purchase_invoices/{inv_id}/reverse", follow_redirects=True
+        )
 
     with app.app_context():
         item = db.session.get(Item, item_id)


### PR DESCRIPTION
## Summary
- When receiving an invoice line without a unit, fall back to the item's receiving-default unit and record it on the invoice line
- Ensure the item's cost updates persist so the items list reflects the base-unit cost
- Extend purchase flow tests to cover missing unit submissions and explicit unit submissions on the items page

## Testing
- `pre-commit run --files app/routes/purchase_routes.py tests/test_purchase_flow.py`
- `pytest tests/test_purchase_flow.py::test_receive_invoice_base_unit_cost tests/test_purchase_flow.py::test_receive_invoice_missing_unit_defaults tests/test_purchase_flow.py::test_receive_invoice_missing_unit_shows_on_items_page tests/test_purchase_flow.py::test_receive_invoice_selected_unit_shows_on_items_page -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e34fef508324b0333fb7d26a239b