### PR TITLE
Fix duplication when copying location stand sheet items

### DIFF
--- a/app/routes/location_routes.py
+++ b/app/routes/location_routes.py
@@ -205,10 +205,11 @@ def copy_location_items(source_id: int):
         # Remove existing stand sheet items
         LocationStandItem.query.filter_by(location_id=target.id).delete()
 
-        # Recreate stand sheet items matching the source
+        # Recreate stand sheet items matching the source without duplicates
+        existing_items = set()
         for product in source_products:
             for recipe_item in product.recipe_items:
-                if recipe_item.countable:
+                if recipe_item.countable and recipe_item.item_id not in existing_items:
                     expected = source_item_counts.get(recipe_item.item_id, 0)
                     db.session.add(
                         LocationStandItem(
@@ -218,6 +219,7 @@ def copy_location_items(source_id: int):
                             purchase_gl_code_id=recipe_item.item.purchase_gl_code_id,
                         )
                     )
+                    existing_items.add(recipe_item.item_id)
 
         processed_targets.append(str(tid))
 

--- a/tests/test_location_copy_items.py
+++ b/tests/test_location_copy_items.py
@@ -52,6 +52,55 @@ def setup_data(app):
         return user.email, product.id
 
 
+def setup_multi_product_data(app):
+    """Create two products that share the same item."""
+    with app.app_context():
+        user = User(
+            email="copy2@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        gl = GLCode.query.first()
+        item = Item(
+            name="Sugar",
+            base_unit="gram",
+            purchase_gl_code_id=gl.id,
+        )
+        db.session.add_all([user, item])
+        db.session.commit()
+        unit = ItemUnit(
+            item_id=item.id,
+            name="gram",
+            factor=1,
+            receiving_default=True,
+            transfer_default=True,
+        )
+        prod1 = Product(name="Candy", price=1.0, cost=0.5)
+        prod2 = Product(name="Cookie", price=1.5, cost=0.7)
+        db.session.add_all([unit, prod1, prod2])
+        db.session.commit()
+        db.session.add_all(
+            [
+                ProductRecipeItem(
+                    product_id=prod1.id,
+                    item_id=item.id,
+                    unit_id=unit.id,
+                    quantity=1,
+                    countable=True,
+                ),
+                ProductRecipeItem(
+                    product_id=prod2.id,
+                    item_id=item.id,
+                    unit_id=unit.id,
+                    quantity=2,
+                    countable=True,
+                ),
+            ]
+        )
+        db.session.commit()
+        return user.email, [prod1.id, prod2.id]
+
+
 def test_copy_location_items(client, app):
     email, prod_id = setup_data(app)
     with client:
@@ -106,3 +155,52 @@ def test_copy_button_visible(client, app):
         assert resp.status_code == 200
         resp = client.get("/locations")
         assert b"Copy Stand Sheet" in resp.data
+
+
+def test_copy_location_items_multiple_targets(client, app):
+    """Copy stand items to multiple targets without duplicates."""
+    email, prod_ids = setup_multi_product_data(app)
+    with client:
+        login(client, email, "pass")
+        # create source location with both products
+        resp = client.post(
+            "/locations/add",
+            data={"name": "Source", "products": ",".join(str(pid) for pid in prod_ids)},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        # create two target locations without products
+        resp = client.post(
+            "/locations/add",
+            data={"name": "Target1", "products": ""},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        resp = client.post(
+            "/locations/add",
+            data={"name": "Target2", "products": ""},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        with app.app_context():
+            source = Location.query.filter_by(name="Source").first()
+            t1 = Location.query.filter_by(name="Target1").first()
+            t2 = Location.query.filter_by(name="Target2").first()
+            source_id = source.id
+            t1_id = t1.id
+            t2_id = t2.id
+        # copy items to both targets
+        resp = client.post(
+            f"/locations/{source_id}/copy_items",
+            json={"target_ids": [t1_id, t2_id]},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["success"] is True
+        # both targets should have two products and one stand item each
+        with app.app_context():
+            refreshed1 = db.session.get(Location, t1_id)
+            refreshed2 = db.session.get(Location, t2_id)
+            assert len(refreshed1.products) == 2
+            assert len(refreshed2.products) == 2
+            assert LocationStandItem.query.filter_by(location_id=t1_id).count() == 1
+            assert LocationStandItem.query.filter_by(location_id=t2_id).count() == 1


### PR DESCRIPTION
## Summary
- avoid inserting duplicate stand sheet items when copying a location to others
- add regression test for copying to multiple locations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4b8648bc883248a4eb293d4d9973f