### PR TITLE
Expand item table column options

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -14,6 +14,8 @@ from flask import (
 from flask_login import login_required
 from werkzeug.utils import secure_filename
 
+from sqlalchemy.orm import selectinload
+
 from app import db
 from app.forms import ImportItemsForm, ItemForm
 from app.models import (
@@ -71,7 +73,11 @@ def view_items():
         int(x) for x in request.args.getlist("vendor_id") if x.isdigit()
     ]
 
-    query = Item.query
+    query = Item.query.options(
+        selectinload(Item.units),
+        selectinload(Item.purchase_gl_code),
+        selectinload(Item.gl_code_rel),
+    )
     if archived == "active":
         query = query.filter(Item.archived.is_(False))
     elif archived == "archived":

--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -1,7 +1,42 @@
 <tr id="item-row-{{ item.id }}">
     <td class="col-select"><input type="checkbox" name="item_ids" value="{{ item.id }}" style="transform: scale(1.5);"></td>
+    <td class="col-id" data-sort-value="{{ item.id }}">{{ item.id }}</td>
     <td class="col-name">{{ item.name }}</td>
-    <td class="col-cost">{{ '%.6f'|format(item.cost) }} / {{ item.base_unit }}</td>
+    <td class="col-base-unit">{{ item.base_unit or '—' }}</td>
+    <td class="col-cost" data-sort-value="{{ '%.6f'|format(item.cost or 0) }}">{{ '%.6f'|format(item.cost or 0) }} / {{ item.base_unit or '—' }}</td>
+    <td class="col-quantity" data-sort-value="{{ '%.6f'|format(item.quantity or 0) }}">{{ '%.6f'|format(item.quantity or 0) }}</td>
+    <td class="col-gl-code">{{ item.gl_code_rel.code if item.gl_code_rel else item.gl_code or '—' }}</td>
+    <td class="col-gl-desc">{{ item.gl_code_rel.description if item.gl_code_rel and item.gl_code_rel.description else '—' }}</td>
+    <td class="col-purchase-gl-code">{{ item.purchase_gl_code.code if item.purchase_gl_code else '—' }}</td>
+    <td class="col-purchase-gl-desc">{{ item.purchase_gl_code.description if item.purchase_gl_code and item.purchase_gl_code.description else '—' }}</td>
+    <td class="col-units">
+        {% if item.units %}
+            {% for unit in item.units %}
+                <div>{{ unit.name }} (&times;{{ '%.4f'|format(unit.factor) }})</div>
+            {% endfor %}
+        {% else %}
+            <span class="text-muted">—</span>
+        {% endif %}
+    </td>
+    {% set receiving_units = item.units | selectattr('receiving_default') | list %}
+    {% set receiving_unit = receiving_units[0] if receiving_units else None %}
+    <td class="col-receiving-default" data-sort-value="{{ '1' if receiving_unit else '0' }}">
+        {% if receiving_unit %}
+            {{ receiving_unit.name }} (&times;{{ '%.4f'|format(receiving_unit.factor) }})
+        {% else %}
+            <span class="text-muted">—</span>
+        {% endif %}
+    </td>
+    {% set transfer_units = item.units | selectattr('transfer_default') | list %}
+    {% set transfer_unit = transfer_units[0] if transfer_units else None %}
+    <td class="col-transfer-default" data-sort-value="{{ '1' if transfer_unit else '0' }}">
+        {% if transfer_unit %}
+            {{ transfer_unit.name }} (&times;{{ '%.4f'|format(transfer_unit.factor) }})
+        {% else %}
+            <span class="text-muted">—</span>
+        {% endif %}
+    </td>
+    <td class="col-archived" data-sort-value="{{ '1' if item.archived else '0' }}">{{ 'Yes' if item.archived else 'No' }}</td>
     <td class="col-actions">
         <a href="{{ url_for('item.view_item', item_id=item.id) }}" class="btn btn-primary">View</a>
         <button type="button" class="btn btn-secondary edit-item-btn ms-1" data-item-id="{{ item.id }}">Edit</button>

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -15,14 +15,69 @@
                 </button>
                 <div class="dropdown-menu dropdown-menu-end p-3" aria-labelledby="columnSelectorDropdown">
                     <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-id"
+                            data-column-target="col-id" checked>
+                        <label class="form-check-label" for="toggle-column-id">ID</label>
+                    </div>
+                    <div class="form-check">
                         <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-name"
                             data-column-target="col-name" checked>
                         <label class="form-check-label" for="toggle-column-name">Name</label>
                     </div>
                     <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-base-unit"
+                            data-column-target="col-base-unit" checked>
+                        <label class="form-check-label" for="toggle-column-base-unit">Base Unit</label>
+                    </div>
+                    <div class="form-check">
                         <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-cost"
                             data-column-target="col-cost" checked>
-                        <label class="form-check-label" for="toggle-column-cost">Cost</label>
+                        <label class="form-check-label" for="toggle-column-cost">Cost / Base Unit</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-quantity"
+                            data-column-target="col-quantity" checked>
+                        <label class="form-check-label" for="toggle-column-quantity">Quantity</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-gl-code"
+                            data-column-target="col-gl-code" checked>
+                        <label class="form-check-label" for="toggle-column-gl-code">Inventory GL Code</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-gl-desc"
+                            data-column-target="col-gl-desc" checked>
+                        <label class="form-check-label" for="toggle-column-gl-desc">Inventory GL Description</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-purchase-gl-code"
+                            data-column-target="col-purchase-gl-code" checked>
+                        <label class="form-check-label" for="toggle-column-purchase-gl-code">Purchase GL Code</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-purchase-gl-desc"
+                            data-column-target="col-purchase-gl-desc" checked>
+                        <label class="form-check-label" for="toggle-column-purchase-gl-desc">Purchase GL Description</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-units"
+                            data-column-target="col-units" checked>
+                        <label class="form-check-label" for="toggle-column-units">Units</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-receiving-default"
+                            data-column-target="col-receiving-default" checked>
+                        <label class="form-check-label" for="toggle-column-receiving-default">Receiving Default Unit</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-transfer-default"
+                            data-column-target="col-transfer-default" checked>
+                        <label class="form-check-label" for="toggle-column-transfer-default">Transfer Default Unit</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input column-toggle" type="checkbox" id="toggle-column-archived"
+                            data-column-target="col-archived" checked>
+                        <label class="form-check-label" for="toggle-column-archived">Archived</label>
                     </div>
                 </div>
             </div>
@@ -143,8 +198,19 @@
             <thead>
                 <tr>
                     <th scope="col" class="col-select"><input type="checkbox" id="select-all" style="transform: scale(1.5);"></th>
+                    <th scope="col" class="col-id" data-type="number">ID</th>
                     <th scope="col" class="col-name">Name</th>
-                    <th scope="col" class="col-cost" data-type="number">Cost</th>
+                    <th scope="col" class="col-base-unit">Base Unit</th>
+                    <th scope="col" class="col-cost" data-type="number">Cost / Base Unit</th>
+                    <th scope="col" class="col-quantity" data-type="number">Quantity</th>
+                    <th scope="col" class="col-gl-code">Inventory GL Code</th>
+                    <th scope="col" class="col-gl-desc">Inventory GL Description</th>
+                    <th scope="col" class="col-purchase-gl-code">Purchase GL Code</th>
+                    <th scope="col" class="col-purchase-gl-desc">Purchase GL Description</th>
+                    <th scope="col" class="col-units">Units</th>
+                    <th scope="col" class="col-receiving-default">Receiving Default Unit</th>
+                    <th scope="col" class="col-transfer-default">Transfer Default Unit</th>
+                    <th scope="col" class="col-archived">Archived</th>
                     <th scope="col" class="col-actions">Actions</th>
                 </tr>
             </thead>


### PR DESCRIPTION
## Summary
- load related GL code and unit data efficiently when building the item list
- extend the item list column selector with additional item attributes and update the table header
- render each row with the new item attributes, including GL codes, quantities, unit defaults, and archived status

## Testing
- pytest tests/test_purchase_flow.py::test_item_cost_visible_on_items_page tests/test_purchase_flow.py::test_case_item_cost_visible_on_items_page tests/test_purchase_flow.py::test_item_cost_average_visible_on_items_page

------
https://chatgpt.com/codex/tasks/task_e_68c8f9e6ef1083248cd4994b04660f46