### PR TITLE
Strip unit annotations from scanned sheet names

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -646,6 +646,7 @@ def _parse_scanned_sheet(ocr_data, event_location, threshold=80):
             else:
                 name_tokens.append(t)
         name = " ".join(name_tokens).lower()
+        name = re.sub(r"\s*\(.*?\)", "", name).strip()
         if name in item_map and len(numbers) >= 8:
             fields = {
                 "opening_count": (float(numbers[1]), num_confs[1] < threshold),

--- a/tests/test_stand_sheet_scanning.py
+++ b/tests/test_stand_sheet_scanning.py
@@ -102,7 +102,7 @@ def test_scan_stand_sheet(client, app, monkeypatch):
         "height": [0] * 9,
         "conf": [95] * 9,
         "text": [
-            "ScanItem",
+            "ScanItem (each)",
             "10",
             "8",
             "2",


### PR DESCRIPTION
## Summary
- Remove parenthesized unit text from OCR-parsed item names before item lookup
- Add regression test ensuring stand sheet scanning handles names with unit annotations

## Testing
- `pytest tests/test_stand_sheet_scanning.py::test_scan_stand_sheet -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4cc6c54248324ba19d9d527a4f84d