### PR TITLE
Log parsed stand sheet data

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -736,6 +736,12 @@ def scan_stand_sheet():
                 Image.open(img_path), output_type=pytesseract.Output.DICT
             )
             parsed = _parse_scanned_sheet(ocr_data, el)
+            current_app.logger.info(
+                "Parsed stand sheet for event %s location %s: %s",
+                event_id,
+                location_id,
+                parsed,
+            )
             parsed_sheets.append(
                 {
                     "event_id": event_id,


### PR DESCRIPTION
## Summary
- log parsed stand sheet data when scanning

## Testing
- `pytest -q` *(fails: tests/test_stand_sheet_scanning.py::test_scan_stand_sheet - assert None is not None)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cefb01e88324a8a40c3853bb20b8