### PR TITLE
Add column visibility controls to items table

### DIFF
--- a/app/static/js/column_visibility.js
+++ b/app/static/js/column_visibility.js
@@ -1,0 +1,101 @@
+(function () {
+    document.addEventListener('DOMContentLoaded', function () {
+        var table = document.getElementById('itemsTable');
+        if (!table) {
+            return;
+        }
+
+        var checkboxes = Array.prototype.slice.call(document.querySelectorAll('.column-toggle'));
+        if (!checkboxes.length) {
+            return;
+        }
+
+        var storageKey = 'itemsTableColumnVisibility';
+        var storedState = {};
+        try {
+            var saved = window.localStorage.getItem(storageKey);
+            if (saved) {
+                storedState = JSON.parse(saved) || {};
+            }
+        } catch (err) {
+            storedState = {};
+        }
+
+        checkboxes.forEach(function (checkbox) {
+            var columnClass = checkbox.dataset.columnTarget;
+            if (!columnClass) {
+                return;
+            }
+            if (Object.prototype.hasOwnProperty.call(storedState, columnClass)) {
+                checkbox.checked = Boolean(storedState[columnClass]);
+            }
+        });
+
+        if (!checkboxes.some(function (checkbox) { return checkbox.checked; })) {
+            checkboxes[0].checked = true;
+        }
+
+        applyVisibility();
+        persistState();
+
+        checkboxes.forEach(function (checkbox) {
+            checkbox.addEventListener('change', function () {
+                if (!checkbox.checked) {
+                    var visibleCount = checkboxes.filter(function (cb) { return cb.checked; }).length;
+                    if (visibleCount === 0) {
+                        checkbox.checked = true;
+                        window.alert('At least one data column must remain visible.');
+                        return;
+                    }
+                }
+                applyVisibility();
+                persistState();
+            });
+        });
+
+        var observerTarget = table.tBodies && table.tBodies.length ? table.tBodies[0] : table;
+        var observer = new MutationObserver(function (mutations) {
+            for (var i = 0; i < mutations.length; i += 1) {
+                var mutation = mutations[i];
+                if (mutation.type === 'childList' && mutation.addedNodes.length) {
+                    applyVisibility();
+                    break;
+                }
+            }
+        });
+        observer.observe(observerTarget, { childList: true, subtree: true });
+
+        function applyVisibility() {
+            checkboxes.forEach(function (checkbox) {
+                var columnClass = checkbox.dataset.columnTarget;
+                if (!columnClass) {
+                    return;
+                }
+                var cells = table.querySelectorAll('.' + columnClass);
+                cells.forEach(function (cell) {
+                    if (checkbox.checked) {
+                        cell.classList.remove('d-none');
+                    } else {
+                        cell.classList.add('d-none');
+                    }
+                });
+            });
+        }
+
+        function persistState() {
+            var state = {};
+            checkboxes.forEach(function (checkbox) {
+                var columnClass = checkbox.dataset.columnTarget;
+                if (!columnClass) {
+                    return;
+                }
+                state[columnClass] = checkbox.checked;
+            });
+            try {
+                window.localStorage.setItem(storageKey, JSON.stringify(state));
+            } catch (err) {
+                /* Ignore storage errors */
+            }
+        }
+    });
+})();

--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -1,8 +1,8 @@
 <tr id="item-row-{{ item.id }}">
-    <td><input type="checkbox" name="item_ids" value="{{ item.id }}" style="transform: scale(1.5);"></td>
-    <td>{{ item.name }}</td>
-    <td>{{ '%.6f'|format(item.cost) }} / {{ item.base_unit }}</td>
-    <td>
+    <td class="col-select"><input type="checkbox" name="item_ids" value="{{ item.id }}" style="transform: scale(1.5);"></td>
+    <td class="col-name">{{ item.name }}</td>
+    <td class="col-cost">{{ '%.6f'|format(item.cost) }} / {{ item.base_unit }}</td>
+    <td class="col-actions">
         <a href="{{ url_for('item.view_item', item_id=item.id) }}" class="btn btn-primary">View</a>
         <button type="button" class="btn btn-secondary edit-item-btn ms-1" data-item-id="{{ item.id }}">Edit</button>
         <button type="button" class="btn btn-secondary copy-item-btn ms-1" data-item-id="{{ item.id }}">Copy</button>

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -8,6 +8,24 @@
             <button type="button" class="btn btn-primary mb-3" id="createItemBtn">Add New Item</button>
         </div>
         <div class="col-auto">
