### PR TITLE
Fix recipe item name display on product forms

### DIFF
--- a/app/templates/products/_create_product_form.html
+++ b/app/templates/products/_create_product_form.html
@@ -22,16 +22,11 @@
     </div>
     <div id="item-list">
         {% for item in form.items %}
-        {% set selected_name = '' %}
-        {% for val, label in form.items[0].item.choices %}
-            {% if val == item.item.data %}
-                {% set selected_name = label %}
-            {% endif %}
-        {% endfor %}
+        {% set selected_name = item.item.choices | selectattr('0', 'equalto', item.item.data) | map(attribute=1) | first %}
         <div class="row mb-2 align-items-center item-row">
             <div class="col position-relative">
                 <input type="hidden" name="{{ item.item.name }}" value="{{ item.item.data or '' }}" class="item-id">
-                <input type="text" class="form-control item-search" placeholder="Search item..." autocomplete="off" value="{{ selected_name }}">
+                <input type="text" class="form-control item-search" placeholder="Search item..." autocomplete="off" value="{{ selected_name or '' }}">
                 <div class="list-group item-suggestions"></div>
             </div>
             <div class="col">


### PR DESCRIPTION
## Summary
- update the product recipe form template so the search field resolves the saved item label correctly
- ensure previously saved recipe items show their names when editing a product

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c993aec874832480724754376d4a0d