### PR TITLE
Add search-based item selector for purchase orders

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -445,7 +445,7 @@ class ImportForm(FlaskForm):
 
 
 class POItemForm(FlaskForm):
-    item = SelectField("Item", coerce=int)
+    item = HiddenField("Item")
     product = SelectField(
         "Product", coerce=int, validators=[Optional()], validate_choice=False
     )
@@ -473,11 +473,9 @@ class PurchaseOrderForm(FlaskForm):
             (v.id, f"{v.first_name} {v.last_name}")
             for v in Vendor.query.filter_by(archived=False).all()
         ]
-        items = load_item_choices()
         units = load_unit_choices()
         products = [(p.id, p.name) for p in Product.query.all()]
         for item_form in self.items:
-            item_form.item.choices = items
             item_form.product.choices = products
             item_form.unit.choices = units
 

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -169,11 +169,26 @@ def create_purchase_order():
         flash("Purchase order created successfully!", "success")
         return redirect(url_for("purchase.view_purchase_orders"))
 
+    selected_item_ids = []
+    for item_form in form.items:
+        if item_form.item.data:
+            try:
+                selected_item_ids.append(int(item_form.item.data))
+            except (TypeError, ValueError):
+                continue
+    item_lookup = {}
+    if selected_item_ids:
+        item_lookup = {
+            item.id: item.name
+            for item in Item.query.filter(Item.id.in_(selected_item_ids)).all()
+        }
+
     codes = GLCode.query.filter(GLCode.code.like("5%"))
     return render_template(
         "purchase_orders/create_purchase_order.html",
         form=form,
         gl_codes=codes,
+        item_lookup=item_lookup,
     )
 
 
@@ -228,15 +243,24 @@ def edit_purchase_order(po_id):
         for i, poi in enumerate(po.items):
             if len(form.items) <= i:
                 form.items.append_entry()
-        for item_form in form.items:
-            item_form.item.choices = [
-                (i.id, i.name)
-                for i in Item.query.filter_by(archived=False).all()
-            ]
         for i, poi in enumerate(po.items):
             form.items[i].item.data = poi.item_id
             form.items[i].unit.data = poi.unit_id
             form.items[i].quantity.data = poi.quantity
+
+    selected_item_ids = []
+    for item_form in form.items:
+        if item_form.item.data:
+            try:
+                selected_item_ids.append(int(item_form.item.data))
+            except (TypeError, ValueError):
+                continue
+    item_lookup = {}
+    if selected_item_ids:
+        item_lookup = {
+            item.id: item.name
+            for item in Item.query.filter(Item.id.in_(selected_item_ids)).all()
+        }
 
     codes = GLCode.query.filter(GLCode.code.like("5%"))
     return render_template(
@@ -244,6 +268,7 @@ def edit_purchase_order(po_id):
         form=form,
         po=po,
         gl_codes=codes,
+        item_lookup=item_lookup,
     )
 
 

