### PR TITLE
Replace Tesseract OCR with EasyOCR helper

### DIFF
--- a/app/utils/standsheet_ocr.py
+++ b/app/utils/standsheet_ocr.py
@@ -1,0 +1,45 @@
+"""OCR helper for reading stand sheets using EasyOCR.
+
+This module lazily loads the EasyOCR model so importing this module does not
+require the heavy dependency to be immediately available.  The exposed
+``read_stand_sheet`` function returns data in a format similar to
+``pytesseract.image_to_data`` so existing parsing logic can remain unchanged.
+"""
+
+from typing import Dict, List
+
+_reader = None
+
+
+def _get_reader():
+    """Return a cached EasyOCR reader instance."""
+    global _reader
+    if _reader is None:
+        try:
+            import easyocr  # type: ignore
+        except ImportError as exc:
+            raise RuntimeError(
+                "easyocr is required to read stand sheets"
+            ) from exc
+        _reader = easyocr.Reader(["en"], gpu=False)
+    return _reader
+
+
+def read_stand_sheet(path: str) -> Dict[str, List]:
+    """Read an image file and return OCR data.
+
+    The returned dictionary contains ``text``, ``conf`` and ``line_num`` lists,
+    matching the structure produced by ``pytesseract.image_to_data``.
+    """
+
+    reader = _get_reader()
+    results = reader.readtext(path, detail=1)
+    data: Dict[str, List] = {"text": [], "conf": [], "line_num": []}
+    for idx, _res in enumerate(results, start=1):
+        # Each result is (bbox, text, confidence)
+        _, txt, conf = _res
+        data["text"].append(txt)
+        # EasyOCR returns confidence in range [0,1]; scale to [0,100]
+        data["conf"].append(float(conf) * 100)
+        data["line_num"].append(idx)
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pandas==2.2.2
 reportlab==4.4.2
 pdfplumber==0.9.0
 twilio==9.0.0
-pytesseract==0.3.10
+easyocr==1.7.1  # handwriting-capable OCR
 opencv-python-headless==4.10.0.84
 qrcode==7.4.2
 pdf2image==1.17.0  # requires Poppler

--- a/tests/test_stand_sheet_scanning.py
+++ b/tests/test_stand_sheet_scanning.py
@@ -90,17 +90,17 @@ def test_scan_stand_sheet(client, app, monkeypatch):
         "app.routes.event_routes.convert_from_path", lambda *a, **k: [img]
     )
     dummy_data = {
-        "level": [1] * 8,
-        "page_num": [1] * 8,
-        "block_num": [1] * 8,
-        "par_num": [1] * 8,
-        "line_num": [1] * 8,
-        "word_num": list(range(1, 9)),
-        "left": [0] * 8,
-        "top": [0] * 8,
-        "width": [0] * 8,
-        "height": [0] * 8,
-        "conf": [95] * 8,
+        "level": [1] * 9,
+        "page_num": [1] * 9,
+        "block_num": [1] * 9,
+        "par_num": [1] * 9,
+        "line_num": [1] * 9,
+        "word_num": list(range(1, 10)),
+        "left": [0] * 9,
+        "top": [0] * 9,
+        "width": [0] * 9,
+        "height": [0] * 9,
+        "conf": [95] * 9,
         "text": [
             "ScanItem (each)",
             "10",
@@ -110,10 +110,12 @@ def test_scan_stand_sheet(client, app, monkeypatch):
             "0",
             "0",
             "4",
+            "0",
         ],
     }
     monkeypatch.setattr(
-        "pytesseract.image_to_data", lambda *_args, **_kwargs: dummy_data
+        "app.routes.event_routes.read_stand_sheet",
+        lambda *_args, **_kwargs: dummy_data,
     )
 
     with client:


### PR DESCRIPTION
## Summary
- swap out pytesseract for EasyOCR in requirements and routing
- add `read_stand_sheet` helper wrapping EasyOCR output
- adjust stand sheet scan route and tests to use the new helper

## Testing
- `pre-commit run --files requirements.txt app/utils/standsheet_ocr.py app/routes/event_routes.py tests/test_stand_sheet_scanning.py`
- `pytest tests/test_stand_sheet_scanning.py`

------
https://chatgpt.com/codex/tasks/task_e_68c4e7cacee88324bc7316bf6203f245