### PR TITLE
Add PaddleOCR fallback for stand sheet OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ You can perform the steps below manually or run one of the setup scripts provide
    `pytesseract` library and falls back to EasyOCR for handwritten numbers.
    Install `tesseract-ocr` via your package manager
    (for Debian/Ubuntu: `apt-get install tesseract-ocr`). The provided Docker
-   image includes this dependency as well.
+   image includes this dependency as well. For a final fallback the
+   application can use PaddleOCR when both engines return low confidence.
+   Install the CPU versions of `paddlepaddle` and `paddleocr` via pip to
+   enable this optional dependency.
 
 ## Required Environment Variables
 

--- a/app/utils/standsheet_ocr.py
+++ b/app/utils/standsheet_ocr.py
@@ -12,7 +12,10 @@ from typing import Dict, List
 
 import cv2
 
+CONF_THRESHOLD = 50.0
+
 _reader = None
+_paddle_reader = None
 
 
 def _get_reader():
@@ -27,6 +30,20 @@ def _get_reader():
             ) from exc
         _reader = easyocr.Reader(["en"], gpu=False)
     return _reader
+
+
+def _get_paddle_reader():
+    """Return a cached PaddleOCR reader instance."""
+    global _paddle_reader
+    if _paddle_reader is None:
+        try:
+            from paddleocr import PaddleOCR  # type: ignore
+        except ImportError as exc:  # pragma: no cover - runtime dependency
+            raise RuntimeError(
+                "paddleocr is required to read stand sheets",
+            ) from exc
+        _paddle_reader = PaddleOCR(use_angle_cls=False, lang="en", show_log=False)
+    return _paddle_reader
 
 
 def _tesseract_data(path: str):
@@ -96,8 +113,11 @@ def read_stand_sheet(path: str) -> Dict[str, List]:
                 data["width"].append(int(width))
                 data["height"].append(int(height))
 
-    if data["text"]:
+    if data["text"] and max(data["conf"]) >= CONF_THRESHOLD:
         return data
+
+    for key in data:
+        data[key].clear()
 
     reader = _get_reader()
     results = reader.readtext(path, detail=1)
@@ -105,6 +125,35 @@ def read_stand_sheet(path: str) -> Dict[str, List]:
         if txt.strip():
             data["text"].append(txt)
             # EasyOCR returns confidence in range [0,1]; scale to [0,100]
+            data["conf"].append(float(conf) * 100)
+            data["line_num"].append(idx)
+            xs = [p[0] for p in box]
+            ys = [p[1] for p in box]
+            left = min(xs)
+            top = min(ys)
+            width = max(xs) - left
+            height = max(ys) - top
+            data["left"].append(int(left))
+            data["top"].append(int(top))
+            data["width"].append(int(width))
+            data["height"].append(int(height))
+
+    if data["text"] and max(data["conf"]) >= CONF_THRESHOLD:
+        return data
+
+    for key in data:
+        data[key].clear()
+
+    reader = _get_paddle_reader()
+    img = cv2.imread(path, cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        return data
+    _, img = cv2.threshold(img, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    results = reader.ocr(img)
+    for idx, (box, (txt, conf)) in enumerate(results, start=1):
+        if txt.strip():
+            data["text"].append(txt)
+            # PaddleOCR returns confidence in [0,1]; scale to [0,100]
             data["conf"].append(float(conf) * 100)
             data["line_num"].append(idx)
             xs = [p[0] for p in box]

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,5 @@ easyocr==1.7.1  # handwriting-capable OCR
 opencv-python-headless==4.10.0.84
 qrcode==7.4.2
 pdf2image==1.17.0  # requires Poppler
+paddlepaddle==2.6.1  # PaddleOCR dependency
+paddleocr==2.7.0.3  # optional fallback OCR

--- a/tests/test_standsheet_ocr.py
+++ b/tests/test_standsheet_ocr.py
@@ -70,3 +70,45 @@ def test_falls_back_to_easyocr(monkeypatch, tmp_path):
         "width": [10],
         "height": [10],
     }
+
+
+def test_falls_back_to_paddleocr(monkeypatch, tmp_path):
+    path = _dummy_image(tmp_path)
+
+    low_conf = {
+        "text": ["123"],
+        "conf": ["10"],
+        "line_num": ["1"],
+        "left": ["1"],
+        "top": ["2"],
+        "width": ["3"],
+        "height": ["4"],
+    }
+    monkeypatch.setattr("app.utils.standsheet_ocr._tesseract_data", lambda p: low_conf)
+
+    class DummyEasyReader:
+        def readtext(self, _path, detail=1):
+            box = [(0, 0), (10, 0), (10, 10), (0, 10)]
+            return [(box, "456", 0.2)]
+
+    monkeypatch.setattr("app.utils.standsheet_ocr._get_reader", lambda: DummyEasyReader())
+
+    class DummyPaddleReader:
+        def ocr(self, _img):
+            box = [[0, 0], [10, 0], [10, 10], [0, 10]]
+            return [[box, ("789", 0.95)]]
+
+    monkeypatch.setattr(
+        "app.utils.standsheet_ocr._get_paddle_reader", lambda: DummyPaddleReader()
+    )
+
+    result = read_stand_sheet(path)
+    assert result == {
+        "text": ["789"],
+        "conf": [95.0],
+        "line_num": [1],
+        "left": [0],
+        "top": [0],
+        "width": [10],
+        "height": [10],
+    }


### PR DESCRIPTION
## Summary
- add PaddleOCR import with cached reader and confidence threshold logic
- trigger PaddleOCR when Tesseract and EasyOCR confidence is low
- document optional PaddleOCR dependency and update requirements
- test new PaddleOCR path and confidence scaling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4fc021e9083249f1ade29d370ec4c