--- a/app/static/js/purchase_order_form.js
+++ b/app/static/js/purchase_order_form.js
@@ -1,0 +1,514 @@
+(function () {
+    "use strict";
+
+    function toNumber(value) {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
+
+    function initPurchaseOrderForm(config) {
+        const container = config && config.container ? config.container : null;
+        if (!container) {
+            return;
+        }
+
+        const addRowButton = config.addRowButton || null;
+        const quickAddButton = config.quickAddButton || null;
+        const saveNewItemButton = config.saveNewItemButton || null;
+        const newItemModalEl = config.newItemModal || null;
+        const searchTimers = new WeakMap();
+
+        let nextIndex = toNumber(
+            config.nextIndex !== undefined
+                ? config.nextIndex
+                : container.dataset.nextIndex
+        );
+        if (nextIndex < container.querySelectorAll(".item-row").length) {
+            nextIndex = container.querySelectorAll(".item-row").length;
+        }
+        container.dataset.nextIndex = String(nextIndex);
+
+        let newItemModal = null;
+        if (newItemModalEl && typeof bootstrap !== "undefined") {
+            newItemModal =
+                bootstrap.Modal.getInstance(newItemModalEl) ||
+                new bootstrap.Modal(newItemModalEl);
+        }
+
+        function closeAllSuggestionLists(exceptList) {
+            container.querySelectorAll(".suggestion-list").forEach((list) => {
+                if (list !== exceptList) {
+                    list.classList.add("d-none");
+                }
+            });
+        }
+
+        function clearSuggestions(list) {
+            if (list) {
+                list.innerHTML = "";
+                list.classList.add("d-none");
+            }
+        }
+
+        function clearUnits(unitSelect) {
+            if (unitSelect) {
+                unitSelect.innerHTML = "";
+                unitSelect.dataset.selected = "";
+            }
+        }
+
+        function fetchUnits(itemId, unitSelect, selectedUnitId) {
+            if (!unitSelect || !itemId) {
+                clearUnits(unitSelect);
+                return;
+            }
+
+            fetch(`/items/${itemId}/units`)
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error("Failed to load units");
+                    }
+                    return response.json();
+                })
+                .then((data) => {
+                    const options = data.units
+                        .map((unit) => {
+                            const shouldSelect = selectedUnitId
+                                ? parseInt(selectedUnitId, 10) === unit.id
+                                : unit.receiving_default;
+                            const plural = unit.factor !== 1 ? "s" : "";
+                            return `
+                                <option value="${unit.id}" ${
+                                shouldSelect ? "selected" : ""
+                            }>
+                                    ${unit.name} of ${unit.factor} ${data.base_unit}${plural}
+                                </option>
+                            `;
+                        })
+                        .join("");
+                    unitSelect.innerHTML = options;
+                    unitSelect.dataset.selected = "";
+                })
+                .catch(() => {
+                    clearUnits(unitSelect);
+                });
+        }
+
+        function createRowElement(index, options = {}) {
+            const row = document.createElement("div");
+            row.classList.add("row", "g-2", "mt-2", "item-row", "align-items-center");
+
+            const itemCol = document.createElement("div");
+            itemCol.classList.add("col", "position-relative");
+
+            const searchInput = document.createElement("input");
+            searchInput.type = "text";
+            searchInput.name = `items-${index}-item-label`;
+            searchInput.classList.add("form-control", "item-search");
+            searchInput.placeholder = "Search for an item";
+            searchInput.autocomplete = "off";
+            if (options.itemName) {
+                searchInput.value = options.itemName;
+            }
+            itemCol.appendChild(searchInput);
+
+            const hiddenInput = document.createElement("input");
+            hiddenInput.type = "hidden";
+            hiddenInput.name = `items-${index}-item`;
+            hiddenInput.classList.add("item-id-field");
+            if (options.itemId) {
+                hiddenInput.value = options.itemId;
+            }
+            itemCol.appendChild(hiddenInput);
+
+            const suggestionList = document.createElement("div");
+            suggestionList.classList.add(
+                "list-group",
+                "suggestion-list",
+                "d-none",
+                "position-absolute",
+                "w-100"
+            );
+            suggestionList.style.zIndex = "1000";
+            suggestionList.style.maxHeight = "200px";
+            suggestionList.style.overflowY = "auto";
+            itemCol.appendChild(suggestionList);
+
+            const unitCol = document.createElement("div");
+            unitCol.classList.add("col");
+            const unitSelect = document.createElement("select");
+            unitSelect.name = `items-${index}-unit`;
+            unitSelect.classList.add("form-control", "unit-select");
+            unitSelect.dataset.selected = options.unitId ? String(options.unitId) : "";
+            unitCol.appendChild(unitSelect);
+
+            const quantityCol = document.createElement("div");
+            quantityCol.classList.add("col");
+            const quantityInput = document.createElement("input");
+            quantityInput.type = "number";
+            quantityInput.step = "any";
+            quantityInput.name = `items-${index}-quantity`;
+            quantityInput.classList.add("form-control", "quantity");
+            if (options.quantity !== undefined && options.quantity !== null) {
+                quantityInput.value = options.quantity;
+            }
+            quantityCol.appendChild(quantityInput);
+
+            const removeCol = document.createElement("div");
+            removeCol.classList.add("col-auto");
+            const removeButton = document.createElement("button");
+            removeButton.type = "button";
+            removeButton.classList.add("btn", "btn-danger", "remove-item");
+            removeButton.textContent = "Remove";
+            removeCol.appendChild(removeButton);
+
+            row.append(itemCol, unitCol, quantityCol, removeCol);
+            return row;
+        }
+
+        function addRow(options = {}) {
+            const row = createRowElement(nextIndex, options);
+            container.appendChild(row);
+            nextIndex += 1;
+            container.dataset.nextIndex = String(nextIndex);
+
+            const unitSelect = row.querySelector(".unit-select");
+            if (options.itemId) {
+                fetchUnits(options.itemId, unitSelect, options.unitId || null);
+            }
+
+            if (!options.itemId) {
+                const searchInput = row.querySelector(".item-search");
+                if (searchInput) {
+                    searchInput.focus();
+                }
+            }
+
+            return row;
+        }
+
+        function performSearch(input, term) {
+            const row = input.closest(".item-row");
+            if (!row) {
+                return;
+            }
+            const suggestionList = row.querySelector(".suggestion-list");
+            if (!suggestionList) {
+                return;
+            }
+
+            fetch(`/items/search?term=${encodeURIComponent(term)}`)
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error("Search failed");
+                    }
+                    return response.json();
+                })
+                .then((items) => {
+                    if (input.value.trim() !== term) {
+                        return;
+                    }
+
+                    suggestionList.innerHTML = "";
+                    if (!items.length) {
+                        suggestionList.classList.add("d-none");
+                        return;
+                    }
+
+                    items.forEach((item) => {
+                        const option = document.createElement("button");
+                        option.type = "button";
+                        option.className =
+                            "list-group-item list-group-item-action suggestion-option";
+                        option.textContent = item.name;
+                        option.dataset.itemId = item.id;
+                        option.dataset.itemName = item.name;
+                        suggestionList.appendChild(option);
+                    });
+
+                    suggestionList.classList.remove("d-none");
+                })
+                .catch(() => {
+                    suggestionList.classList.add("d-none");
+                });
+        }
+
+        function handleSearchInput(input) {
+            const row = input.closest(".item-row");
+            if (!row) {
+                return;
+            }
+            const hiddenField = row.querySelector(".item-id-field");
+            const unitSelect = row.querySelector(".unit-select");
+            const suggestionList = row.querySelector(".suggestion-list");
+
+            if (hiddenField) {
+                hiddenField.value = "";
+            }
+            clearUnits(unitSelect);
+            closeAllSuggestionLists(suggestionList);
+
+            const term = input.value.trim();
+            if (!term) {
+                clearSuggestions(suggestionList);
+                return;
+            }
+
+            if (searchTimers.has(input)) {
+                clearTimeout(searchTimers.get(input));
+            }
+            const timer = setTimeout(() => {
+                performSearch(input, term);
+            }, 150);
+            searchTimers.set(input, timer);
+        }
+
+        function handleSuggestionSelection(option) {
+            const row = option.closest(".item-row");
+            if (!row) {
+                return;
+            }
+
+            const hiddenField = row.querySelector(".item-id-field");
+            const searchInput = row.querySelector(".item-search");
+            const unitSelect = row.querySelector(".unit-select");
+            const suggestionList = row.querySelector(".suggestion-list");
+
+            if (hiddenField) {
+                hiddenField.value = option.dataset.itemId || "";
+            }
+            if (searchInput) {
+                searchInput.value = option.dataset.itemName || "";
+            }
+            clearSuggestions(suggestionList);
+            fetchUnits(option.dataset.itemId, unitSelect);
+
+            const quantityInput = row.querySelector(".quantity");
+            if (quantityInput) {
+                quantityInput.focus();
+            }
+        }
+
+        function handleSearchKeydown(event) {
+            const input = event.target;
+            const row = input.closest(".item-row");
+            if (!row) {
+                return;
+            }
+            const suggestionList = row.querySelector(".suggestion-list");
+            if (!suggestionList) {
+                return;
+            }
+
+            if (event.key === "Enter") {
+                const firstOption = suggestionList.querySelector(".suggestion-option");
+                if (!suggestionList.classList.contains("d-none") && firstOption) {
+                    event.preventDefault();
+                    handleSuggestionSelection(firstOption);
+                }
+            } else if (event.key === "Escape") {
+                suggestionList.classList.add("d-none");
+            }
+        }
+
+        function handleQuantityKeydown(event) {
+            if (event.key !== "Tab" || event.shiftKey) {
+                return;
+            }
+            const currentRow = event.target.closest(".item-row");
+            if (!currentRow) {
+                return;
+            }
+            const nextRow = currentRow.nextElementSibling;
+            if (!nextRow) {
+                return;
+            }
+            const nextQuantity = nextRow.querySelector(".quantity");
+            if (nextQuantity) {
+                event.preventDefault();
+                nextQuantity.focus();
+            }
+        }
+
+        if (addRowButton) {
+            addRowButton.addEventListener("click", (event) => {
+                event.preventDefault();
+                addRow();
+            });
+        }
+
+        if (quickAddButton && newItemModal) {
+            quickAddButton.addEventListener("click", () => {
+                newItemModal.show();
+            });
+        }
+
+        if (saveNewItemButton) {
+            saveNewItemButton.addEventListener("click", () => {
+                const nameInput = document.getElementById("new-item-name");
+                const glCodeSelect = document.getElementById("new-item-gl-code");
+                const baseUnitSelect = document.getElementById("new-item-base-unit");
+                const receivingUnitInput = document.getElementById(
+                    "new-item-receiving-unit"
+                );
+                const receivingFactorInput = document.getElementById(
+                    "new-item-receiving-factor"
+                );
+                const transferUnitInput = document.getElementById(
+                    "new-item-transfer-unit"
+                );
+                const transferFactorInput = document.getElementById(
+                    "new-item-transfer-factor"
+                );
+                const csrfTokenInput = document.querySelector(
+                    'input[name="csrf_token"]'
+                );
+
+                const name = nameInput ? nameInput.value.trim() : "";
+                const glCode = glCodeSelect ? glCodeSelect.value : null;
+                const baseUnit = baseUnitSelect ? baseUnitSelect.value : null;
+                const receivingUnit = receivingUnitInput
+                    ? receivingUnitInput.value.trim()
+                    : "";
+                const receivingFactor = receivingFactorInput
+                    ? parseFloat(receivingFactorInput.value) || 0
+                    : 0;
+                const transferUnit = transferUnitInput
+                    ? transferUnitInput.value.trim()
+                    : "";
+                const transferFactor = transferFactorInput
+                    ? parseFloat(transferFactorInput.value) || 0
+                    : 0;
+                const csrfToken = csrfTokenInput ? csrfTokenInput.value : null;
+
+                if (
+                    !name ||
+                    !receivingUnit ||
+                    !transferUnit ||
+                    receivingFactor <= 0 ||
+                    transferFactor <= 0
+                ) {
+                    return;
+                }
+
+                fetch("/items/quick_add", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-CSRFToken": csrfToken || "",
+                    },
+                    body: JSON.stringify({
+                        name,
+                        purchase_gl_code: glCode,
+                        base_unit: baseUnit,
+                        receiving_unit: receivingUnit,
+                        receiving_factor: receivingFactor,
+                        transfer_unit: transferUnit,
+                        transfer_factor: transferFactor,
+                    }),
+                })
+                    .then((response) => {
+                        if (!response.ok) {
+                            throw new Error("Unable to create item");
+                        }
+                        return response.json();
+                    })
+                    .then((data) => {
+                        if (!data || !data.id) {
+                            return;
+                        }
+                        const row = addRow({
+                            itemId: data.id,
+                            itemName: data.name,
+                        });
+                        const unitSelect = row.querySelector(".unit-select");
+                        fetchUnits(data.id, unitSelect);
+                        const quantityInput = row.querySelector(".quantity");
+                        if (quantityInput) {
+                            quantityInput.focus();
+                        }
+
+                        if (nameInput) {
+                            nameInput.value = "";
+                        }
+                        if (receivingUnitInput) {
+                            receivingUnitInput.value = "";
+                        }
+                        if (receivingFactorInput) {
+                            receivingFactorInput.value = "1";
+                        }
+                        if (transferUnitInput) {
+                            transferUnitInput.value = "";
+                        }
+                        if (transferFactorInput) {
+                            transferFactorInput.value = "1";
+                        }
+
+                        if (newItemModal) {
+                            newItemModal.hide();
+                        }
+                    })
+                    .catch(() => {
+                        /* Silent failure keeps UI responsive */
+                    });
+            });
+        }
+
+        container.addEventListener("input", (event) => {
+            if (event.target.classList.contains("item-search")) {
+                handleSearchInput(event.target);
+            }
+        });
+
+        container.addEventListener("focusin", (event) => {
+            if (event.target.classList.contains("item-search")) {
+                const row = event.target.closest(".item-row");
+                if (!row) {
+                    return;
+                }
+                const suggestionList = row.querySelector(".suggestion-list");
+                if (suggestionList && suggestionList.children.length) {
+                    closeAllSuggestionLists(suggestionList);
+                    suggestionList.classList.remove("d-none");
+                }
+            }
+        });
+
+        container.addEventListener("keydown", (event) => {
+            if (event.target.classList.contains("item-search")) {
+                handleSearchKeydown(event);
+            } else if (event.target.classList.contains("quantity")) {
+                handleQuantityKeydown(event);
+            }
+        });
+
+        container.addEventListener("click", (event) => {
+            if (event.target.classList.contains("remove-item")) {
+                event.target.closest(".row").remove();
+            } else if (event.target.classList.contains("suggestion-option")) {
+                handleSuggestionSelection(event.target);
+            }
+        });
+
+        document.addEventListener("click", (event) => {
+            if (!container.contains(event.target)) {
+                closeAllSuggestionLists();
+            }
+        });
+
+        Array.from(container.querySelectorAll(".item-row")).forEach((row) => {
+            const hiddenField = row.querySelector(".item-id-field");
+            const unitSelect = row.querySelector(".unit-select");
+            const selectedUnit = unitSelect ? unitSelect.dataset.selected : null;
+            if (hiddenField && hiddenField.value) {
+                fetchUnits(hiddenField.value, unitSelect, selectedUnit || null);
+            }
+        });
+
+        return {
+            addRow,
+        };
+    }
+
+    window.initPurchaseOrderForm = initPurchaseOrderForm;
+})();

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -22,11 +22,21 @@
         </div>
         <h4>Items</h4>
         <button id="quick-add-item" type="button" class="btn btn-link p-0">Create New Item</button>
