### PR TITLE
Add reusable client-side table sorting

### DIFF
--- a/app/static/js/table-sort.js
+++ b/app/static/js/table-sort.js
@@ -1,0 +1,131 @@
+(function (window, document) {
+    'use strict';
+
+    function getCellValue(row, index) {
+        const cell = row.cells[index];
+        if (!cell) {
+            return '';
+        }
+        const dataValue = cell.getAttribute('data-sort-value');
+        return (dataValue !== null ? dataValue : cell.textContent).trim();
+    }
+
+    function parseNumber(value) {
+        if (typeof value === 'number') {
+            return value;
+        }
+        if (typeof value !== 'string') {
+            return NaN;
+        }
+        const normalized = value.replace(/,/g, '').trim();
+        if (!normalized) {
+            return NaN;
+        }
+        const parsed = parseFloat(normalized);
+        return Number.isNaN(parsed) ? NaN : parsed;
+    }
+
+    function updateIndicators(headers, activeHeader, direction) {
+        headers.forEach((header) => {
+            if (header === activeHeader) {
+                header.setAttribute('aria-sort', direction === 'asc' ? 'ascending' : 'descending');
+                let indicator = header.querySelector('.sort-indicator');
+                if (!indicator) {
+                    indicator = document.createElement('span');
+                    indicator.className = 'sort-indicator';
+                    indicator.style.marginLeft = '0.25rem';
+                    header.appendChild(indicator);
+                }
+                indicator.textContent = direction === 'asc' ? '▲' : '▼';
+            } else {
+                header.removeAttribute('aria-sort');
+                delete header.dataset.sortDirection;
+                const indicator = header.querySelector('.sort-indicator');
+                if (indicator) {
+                    indicator.remove();
+                }
+            }
+        });
+    }
+
+    function bindSortableTable(table) {
+        if (!table || table.dataset.sortableInitialized === 'true') {
+            return;
+        }
+
+        const head = table.tHead;
+        const body = table.tBodies[0];
+        if (!head || !body) {
+            return;
+        }
+
+        const headers = Array.from(head.querySelectorAll('th'));
+        headers.forEach((th, index) => {
+            if (th.dataset.sortable === 'false') {
+                return;
+            }
+            th.style.cursor = 'pointer';
+            th.addEventListener('click', (event) => {
+                if (event.target.closest('button, a, input, select, textarea, label')) {
+                    return;
+                }
+
+                const currentDirection = th.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
+                const type = th.dataset.type === 'number' ? 'number' : 'text';
+                const rows = Array.from(body.rows);
+
+                rows.sort((rowA, rowB) => {
+                    const valueA = getCellValue(rowA, index);
+                    const valueB = getCellValue(rowB, index);
+
+                    if (type === 'number') {
+                        const numA = parseNumber(valueA);
+                        const numB = parseNumber(valueB);
+                        const safeA = Number.isNaN(numA) ? Number.NEGATIVE_INFINITY : numA;
+                        const safeB = Number.isNaN(numB) ? Number.NEGATIVE_INFINITY : numB;
+
+                        if (safeA === safeB) {
+                            return 0;
+                        }
+                        if (currentDirection === 'asc') {
+                            return safeA < safeB ? -1 : 1;
+                        }
+                        return safeA > safeB ? -1 : 1;
+                    }
+
+                    const textA = valueA.toLowerCase();
+                    const textB = valueB.toLowerCase();
+
+                    if (textA === textB) {
+                        return 0;
+                    }
+                    if (currentDirection === 'asc') {
+                        return textA.localeCompare(textB);
+                    }
+                    return textB.localeCompare(textA);
+                });
+
+                rows.forEach((row) => body.appendChild(row));
+
+                th.dataset.sortDirection = currentDirection;
+                updateIndicators(headers, th, currentDirection);
+            });
+        });
+
+        table.dataset.sortableInitialized = 'true';
+    }
+
+    function initAllSortableTables(root) {
+        const context = root || document;
+        const tables = context.querySelectorAll('table.sortable');
+        tables.forEach((table) => bindSortableTable(table));
+    }
+
+    window.TableSort = window.TableSort || {};
+    window.TableSort.bind = bindSortableTable;
+    window.TableSort.initAll = initAllSortableTables;
+
+    document.addEventListener('DOMContentLoaded', () => {
+        initAllSortableTables(document);
+    });
+}(window, document));

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -354,6 +354,7 @@
     </div>
     <!-- Scripts: jQuery must be loaded before Bootstrap -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="{{ url_for('static', filename='js/table-sort.js') }}"></script>
 </body>
 
 </html>

