### PR TITLE
Enhance stand sheet OCR parsing with position data

### DIFF
--- a/tests/test_standsheet_ocr.py
+++ b/tests/test_standsheet_ocr.py
@@ -14,7 +14,15 @@ def _dummy_image(tmp_path: Path) -> str:
 def test_uses_tesseract_when_available(monkeypatch, tmp_path):
     path = _dummy_image(tmp_path)
 
-    dummy = {"text": ["123"], "conf": ["85"], "line_num": ["1"]}
+    dummy = {
+        "text": ["123"],
+        "conf": ["85"],
+        "line_num": ["1"],
+        "left": ["1"],
+        "top": ["2"],
+        "width": ["3"],
+        "height": ["4"],
+    }
     monkeypatch.setattr(
         "app.utils.standsheet_ocr._tesseract_data", lambda p: dummy
     )
@@ -26,7 +34,15 @@ def test_uses_tesseract_when_available(monkeypatch, tmp_path):
     )
 
     result = read_stand_sheet(path)
-    assert result == {"text": ["123"], "conf": [85.0], "line_num": [1]}
+    assert result == {
+        "text": ["123"],
+        "conf": [85.0],
+        "line_num": [1],
+        "left": [1],
+        "top": [2],
+        "width": [3],
+        "height": [4],
+    }
 
 
 def test_falls_back_to_easyocr(monkeypatch, tmp_path):
@@ -37,11 +53,20 @@ def test_falls_back_to_easyocr(monkeypatch, tmp_path):
 
     class DummyReader:
         def readtext(self, _path, detail=1):
-            return [((0, 0, 0, 0), "456", 0.9)]
+            box = [(0, 0), (10, 0), (10, 10), (0, 10)]
+            return [(box, "456", 0.9)]
 
     monkeypatch.setattr(
         "app.utils.standsheet_ocr._get_reader", lambda: DummyReader()
     )
 
     result = read_stand_sheet(path)
-    assert result == {"text": ["456"], "conf": [90.0], "line_num": [1]}
+    assert result == {
+        "text": ["456"],
+        "conf": [90.0],
+        "line_num": [1],
+        "left": [0],
+        "top": [0],
+        "width": [10],
+        "height": [10],
+    }


### PR DESCRIPTION
## Summary
- return positional information from Tesseract/EasyOCR helpers
- parse stand sheet tokens by row and column positions, flagging missing fields
- cover partial and misaligned rows in tests

## Testing
- `pre-commit run --files app/utils/standsheet_ocr.py app/routes/event_routes.py tests/test_standsheet_ocr.py tests/test_stand_sheet_scanning.py`
- `pytest tests/test_standsheet_ocr.py tests/test_stand_sheet_scanning.py`


------
https://chatgpt.com/codex/tasks/task_e_68c4f8b51bc48324bc34f9e39bcb65f0