-        <div id="items">
+        <div id="items" data-next-index="{{ form.items|length }}">
         {% for item in form.items %}
+        {% set item_id = item.item.data %}
+        {% set selected_name = '' %}
+        {% if item_id %}
+            {% set selected_name = item_lookup.get(item_id|int, '') %}
+        {% endif %}
+        {% set input_value = request.form.get('items-' ~ loop.index0 ~ '-item-label', selected_name) %}
         <div class="row g-2 mt-2 item-row align-items-center">
-            <div class="col">{{ item.item(class="form-control item-select") }}</div>
-            <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select"></select></div>
+            <div class="col position-relative">
+                <input type="text" name="items-{{ loop.index0 }}-item-label" class="form-control item-search" placeholder="Search for an item" autocomplete="off" value="{{ input_value }}">
+                {{ item.item(class="item-id-field") }}
+                <div class="list-group suggestion-list d-none position-absolute w-100" style="z-index: 1000; max-height: 200px; overflow-y: auto;"></div>
+            </div>
+            <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data or '' }}"></select></div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col-auto">
                 <button type="button" class="btn btn-danger remove-item">Remove</button>
@@ -93,124 +103,17 @@
     </div>
 </div>
 
+<script src="{{ url_for('static', filename='js/purchase_order_form.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    let itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
-    let itemIndex = {{ form.items|length }};
-
-    function createRow(index) {
-        const row = document.createElement('div');
-        row.classList.add('row','g-2','mt-2','item-row','align-items-center');
-        row.innerHTML = `
-            <div class="col"><select name="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
-            <div class="col"><select name="items-${index}-unit" class="form-control unit-select"></select></div>
-            <div class="col"><input type="number" step="any" name="items-${index}-quantity" class="form-control quantity"></div>
-            <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
-        `;
-        return row;
-    }
-
-    function fetchUnits(selectEl) {
-        const itemId = selectEl.value;
-        const unitSelect = selectEl.closest('.item-row').querySelector('.unit-select');
-        if (!itemId) {
-            unitSelect.innerHTML = '';
-            return;
-        }
-        fetch(`/items/${itemId}/units`).then(r => r.json()).then(data => {
-            let opts = '';
-            data.units.forEach(u => {
-                opts += `<option value="${u.id}" ${u.receiving_default ? 'selected' : ''}>${u.name} of ${u.factor} ${data.base_unit}${u.factor != 1 ? 's' : ''}</option>`;
-            });
-            unitSelect.innerHTML = opts;
-        });
-    }
-
-    document.getElementById('add-item').addEventListener('click', function(e) {
-        e.preventDefault();
-        const row = createRow(itemIndex);
-        document.getElementById('items').appendChild(row);
-        itemIndex++;
+    initPurchaseOrderForm({
+        container: document.getElementById('items'),
+        addRowButton: document.getElementById('add-item'),
+        quickAddButton: document.getElementById('quick-add-item'),
+        newItemModal: document.getElementById('newItemModal'),
+        saveNewItemButton: document.getElementById('save-new-item'),
+        nextIndex: {{ form.items|length }}
     });
-
-    document.getElementById('items').addEventListener('click', function(e) {
-        if (e.target && e.target.classList.contains('remove-item')) {
-            e.target.closest('.row').remove();
-        }
-    });
-
-    document.getElementById('items').addEventListener('change', function(e) {
-        if (e.target && e.target.classList.contains('item-select')) {
-            fetchUnits(e.target);
-        }
-    });
-
-    document.getElementById('items').addEventListener('keydown', function(e) {
-        if (
-            e.target &&
-            e.target.classList.contains('quantity') &&
-            e.key === 'Tab' &&
-            !e.shiftKey
-        ) {
-            const nextRow = e.target.closest('.item-row').nextElementSibling;
-            if (nextRow && nextRow.querySelector('.quantity')) {
-                e.preventDefault();
-                nextRow.querySelector('.quantity').focus();
-            }
-        }
-    });
-
-    document.getElementById('quick-add-item').addEventListener('click', function() {
-        new bootstrap.Modal(document.getElementById('newItemModal')).show();
-    });
-
-    document.getElementById('save-new-item').addEventListener('click', function() {
-        const name = document.getElementById('new-item-name').value.trim();
-        const glCode = document.getElementById('new-item-gl-code').value;
-        const baseUnit = document.getElementById('new-item-base-unit').value;
-        const recvUnit = document.getElementById('new-item-receiving-unit').value.trim();
-        const recvFactor = parseFloat(document.getElementById('new-item-receiving-factor').value) || 0;
-        const transUnit = document.getElementById('new-item-transfer-unit').value.trim();
-        const transFactor = parseFloat(document.getElementById('new-item-transfer-factor').value) || 0;
-        const csrfToken = document.querySelector('input[name="csrf_token"]').value;
-        if (!name || !recvUnit || !transUnit || recvFactor <= 0 || transFactor <= 0) return;
-        fetch('/items/quick_add', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
-            body: JSON.stringify({
-                name: name,
-                purchase_gl_code: glCode,
-                base_unit: baseUnit,
-                receiving_unit: recvUnit,
-                receiving_factor: recvFactor,
-                transfer_unit: transUnit,
-                transfer_factor: transFactor
-            })
-        }).then(r => r.json()).then(data => {
-            if (data.id) {
-                itemOptions += `<option value="${data.id}">${data.name}</option>`;
-                document.querySelectorAll('.item-select').forEach(sel => {
-                    sel.insertAdjacentHTML('beforeend', `<option value="${data.id}">${data.name}</option>`);
-                });
-
-                const row = createRow(itemIndex);
-                document.getElementById('items').appendChild(row);
-                const newSelect = row.querySelector('.item-select');
-                newSelect.value = data.id;
-                fetchUnits(newSelect);
-                itemIndex++;
-
-                document.getElementById('new-item-name').value = '';
-                document.getElementById('new-item-receiving-unit').value = '';
-                document.getElementById('new-item-receiving-factor').value = '1';
-                document.getElementById('new-item-transfer-unit').value = '';
-                document.getElementById('new-item-transfer-factor').value = '1';
-                bootstrap.Modal.getInstance(document.getElementById('newItemModal')).hide();
-            }
-        });
-    });
-
-    document.querySelectorAll('.item-select').forEach(sel => fetchUnits(sel));
 });
 </script>
 {% endblock %}

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -22,12 +22,22 @@
         </div>
         <h4>Items</h4>
         <button id="quick-add-item" type="button" class="btn btn-link p-0">Create New Item</button>
