### PR TITLE
Add Tesseract dependency for stand sheet scanning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PYTHONUNBUFFERED=1 \
 WORKDIR /app
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends poppler-utils && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends poppler-utils tesseract-ocr && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies
 COPY requirements.txt .

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ You can perform the steps below manually or run one of the setup scripts provide
    (for Debian/Ubuntu: `apt-get install poppler-utils`). The Docker image
    provided with this project installs this dependency automatically.
 
+   OCR for stand sheets also relies on the Tesseract engine. Install
+   `tesseract-ocr` via your package manager
+   (for Debian/Ubuntu: `apt-get install tesseract-ocr`). The provided Docker
+   image includes this dependency as well.
+
 ## Required Environment Variables
 
 The application requires several variables to be present in your environment:


### PR DESCRIPTION
## Summary
- Install tesseract-ocr in Docker image for stand sheet OCR support
- Document tesseract requirement alongside poppler in README

## Testing
- `pytest tests/test_stand_sheet_scanning.py -q`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c5f1d19083249c624453085f2c24