### PR TITLE
Streamline OCR dependencies to PaddleOCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,9 @@ You can perform the steps below manually or run one of the setup scripts provide
    (for Debian/Ubuntu: `apt-get install poppler-utils`). The Docker image
    provided with this project installs this dependency automatically.
 
-   OCR for stand sheets primarily relies on the Tesseract engine via the
-   `pytesseract` library and falls back to EasyOCR for handwritten numbers.
-   Install `tesseract-ocr` via your package manager
-   (for Debian/Ubuntu: `apt-get install tesseract-ocr`). The provided Docker
-   image includes this dependency as well. For a final fallback the
-   application can use PaddleOCR when both engines return low confidence.
-   Install the CPU versions of `paddlepaddle` and `paddleocr` via pip to
-   enable this optional dependency.
+    OCR for stand sheets is handled by PaddleOCR.
+    Install the CPU versions of `paddlepaddle` and `paddleocr` via pip to
+    enable this feature. The provided Docker image includes these packages.
 
 ## Required Environment Variables
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,10 +23,8 @@ reportlab==4.4.2
 pdfplumber==0.9.0
 twilio==9.0.0
 Pillow==10.4.0
-pytesseract==0.3.10  # OCR for printed text
-easyocr==1.7.1  # handwriting-capable OCR
 opencv-python-headless==4.10.0.84
 qrcode==7.4.2
 pdf2image==1.17.0  # requires Poppler
 paddlepaddle==2.6.1  # PaddleOCR dependency
-paddleocr==2.7.0.3  # optional fallback OCR
+paddleocr==2.7.0.3  # OCR engine


### PR DESCRIPTION
## Summary
- remove pytesseract and EasyOCR from requirements, leaving PaddleOCR
- update README to document only PaddleOCR for OCR

## Testing
- `pre-commit run --files requirements.txt README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4fe2921c88324a90590afc9557582