-        <div id="items">
+        <div id="items" data-next-index="{{ form.items|length }}">
         {% for item in form.items %}
+        {% set item_id = item.item.data %}
+        {% set selected_name = '' %}
+        {% if item_id %}
+            {% set selected_name = item_lookup.get(item_id|int, '') %}
+        {% endif %}
+        {% set input_value = request.form.get('items-' ~ loop.index0 ~ '-item-label', selected_name) %}
         <div class="row g-2 mt-2 item-row align-items-center">
-            <div class="col">{{ item.item(class="form-control item-select") }}</div>
-            <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data }}"></select></div>
-            <div class="col">{{ item.quantity(class="form-control") }}</div>
+            <div class="col position-relative">
+                <input type="text" name="items-{{ loop.index0 }}-item-label" class="form-control item-search" placeholder="Search for an item" autocomplete="off" value="{{ input_value }}">
+                {{ item.item(class="item-id-field") }}
+                <div class="list-group suggestion-list d-none position-absolute w-100" style="z-index: 1000; max-height: 200px; overflow-y: auto;"></div>
+            </div>
+            <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data or '' }}"></select></div>
+            <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col-auto">
                 <button type="button" class="btn btn-danger remove-item">Remove</button>
             </div>
@@ -93,112 +103,16 @@
     </div>
 </div>
 
