### PR TITLE
feat: add modal for stand sheet copy

### DIFF
--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -116,10 +116,32 @@
         <div class="modal-content"></div>
     </div>
 </div>
+<!-- Copy Stand Sheet Modal -->
+<div class="modal fade" id="copyModal" tabindex="-1" aria-labelledby="copyModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="copyModalLabel">Copy Stand Sheet</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="copyForm">
+                    <div id="copyLocationList" class="mb-3"></div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="submit" form="copyForm" class="btn btn-primary">Copy</button>
+            </div>
+        </div>
+    </div>
+</div>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     const csrfToken = document.getElementById('csrf_token').value;
     const locationModal = new bootstrap.Modal(document.getElementById('locationModal'));
+    const copyModal = new bootstrap.Modal(document.getElementById('copyModal'));
+    let currentSourceId = null;
 
     $('#addLocationBtn').on('click', function() {
         $.get('{{ url_for('locations.add_location') }}', function(data) {
@@ -175,22 +197,36 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     $(document).on('click', '.copy-location-btn', function() {
-        const sourceId = $(this).data('id');
-        const targetIds = prompt('Enter target location ID(s) to copy stand sheet to (comma-separated):');
-        if (!targetIds) {
-            return;
-        }
-        const ids = targetIds.split(',').map(id => id.trim()).filter(Boolean);
+        currentSourceId = $(this).data('id');
+        const options = $('table tbody tr').map(function() {
+            const id = $(this).data('id');
+            const name = $(this).find('td:first').text();
+            if (id === currentSourceId) {
+                return null;
+            }
+            return `<div class="form-check"><input class="form-check-input" type="checkbox" value="${id}" id="copy-${id}"><label class="form-check-label" for="copy-${id}">${name}</label></div>`;
+        }).get().join('');
+        $('#copyLocationList').html(options || '<p class="text-muted">No other locations available.</p>');
+        copyModal.show();
+    });
+
+    $('#copyForm').on('submit', function(e) {
+        e.preventDefault();
+        const ids = $('#copyLocationList input:checked').map(function() {
+            return $(this).val();
+        }).get();
         if (ids.length === 0) {
+            alert('Please select at least one target location.');
             return;
         }
         $.ajax({
-            url: `/locations/${sourceId}/copy_items`,
+            url: `/locations/${currentSourceId}/copy_items`,
             method: 'POST',
             contentType: 'application/json',
             headers: { 'X-CSRFToken': csrfToken },
             data: JSON.stringify({ target_ids: ids }),
             success: function(resp) {
+                copyModal.hide();
                 alert('Stand sheet copied successfully.');
             },
             error: function(xhr) {


### PR DESCRIPTION
## Summary
- add bootstrap modal to select target locations when copying a stand sheet
- populate modal with available locations and submit selection via AJAX

## Testing
- `pre-commit run --files app/templates/locations/view_locations.html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4ad0e32408324aa41482e15b8e566