### PR TITLE
Improve stand sheet OCR with Tesseract fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ You can perform the steps below manually or run one of the setup scripts provide
    (for Debian/Ubuntu: `apt-get install poppler-utils`). The Docker image
    provided with this project installs this dependency automatically.
 
-   OCR for stand sheets also relies on the Tesseract engine. Install
-   `tesseract-ocr` via your package manager
+   OCR for stand sheets primarily relies on the Tesseract engine via the
+   `pytesseract` library and falls back to EasyOCR for handwritten numbers.
+   Install `tesseract-ocr` via your package manager
    (for Debian/Ubuntu: `apt-get install tesseract-ocr`). The provided Docker
    image includes this dependency as well.
 

--- a/app/utils/standsheet_ocr.py
+++ b/app/utils/standsheet_ocr.py
@@ -1,12 +1,16 @@
-"""OCR helper for reading stand sheets using EasyOCR.
+"""OCR helper for reading stand sheets.
 
-This module lazily loads the EasyOCR model so importing this module does not
-require the heavy dependency to be immediately available.  The exposed
-``read_stand_sheet`` function returns data in a format similar to
-``pytesseract.image_to_data`` so existing parsing logic can remain unchanged.
+This module first attempts to read stand sheets using the Tesseract engine via
+``pytesseract`` which excels at printed text. If Tesseract is unavailable or
+fails to return any results, it falls back to EasyOCR which is better at
+deciphering handwritten numbers. The exposed ``read_stand_sheet`` function
+returns data in a format similar to ``pytesseract.image_to_data`` so existing
+parsing logic can remain unchanged.
 """
 
 from typing import Dict, List
+
+import cv2
 
 _reader = None
 
@@ -17,12 +21,33 @@ def _get_reader():
     if _reader is None:
         try:
             import easyocr  # type: ignore
-        except ImportError as exc:
+        except ImportError as exc:  # pragma: no cover - runtime dependency
             raise RuntimeError(
-                "easyocr is required to read stand sheets"
+                "easyocr is required to read stand sheets",
             ) from exc
         _reader = easyocr.Reader(["en"], gpu=False)
     return _reader
+
+
+def _tesseract_data(path: str):
+    """Return OCR data from Tesseract or ``None`` if unavailable."""
+    try:
+        import pytesseract  # type: ignore
+        from pytesseract import Output
+    except Exception:  # pragma: no cover - import error handled below
+        return None
+
+    img = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        return None
+    # Apply adaptive threshold to improve character recognition
+    _, img = cv2.threshold(img, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    try:
+        return pytesseract.image_to_data(
+            img, output_type=Output.DICT, config="--oem 3 --psm 6"
+        )
+    except Exception:  # pragma: no cover - OCR failure
+        return None
 
 
 def read_stand_sheet(path: str) -> Dict[str, List]:
@@ -32,14 +57,27 @@ def read_stand_sheet(path: str) -> Dict[str, List]:
     matching the structure produced by ``pytesseract.image_to_data``.
     """
 
+    data: Dict[str, List] = {"text": [], "conf": [], "line_num": []}
+
+    tess = _tesseract_data(path)
+    if tess:
+        for text, conf, line in zip(
+            tess["text"], tess["conf"], tess["line_num"]
+        ):
+            if text.strip():
+                data["text"].append(text)
+                data["conf"].append(float(conf))
+                data["line_num"].append(int(line))
+
+    if data["text"]:
+        return data
+
     reader = _get_reader()
     results = reader.readtext(path, detail=1)
-    data: Dict[str, List] = {"text": [], "conf": [], "line_num": []}
-    for idx, _res in enumerate(results, start=1):
-        # Each result is (bbox, text, confidence)
-        _, txt, conf = _res
-        data["text"].append(txt)
-        # EasyOCR returns confidence in range [0,1]; scale to [0,100]
-        data["conf"].append(float(conf) * 100)
-        data["line_num"].append(idx)
+    for idx, (_box, txt, conf) in enumerate(results, start=1):
+        if txt.strip():
+            data["text"].append(txt)
+            # EasyOCR returns confidence in range [0,1]; scale to [0,100]
+            data["conf"].append(float(conf) * 100)
+            data["line_num"].append(idx)
     return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ pandas==2.2.2
 reportlab==4.4.2
 pdfplumber==0.9.0
 twilio==9.0.0
+Pillow==10.4.0
+pytesseract==0.3.10  # OCR for printed text
 easyocr==1.7.1  # handwriting-capable OCR
 opencv-python-headless==4.10.0.84
 qrcode==7.4.2

--- a/tests/test_standsheet_ocr.py
+++ b/tests/test_standsheet_ocr.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+from PIL import Image
+
+from app.utils.standsheet_ocr import read_stand_sheet
+
+
+def _dummy_image(tmp_path: Path) -> str:
+    img_path = tmp_path / "dummy.png"
+    Image.new("RGB", (10, 10), "white").save(img_path)
+    return str(img_path)
+
+
+def test_uses_tesseract_when_available(monkeypatch, tmp_path):
+    path = _dummy_image(tmp_path)
+
+    dummy = {"text": ["123"], "conf": ["85"], "line_num": ["1"]}
+    monkeypatch.setattr(
+        "app.utils.standsheet_ocr._tesseract_data", lambda p: dummy
+    )
+    monkeypatch.setattr(
+        "app.utils.standsheet_ocr._get_reader",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("EasyOCR should not be used")
+        ),
+    )
+
+    result = read_stand_sheet(path)
+    assert result == {"text": ["123"], "conf": [85.0], "line_num": [1]}
+
+
+def test_falls_back_to_easyocr(monkeypatch, tmp_path):
+    path = _dummy_image(tmp_path)
+    monkeypatch.setattr(
+        "app.utils.standsheet_ocr._tesseract_data", lambda p: None
+    )
+
+    class DummyReader:
+        def readtext(self, _path, detail=1):
+            return [((0, 0, 0, 0), "456", 0.9)]
+
+    monkeypatch.setattr(
+        "app.utils.standsheet_ocr._get_reader", lambda: DummyReader()
+    )
+
+    result = read_stand_sheet(path)
+    assert result == {"text": ["456"], "conf": [90.0], "line_num": [1]}


### PR DESCRIPTION
## Summary
- improve stand sheet OCR by first using Tesseract and falling back to EasyOCR for handwriting
- document Tesseract/EasyOCR combo and add pytesseract dependency
- test the new OCR helper

## Testing
- `pre-commit run --files app/utils/standsheet_ocr.py tests/test_standsheet_ocr.py requirements.txt README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4f2a842048324bc131a43e650b947