### PR TITLE
Add product copy functionality

### DIFF
--- a/app/templates/products/_product_row.html
+++ b/app/templates/products/_product_row.html
@@ -6,6 +6,7 @@
     <td>{{ product.last_sold_at.strftime('%Y-%m-%d') if product.last_sold_at else 'Never' }}</td>
     <td>
         <a href="{{ url_for('product.edit_product', product_id=product.id) }}" class="btn btn-primary mr-2">Edit</a>
+        <a href="{{ url_for('product.copy_product', product_id=product.id) }}" class="btn btn-secondary mr-2">Copy</a>
         <form action="{{ url_for('product.delete_product', product_id=product.id) }}" method="post" class="d-inline">
             {{ delete_form.hidden_tag() }}
             <button type="submit" class="btn btn-danger">Delete</button>

--- a/app/templates/products/create_product.html
+++ b/app/templates/products/create_product.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}Create Product{% endblock %}
+{% block title %}{{ title or "Create Product" }}{% endblock %}
 
 {% block content %}
 <div class="container mt-5">
-    <h2>Create Product</h2>
-    {% set form_action = url_for('product.create_product') %}
+    <h2>{{ title or "Create Product" }}</h2>
+    {% set form_action = form_action or url_for('product.create_product') %}
     {% include 'products/_create_product_form.html' %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow duplicating existing products via `/products/copy/<id>`
- expose Copy button in product list
- make product creation template support custom titles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c48f962c248324a63ea3186e772f32