+            <div class="dropdown d-inline-block mb-3 me-2">
+                <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="columnSelectorDropdown"
+                    data-bs-toggle="dropdown" aria-expanded="false">
+                    Columns
+                </button>
+                <div class="dropdown-menu dropdown-menu-end p-3" aria-labelledby="columnSelectorDropdown">
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-name"
+                            data-column-target="col-name" checked>
+                        <label class="form-check-label" for="toggle-column-name">Name</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-cost"
+                            data-column-target="col-cost" checked>
+                        <label class="form-check-label" for="toggle-column-cost">Cost</label>
+                    </div>
+                </div>
+            </div>
             <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
                 Filters
             </button>
@@ -124,10 +142,10 @@
         <table class="table sortable" id="itemsTable">
             <thead>
                 <tr>
-                    <th scope="col"><input type="checkbox" id="select-all" style="transform: scale(1.5);"></th>
-                    <th scope="col">Name</th>
-                    <th scope="col" data-type="number">Cost</th>
-                    <th scope="col">Actions</th>
+                    <th scope="col" class="col-select"><input type="checkbox" id="select-all" style="transform: scale(1.5);"></th>
+                    <th scope="col" class="col-name">Name</th>
+                    <th scope="col" class="col-cost" data-type="number">Cost</th>
+                    <th scope="col" class="col-actions">Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -156,13 +174,19 @@
         </ul>
     </nav>
 </div>
+<script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 <script>
-document.getElementById('select-all').onclick = function() {
-    var checkboxes = document.querySelectorAll('input[type="checkbox"][name="item_ids"]');
-    for (var checkbox of checkboxes) {
-        checkbox.checked = this.checked;
+document.addEventListener('DOMContentLoaded', function() {
+    var selectAll = document.getElementById('select-all');
+    if (selectAll) {
+        selectAll.addEventListener('click', function() {
+            var checkboxes = document.querySelectorAll('input[type="checkbox"][name="item_ids"]');
+            checkboxes.forEach(function(checkbox) {
+                checkbox.checked = selectAll.checked;
+            });
+        });
     }
-}
+});
 </script>
 <!-- Item Modal -->
 <div class="modal fade" id="itemModal" tabindex="-1" aria-hidden="true">

--- a/tests/test_item_column_selector.py
+++ b/tests/test_item_column_selector.py
@@ -1,0 +1,30 @@
+import os
+
+from app import db
+from app.models import Item
+from tests.utils import login
+
+
+def test_item_column_selector_checkboxes_render(client, app):
+    with app.app_context():
+        if Item.query.count() == 0:
+            item = Item(name="Column Test Item", base_unit="each", cost=1.23)
+            db.session.add(item)
+            db.session.commit()
+
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    admin_pass = os.getenv("ADMIN_PASS", "adminpass")
+
+    client.environ_base["wsgi.url_scheme"] = "https"
+    with client:
+        login_response = login(client, admin_email, admin_pass)
+        assert login_response.status_code == 200
+        assert login_response.request.path != "/auth/login"
+
+        response = client.get("/items", follow_redirects=True)
+        assert response.request.path == "/items"
+        page = response.get_data(as_text=True)
+        assert 'id="toggle-column-name"' in page
+        assert 'data-column-target="col-name"' in page
+        assert 'id="toggle-column-cost"' in page
+        assert 'data-column-target="col-cost"' in page


### PR DESCRIPTION
## Summary
- add a column visibility dropdown to the items list and tag table columns with unique classes
- implement a reusable JavaScript helper to toggle column visibility with localStorage persistence and a last-column guard
- add regression coverage to confirm the column selector renders on the items page

## Testing
- pytest tests/test_item_column_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68c8d6f9bcb08324bdd83f47b811b9cd