### PR TITLE
Add received invoice report

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -382,6 +382,14 @@ class VendorInvoiceReportForm(FlaskForm):
     submit = SubmitField("Generate Report")
 
 
+class ReceivedInvoiceReportForm(FlaskForm):
+    """Report form for received purchase invoices."""
+
+    start_date = DateField("Start Date", validators=[DataRequired()])
+    end_date = DateField("End Date", validators=[DataRequired()])
+    submit = SubmitField("Generate Report")
+
+
 # forms.py
 class ProductSalesReportForm(FlaskForm):
     start_date = DateField("Start Date", validators=[DataRequired()])

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -2,7 +2,10 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Purchase Invoices</h2>
-    <div class="row justify-content-end">
+    <div class="row justify-content-end g-2">
+        <div class="col-auto">
+            <a href="{{ url_for('report.received_invoice_report') }}" class="btn btn-secondary mb-3">Received Invoice Report</a>
+        </div>
         <div class="col-auto">
             <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
                 Filters

--- a/app/templates/report_received_invoices.html
+++ b/app/templates/report_received_invoices.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container mt-5">
+    <h2>Received Invoice Report</h2>
+    <p class="text-muted">Select a date range to view all purchase invoices received during that period.</p>
+    <form method="POST" class="mb-4">
+        {{ form.hidden_tag() }}
+        <div class="row g-3">
+            <div class="col-md-6">
+                {{ form.start_date.label(class="form-label") }}
+                {{ form.start_date(class="form-control") }}
+                {% if form.start_date.errors %}
+                    <div class="text-danger small">
+                        {{ form.start_date.errors[0] }}
+                    </div>
+                {% endif %}
+            </div>
+            <div class="col-md-6">
+                {{ form.end_date.label(class="form-label") }}
+                {{ form.end_date(class="form-control") }}
+                {% if form.end_date.errors %}
+                    <div class="text-danger small">
+                        {{ form.end_date.errors[0] }}
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary mt-3">Generate Report</button>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/report_received_invoices_results.html
+++ b/app/templates/report_received_invoices_results.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container mt-5">
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <h2 class="mb-0">Received Invoice Report</h2>
+        <a class="btn btn-outline-secondary" href="{{ url_for('report.received_invoice_report') }}">Change Dates</a>
+    </div>
+    <p class="text-muted mt-2 mb-4">
+        Report period: {{ start.strftime('%Y-%m-%d') }} to {{ end.strftime('%Y-%m-%d') }}
+    </p>
+    {% if results %}
+    <div class="table-responsive">
+    <table class="table table-bordered table-striped align-middle">
+        <thead class="table-light">
+            <tr>
+                <th scope="col">Order Date</th>
+                <th scope="col">Received By</th>
+                <th scope="col">Received Date</th>
+                <th scope="col">Vendor</th>
+                <th scope="col" class="text-end">Invoice Total</th>
+                <th scope="col">Invoice Number</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% set totals = namespace(amount=0) %}
+            {% for row in results %}
+                {% set totals.amount = totals.amount + row.invoice.total %}
+                <tr>
+                    <td>{{ row.order_date|format_datetime('%Y-%m-%d') }}</td>
+                    <td>{{ row.received_by }}</td>
+                    <td>{{ row.invoice.received_date|format_datetime('%Y-%m-%d') }}</td>
+                    <td>{{ row.invoice.vendor_name }}</td>
+                    <td class="text-end">${{ '%.2f'|format(row.invoice.total) }}</td>
+                    <td>{{ row.invoice.invoice_number or '' }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+        <tfoot>
+            <tr>
+                <th colspan="4" class="text-end">Total for {{ results|length }} invoice{% if results|length != 1 %}s{% endif %}:</th>
+                <th class="text-end">${{ '%.2f'|format(totals.amount) }}</th>
+                <th></th>
+            </tr>
+        </tfoot>
+    </table>
+    </div>
+    {% else %}
+    <div class="alert alert-info" role="alert">
+        No received invoices were found for the selected date range.
+    </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a date-driven received invoice report form and query logic
- render received invoice results with totals and display details for each invoice
- link to the new report from the purchase invoices page for easy access

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8cea6f61083248c16b97097a815eb