### PR TITLE
Fix item unit addition and add copy item workflow

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -282,6 +282,22 @@ def add_item():
     return render_template("items/item_form_page.html", form=form, title="Add Item")
 
 
+@item.route("/items/copy/<int:item_id>")
+@login_required
+def copy_item(item_id):
+    """Provide a pre-filled form for duplicating an item."""
+    item = db.session.get(Item, item_id)
+    if item is None:
+        abort(404)
+    form = ItemForm(obj=item)
+    form.gl_code.data = item.gl_code
+    form.gl_code_id.data = item.gl_code_id
+    form.purchase_gl_code.data = item.purchase_gl_code_id
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+        return render_template("items/item_form.html", form=form)
+    return render_template("items/item_form_page.html", form=form, title="Add Item")
+
+
 @item.route("/items/edit/<int:item_id>", methods=["GET", "POST"])
 @login_required
 def edit_item(item_id):

--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -5,6 +5,7 @@
     <td>
         <a href="{{ url_for('item.view_item', item_id=item.id) }}" class="btn btn-primary">View</a>
         <button type="button" class="btn btn-secondary edit-item-btn ms-1" data-item-id="{{ item.id }}">Edit</button>
+        <button type="button" class="btn btn-secondary copy-item-btn ms-1" data-item-id="{{ item.id }}">Copy</button>
         <a href="{{ url_for('item.item_locations', item_id=item.id) }}" class="btn btn-info ms-1">Locations</a>
     </td>
 </tr>

--- a/app/templates/items/item_form.html
+++ b/app/templates/items/item_form.html
@@ -39,7 +39,7 @@
         <button type="button" class="btn btn-secondary" id="add-unit">Add Unit</button>
         {{ form.submit(class="btn btn-primary") }}
     </form>
-    <script>
+    <script data-allow-html>
         let unitIndex = {{ form.units|length }};
         document.getElementById('add-unit').addEventListener('click', function() {
             const container = document.getElementById('units-container');

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -180,14 +180,11 @@ document.getElementById('select-all').onclick = function() {
 <script>
 const itemModalEl = document.getElementById('itemModal');
 
-function isSafeScriptContent(content) {
-    return content && !/<\/?[a-z][\s\S]*>/i.test(content);
-}
-
 function executeScripts(container) {
     container.querySelectorAll('script').forEach(s => {
         const content = s.textContent;
-        if (isSafeScriptContent(content)) {
+        const allowHtml = s.dataset.allowHtml !== undefined;
+        if (allowHtml || !/<\/?[a-z][\s\S]*>/i.test(content)) {
             new Function(content)();
         }
         s.remove();
@@ -253,6 +250,20 @@ document.querySelector('#itemsTable').addEventListener('click', function(e) {
                 const modal = new bootstrap.Modal(itemModalEl);
                 modal.show();
                 bindItemForm(url);
+            });
+    } else if (e.target.classList.contains('copy-item-btn')) {
+        const itemId = e.target.getAttribute('data-item-id');
+        const url = '{{ url_for('item.copy_item', item_id=0) }}'.replace('0', itemId);
+        const actionUrl = '{{ url_for('item.add_item') }}';
+        fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+            .then(r => r.text())
+            .then(html => {
+                itemModalEl.querySelector('.modal-title').textContent = 'Copy Item';
+                itemModalEl.querySelector('.modal-body').innerHTML = html;
+                executeScripts(itemModalEl);
+                const modal = new bootstrap.Modal(itemModalEl);
+                modal.show();
+                bindItemForm(actionUrl);
             });
     }
 });


### PR DESCRIPTION
## Summary
- ensure scripts with HTML content execute in item modal and mark unit script as safe
- allow copying existing items into a pre-filled creation form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c45f7f7ad883249edb3cbfa68fa7eb