--- a/app/templates/events/view_events.html
+++ b/app/templates/events/view_events.html
@@ -4,7 +4,7 @@
 <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createEventModal">Create Event</button>
 <button class="btn btn-secondary ml-2" data-bs-toggle="modal" data-bs-target="#filterModal">Filter</button>
 <div class="table-responsive">
-<table class="table mt-3">
+<table class="table mt-3 sortable">
     <thead>
         <tr><th>Name</th><th>Type</th><th>Start</th><th>End</th><th>Closed</th><th></th></tr>
     </thead>

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -121,12 +121,12 @@
     <form id="bulk-delete-form" action="{{ url_for('item.bulk_delete_items') }}" method="post">
         {{ form.hidden_tag() }}
         <div class="table-responsive">
-        <table class="table" id="itemsTable">
+        <table class="table sortable" id="itemsTable">
             <thead>
                 <tr>
                     <th scope="col"><input type="checkbox" id="select-all" style="transform: scale(1.5);"></th>
                     <th scope="col">Name</th>
-                    <th scope="col">Cost</th>
+                    <th scope="col" data-type="number">Cost</th>
                     <th scope="col">Actions</th>
                 </tr>
             </thead>

--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -23,7 +23,7 @@
     <div class="mb-3"><strong>Viewing:</strong> All locations</div>
     {% endif %}
     <div class="table-responsive">
-    <table class="table">
+    <table class="table sortable">
         <thead>
             <tr>
                 <th>Name</th>

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -127,13 +127,13 @@
     <p>Filtering by Customer: {{ selected_customer.first_name }} {{ selected_customer.last_name }}</p>
     {% endif %}
     <div class="table-responsive">
-    <table class="table" id="product-table">
+    <table class="table sortable" id="product-table">
         <thead>
             <tr>
                 <th>Name</th>
-                <th>Price</th>
-                <th>Cost</th>
-                <th>Food Cost %</th>
+                <th data-type="number">Price</th>
+                <th data-type="number">Cost</th>
+                <th data-type="number">Food Cost %</th>
                 <th>Last Sold</th>
                 <th>Action</th>
             </tr>

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -89,16 +89,16 @@
     </div>
     {% endif %}
     <div class="table-responsive">
-    <table class="table">
+    <table class="table sortable">
         <thead>
             <tr>
-                <th>ID</th>
-                <th>PO</th>
+                <th data-type="number">ID</th>
+                <th data-type="number">PO</th>
                 <th>Vendor</th>
                 <th>Location</th>
                 <th>Date</th>
                 <th>Invoice #</th>
-                <th>Total</th>
+                <th data-type="number">Total</th>
                 <th>Actions</th>
             </tr>
         </thead>

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -78,14 +78,14 @@
     {% endif %}
 
     <div class="table-responsive">
-    <table class="table">
+    <table class="table sortable">
         <thead>
             <tr>
-                <th>ID</th>
+                <th data-type="number">ID</th>
                 <th>Vendor</th>
                 <th>Order Date</th>
                 <th>Expected Date</th>
-                <th>Delivery</th>
+                <th data-type="number">Delivery</th>
                 <th>Actions</th>
             </tr>
         </thead>


### PR DESCRIPTION
## Summary
- add a reusable table sorting helper that toggles sort order, handles numeric columns, and shows an indicator
- load the sorter in the base layout and flag key data tables with sortable and numeric metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8cb953ecc8324b3cdbd7bf153e08c