+<script src="{{ url_for('static', filename='js/purchase_order_form.js') }}"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    let itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
-    let itemIndex = {{ form.items|length }};
-
-    function createRow(index) {
-        const row = document.createElement('div');
-        row.classList.add('row','g-2','mt-2','item-row','align-items-center');
-        row.innerHTML = `
-            <div class="col"><select name="items-${index}-item" class="form-control item-select">${itemOptions}</select></div>
-            <div class="col"><select name="items-${index}-unit" class="form-control unit-select"></select></div>
-            <div class="col"><input type="number" step="any" name="items-${index}-quantity" class="form-control"></div>
-            <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
-        `;
-        return row;
-    }
-
-    function fetchUnits(selectEl, selectedUnitId=null) {
-        const itemId = selectEl.value;
-        const unitSelect = selectEl.closest('.item-row').querySelector('.unit-select');
-        if (!itemId) {
-            unitSelect.innerHTML = '';
-            return;
-        }
-        fetch(`/items/${itemId}/units`).then(r => r.json()).then(data => {
-            let opts = '';
-            data.units.forEach(u => {
-                const selected = (selectedUnitId && parseInt(selectedUnitId) === u.id) || (!selectedUnitId && u.receiving_default) ? 'selected' : '';
-                opts += `<option value="${u.id}" ${selected}>${u.name} of ${u.factor} ${data.base_unit}${u.factor != 1 ? 's' : ''}</option>`;
-            });
-            unitSelect.innerHTML = opts;
-        });
-    }
-
-    document.getElementById('add-item').addEventListener('click', function(e) {
-        e.preventDefault();
-        const row = createRow(itemIndex);
-        document.getElementById('items').appendChild(row);
-        itemIndex++;
-    });
-
-    document.getElementById('items').addEventListener('click', function(e) {
-        if (e.target && e.target.classList.contains('remove-item')) {
-            e.target.closest('.row').remove();
-        }
-    });
-
-    document.getElementById('items').addEventListener('change', function(e) {
-        if (e.target && e.target.classList.contains('item-select')) {
-            fetchUnits(e.target);
-        }
-    });
-
-    document.getElementById('quick-add-item').addEventListener('click', function() {
-        new bootstrap.Modal(document.getElementById('newItemModal')).show();
-    });
-
-    document.getElementById('save-new-item').addEventListener('click', function() {
-        const name = document.getElementById('new-item-name').value.trim();
-        const glCode = document.getElementById('new-item-gl-code').value;
-        const baseUnit = document.getElementById('new-item-base-unit').value;
-        const recvUnit = document.getElementById('new-item-receiving-unit').value.trim();
-        const recvFactor = parseFloat(document.getElementById('new-item-receiving-factor').value) || 0;
-        const transUnit = document.getElementById('new-item-transfer-unit').value.trim();
-        const transFactor = parseFloat(document.getElementById('new-item-transfer-factor').value) || 0;
-        const csrfToken = document.querySelector('input[name="csrf_token"]').value;
-        if (!name || !recvUnit || !transUnit || recvFactor <= 0 || transFactor <= 0) return;
-        fetch('/items/quick_add', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json', 'X-CSRFToken': csrfToken},
-            body: JSON.stringify({
-                name: name,
-                purchase_gl_code: glCode,
-                base_unit: baseUnit,
-                receiving_unit: recvUnit,
-                receiving_factor: recvFactor,
-                transfer_unit: transUnit,
-                transfer_factor: transFactor
-            })
-        }).then(r => r.json()).then(data => {
-            if (data.id) {
-                itemOptions += `<option value="${data.id}">${data.name}</option>`;
-                document.querySelectorAll('.item-select').forEach(sel => {
-                    sel.insertAdjacentHTML('beforeend', `<option value="${data.id}">${data.name}</option>`);
-                });
-
-                const row = createRow(itemIndex);
-                document.getElementById('items').appendChild(row);
-                const newSelect = row.querySelector('.item-select');
-                newSelect.value = data.id;
-                fetchUnits(newSelect);
-                itemIndex++;
-
-                document.getElementById('new-item-name').value = '';
-                document.getElementById('new-item-receiving-unit').value = '';
-                document.getElementById('new-item-receiving-factor').value = '1';
-                document.getElementById('new-item-transfer-unit').value = '';
-                document.getElementById('new-item-transfer-factor').value = '1';
-                bootstrap.Modal.getInstance(document.getElementById('newItemModal')).hide();
-            }
-        });
-    });
-
-    document.querySelectorAll('.item-select').forEach(sel => {
-        const selected = sel.closest('.item-row').querySelector('.unit-select').dataset.selected;
-        fetchUnits(sel, selected);
+    initPurchaseOrderForm({
+        container: document.getElementById('items'),
+        addRowButton: document.getElementById('add-item'),
+        quickAddButton: document.getElementById('quick-add-item'),
+        newItemModal: document.getElementById('newItemModal'),
+        saveNewItemButton: document.getElementById('save-new-item'),
+        nextIndex: {{ form.items|length }}
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- replace the purchase order item drop-downs with a search-as-you-type input backed by the existing `/items/search` endpoint
- initialize selected items and units when loading existing purchase orders and reuse the new shared JavaScript helper on create/edit pages
- extract the client-side logic for adding/removing rows, fetching units, and quick-adding items into a dedicated `purchase_order_form.js`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'twilio')*

------
https://chatgpt.com/codex/tasks/task_e_68c88d435b6083248aecc6155d4368a8