### PR TITLE
Add transfer base unit option and persist filters

### DIFF
--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -1,34 +1,50 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>{{ event.name }}</h2>
-<p>Start: {{ event.start_date }} End: {{ event.end_date }}</p>
-{% if not event.closed %}
-<a class="btn btn-secondary" href="{{ url_for('event.add_location', event_id=event.id) }}">Add Location</a>
-{% endif %}
-<a class="btn btn-secondary" href="{{ url_for('event.bulk_stand_sheets', event_id=event.id) }}">Stand Sheets</a>
-{% if not event.closed %}
-<a class="btn btn-secondary" href="{{ url_for('event.scan_stand_sheet') }}">Upload Stand Sheets</a>
-{% endif %}
-{% if event.event_type == 'inventory' %}
-<a class="btn btn-secondary" href="{{ url_for('event.bulk_count_sheets', event_id=event.id) }}">Count Sheets</a>
-{% endif %}
-{% if not event.closed %}
-<a class="btn btn-secondary" href="{{ url_for('event.upload_terminal_sales', event_id=event.id) }}">Upload Sales</a>
-<a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
-{% endif %}
-<ul class="mt-3">
-{% for el in event.locations %}
-    <li>{{ el.location.name }} -
-        {% if not el.confirmed and not event.closed %}
-            <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a>
-            {% if event.event_type == 'inventory' %}| <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a>{% endif %} |
-            <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> |
-            <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>
-        {% else %}
-            Stand Sheet | Terminal Sales
-            {% if el.confirmed %}| Confirmed{% endif %}
+<div class="container mt-4">
+    <h2>{{ event.name }}</h2>
+    <p>Start: {{ event.start_date }} End: {{ event.end_date }}</p>
+    <div class="mb-3">
+        {% if not event.closed %}
+        <a class="btn btn-primary me-2" href="{{ url_for('event.add_location', event_id=event.id) }}">Add Location</a>
         {% endif %}
-    </li>
-{% endfor %}
-</ul>
+        <a class="btn btn-secondary me-2" href="{{ url_for('event.bulk_stand_sheets', event_id=event.id) }}">Stand Sheets</a>
+        {% if not event.closed %}
+        <a class="btn btn-secondary me-2" href="{{ url_for('event.scan_stand_sheet') }}">Upload Stand Sheets</a>
+        {% endif %}
+        {% if event.event_type == 'inventory' %}
+        <a class="btn btn-secondary me-2" href="{{ url_for('event.bulk_count_sheets', event_id=event.id) }}">Count Sheets</a>
+        {% endif %}
+        {% if not event.closed %}
+        <a class="btn btn-secondary me-2" href="{{ url_for('event.upload_terminal_sales', event_id=event.id) }}">Upload Sales</a>
+        <a class="btn btn-danger" href="{{ url_for('event.close_event', event_id=event.id) }}">Close Event</a>
+        {% endif %}
+    </div>
+    <div class="table-responsive">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Location</th>
+                    <th>Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for el in event.locations %}
+                <tr>
+                    <td>{{ el.location.name }}</td>
+                    <td>
+                        {% if not el.confirmed and not event.closed %}
+                            <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a>
+                            {% if event.event_type == 'inventory' %}| <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a>{% endif %} |
+                            <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> |
+                            <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>
+                        {% else %}
+                            Stand Sheet | Terminal Sales {% if el.confirmed %}| Confirmed{% endif %}
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
 {% endblock %}

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -93,7 +93,7 @@
                     </form>
                 </div>
                 <div class="modal-footer">
-                    <a href="{{ url_for('item.view_items') }}" class="btn btn-outline-secondary">Reset</a>
+                    <a href="{{ url_for('item.view_items', reset=1) }}" class="btn btn-outline-secondary">Reset</a>
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
                 </div>

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -97,7 +97,7 @@
                     </form>
                 </div>
                 <div class="modal-footer">
-                    <a href="{{ url_for('product.view_products') }}" class="btn btn-outline-secondary">Reset</a>
+                    <a href="{{ url_for('product.view_products', reset=1) }}" class="btn btn-outline-secondary">Reset</a>
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     <button type="submit" form="filter-form" class="btn btn-primary">Apply</button>
                 </div>

--- a/app/templates/transfers/add_transfer.html
+++ b/app/templates/transfers/add_transfer.html
@@ -74,10 +74,12 @@
     function addItemToList(item) {
         fetch(`/items/${item.id}/units`).then(r => r.json()).then(data => {
             const base = data.base_unit;
-            const units = data.units;
+            const units = data.units || [];
+            const hasDefault = units.some(u => u.transfer_default);
+            units.unshift({id:0, name: base, factor:1, transfer_default: !hasDefault});
             var options = '';
             units.forEach(u => {
-                const label = `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
+                const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
                 options += `<option value="${u.id}" data-factor="${u.factor}" ${u.transfer_default ? 'selected' : ''}>${label}</option>`;
             });
             var listItem = document.createElement('div');

--- a/app/templates/transfers/edit_transfer.html
+++ b/app/templates/transfers/edit_transfer.html
@@ -83,11 +83,13 @@ document.addEventListener('click', function(event) {
 function addItemToList(item, index) {
     fetch(`/items/${item.id}/units`).then(r => r.json()).then(data => {
         const base = data.base_unit;
-        const units = data.units;
-        var options = '';
+        const units = data.units || [];
+        const hasDefault = units.some(u => u.transfer_default);
+        units.unshift({id:0, name: base, factor:1, transfer_default: !hasDefault});
         let defaultUnit = units.find(u => u.transfer_default) || units[0];
+        var options = '';
         units.forEach(u => {
-            const label = `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
+            const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
             const selected = u.id === defaultUnit.id ? 'selected' : '';
             options += `<option value="${u.id}" data-factor="${u.factor}" ${selected}>${label}</option>`;
         });

--- a/app/templates/transfers/view_transfers.html
+++ b/app/templates/transfers/view_transfers.html
@@ -202,10 +202,12 @@
     function addItemToList(id, name) {
         fetch(`/items/${id}/units`).then(r => r.json()).then(data => {
             const base = data.base_unit;
-            const units = data.units;
+            const units = data.units || [];
+            const hasDefault = units.some(u => u.transfer_default);
+            units.unshift({id:0, name: base, factor:1, transfer_default: !hasDefault});
             var options = '';
             units.forEach(u => {
-                const label = `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
+                const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
                 options += `<option value="${u.id}" data-factor="${u.factor}" ${u.transfer_default ? 'selected' : ''}>${label}</option>`;
             });
             var listItem = document.createElement('div');
@@ -297,11 +299,13 @@
     function addEditItem(item){
         fetch(`/items/${item.id}/units`).then(r => r.json()).then(data => {
             const base = data.base_unit;
-            const units = data.units;
-            var options = '';
+            const units = data.units || [];
+            const hasDefault = units.some(u => u.transfer_default);
+            units.unshift({id:0, name: base, factor:1, transfer_default: !hasDefault});
             let defaultUnit = units.find(u => u.transfer_default) || units[0];
+            var options = '';
             units.forEach(u => {
-                const label = `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
+                const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
                 const selected = u.id === defaultUnit.id ? 'selected' : '';
                 options += `<option value="${u.id}" data-factor="${u.factor}" ${selected}>${label}</option>`;
             });


### PR DESCRIPTION
## Summary
- include base unit as selectable option when creating or editing transfers
- restyle single event view to use Bootstrap layout
- persist item and product filters across sessions until reset

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4be48824483249a7707d02f4b1cb3