### PR TITLE
Remove overlapping standsheet footer

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -87,26 +87,6 @@
 .signoffs .right div {
   margin-bottom: 8px;
 }
-.footer {
-  position: fixed;
-  bottom: 0.25in;
-  left: 0.5in;
-  right: 0.5in;
-  display: flex;
-  font-size: 11px;
-}
-.footer div:nth-child(1) {
-  flex: 1;
-  text-align: left;
-}
-.footer div:nth-child(2) {
-  flex: 1;
-  text-align: center;
-}
-.footer div:nth-child(3) {
-  flex: 1;
-  text-align: right;
-}
 .standsheet-page {
   page-break-after: always;
 }
@@ -215,10 +195,5 @@
   </div>
 </section>
 {% endfor %}
-<footer class="footer">
-  <div>Standsheet</div>
-  <div>1 of 1</div>
-  <div></div>
-</footer>
 </div>
 {% endblock %}

--- a/app/templates/locations/stand_sheet.html
+++ b/app/templates/locations/stand_sheet.html
@@ -60,26 +60,6 @@ body {
 .signoffs .right div {
   margin-bottom: 8px;
 }
-.footer {
-  position: fixed;
-  bottom: 0.25in;
-  left: 0.5in;
-  right: 0.5in;
-  display: flex;
-  font-size: 11px;
-}
-.footer div:nth-child(1) {
-  flex: 1;
-  text-align: left;
-}
-.footer div:nth-child(2) {
-  flex: 1;
-  text-align: center;
-}
-.footer div:nth-child(3) {
-  flex: 1;
-  text-align: right;
-}
 .standsheet-page {
   page-break-after: always;
 }
@@ -174,9 +154,4 @@ body {
     </div>
   </div>
 </section>
-<footer class="footer">
-  <div>Standsheet</div>
-  <div>1 of 1</div>
-  <div></div>
-</footer>
 {% endblock %}


### PR DESCRIPTION
## Summary
- drop fixed footer from bulk and single location standsheet templates
- prevent stock item tables from colliding with page footer text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4bb97202083248cccfa2a108344a4