### PR TITLE
Allow users to configure pagination size

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -665,3 +665,11 @@ class NotificationForm(FlaskForm):
     )
     notify_transfers = BooleanField("Send text on new transfer")
     submit = SubmitField("Update Notifications")
+
+
+class PaginationForm(FlaskForm):
+    items_per_page = IntegerField(
+        "Items per page",
+        validators=[InputRequired(), NumberRange(min=1, max=1000)],
+    )
+    submit = SubmitField("Update Pagination")

--- a/app/models.py
+++ b/app/models.py
@@ -74,6 +74,9 @@ class User(UserMixin, db.Model):
     timezone = db.Column(db.String(50))
     phone_number = db.Column(db.String(20))
     notify_transfers = db.Column(db.Boolean, default=False, nullable=False)
+    items_per_page = db.Column(
+        db.Integer, nullable=False, default=20, server_default="20"
+    )
 
     def get_favorites(self):
         """Return the user's favourite endpoint names as a list."""
@@ -87,6 +90,12 @@ class User(UserMixin, db.Model):
         else:
             favs.add(endpoint)
         self.favorites = ",".join(sorted(favs))
+
+    @property
+    def pagination_limit(self) -> int:
+        """Return the preferred pagination size constrained to sensible bounds."""
+        value = self.items_per_page or 20
+        return max(1, min(value, 1000))
 
 
 class Location(db.Model):

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -30,6 +30,7 @@ from app.forms import (
     InviteUserForm,
     LoginForm,
     NotificationForm,
+    PaginationForm,
     PasswordResetRequestForm,
     RestoreBackupForm,
     SetPasswordForm,
@@ -188,6 +189,9 @@ def profile():
         phone_number=current_user.phone_number or "",
         notify_transfers=current_user.notify_transfers,
     )
+    pagination_form = PaginationForm(
+        items_per_page=current_user.items_per_page
+    )
     if form.validate_on_submit():
         if not check_password_hash(
             current_user.password, form.current_password.data
@@ -215,6 +219,13 @@ def profile():
         db.session.commit()
         flash("Notification settings updated.", "success")
         return redirect(url_for("auth.profile"))
+    elif (
+        "items_per_page" in request.form and pagination_form.validate_on_submit()
+    ):
+        current_user.items_per_page = pagination_form.items_per_page.data
+        db.session.commit()
+        flash("Pagination settings updated.", "success")
+        return redirect(url_for("auth.profile"))
 
     transfers = Transfer.query.filter_by(user_id=current_user.id).all()
     invoices = Invoice.query.filter_by(user_id=current_user.id).all()
@@ -224,6 +235,7 @@ def profile():
         form=form,
         tz_form=tz_form,
         notif_form=notif_form,
+        pagination_form=pagination_form,
         transfers=transfers,
         invoices=invoices,
     )
@@ -261,6 +273,7 @@ def user_profile(user_id):
         phone_number=user.phone_number or "",
         notify_transfers=user.notify_transfers,
     )
+    pagination_form = PaginationForm(items_per_page=user.items_per_page)
     if form.validate_on_submit():
         user.password = generate_password_hash(form.new_password.data)
         db.session.commit()
@@ -279,6 +292,13 @@ def user_profile(user_id):
         db.session.commit()
         flash("Notification settings updated.", "success")
         return redirect(url_for("admin.user_profile", user_id=user_id))
+    elif (
+        "items_per_page" in request.form and pagination_form.validate_on_submit()
+    ):
+        user.items_per_page = pagination_form.items_per_page.data
+        db.session.commit()
+        flash("Pagination settings updated.", "success")
+        return redirect(url_for("admin.user_profile", user_id=user_id))
 
     transfers = Transfer.query.filter_by(user_id=user.id).all()
     invoices = Invoice.query.filter_by(user_id=user.id).all()
@@ -288,6 +308,7 @@ def user_profile(user_id):
         form=form,
         tz_form=tz_form,
         notif_form=notif_form,
+        pagination_form=pagination_form,
         transfers=transfers,
         invoices=invoices,
     )

--- a/app/routes/customer_routes.py
+++ b/app/routes/customer_routes.py
@@ -8,7 +8,7 @@ from flask import (
     url_for,
     jsonify,
 )
-from flask_login import login_required
+from flask_login import current_user, login_required
 
 from app import db
 from app.forms import CustomerForm, DeleteForm
@@ -49,7 +49,9 @@ def view_customers():
     elif pst_exempt == "no":
         query = query.filter(Customer.pst_exempt.is_(False))
 
-    customers = query.paginate(page=page, per_page=20)
+    customers = query.paginate(
+        page=page, per_page=current_user.pagination_limit
+    )
     delete_form = DeleteForm()
     form = CustomerForm()
     return render_template(

--- a/app/routes/glcode_routes.py
+++ b/app/routes/glcode_routes.py
@@ -7,7 +7,7 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import login_required
+from flask_login import current_user, login_required
 
 from app import db
 from app.forms import DeleteForm, GLCodeForm
@@ -30,7 +30,9 @@ def view_gl_codes():
     if description_query:
         query = query.filter(GLCode.description.ilike(f"%{description_query}%"))
 
-    codes = query.order_by(GLCode.code).paginate(page=page, per_page=20)
+    codes = query.order_by(GLCode.code).paginate(
+        page=page, per_page=current_user.pagination_limit
+    )
     delete_form = DeleteForm()
     form = GLCodeForm()
     return render_template(

--- a/app/routes/invoice_routes.py
+++ b/app/routes/invoice_routes.py
@@ -281,7 +281,9 @@ def view_invoices():
     page = request.args.get("page", 1, type=int)
     form.customer_id.choices = [(-1, "All")] + [
         (c.id, f"{c.first_name} {c.last_name}")
-        for c in Customer.query.paginate(page=page, per_page=20).items
+        for c in Customer.query.paginate(
+            page=page, per_page=current_user.pagination_limit
+        ).items
     ]
 
     # Determine filter values from form submission or query params
@@ -325,7 +327,7 @@ def view_invoices():
             <= datetime.combine(end_date, datetime.max.time())
         )
     invoices = query.order_by(Invoice.date_created.desc()).paginate(
-        page=page, per_page=20
+        page=page, per_page=current_user.pagination_limit
     )
     delete_form = DeleteForm()
     create_form = InvoiceForm()

--- a/app/routes/location_routes.py
+++ b/app/routes/location_routes.py
@@ -8,7 +8,7 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import login_required
+from flask_login import current_user, login_required
 
 from app import db
 from app.forms import DeleteForm, LocationForm
@@ -298,7 +298,9 @@ def view_locations():
         else:
             query = query.filter(Location.name.like(f"%{name_query}%"))
 
-    locations = query.order_by(Location.name).paginate(page=page, per_page=20)
+    locations = query.order_by(Location.name).paginate(
+        page=page, per_page=current_user.pagination_limit
+    )
     delete_form = DeleteForm()
     return render_template(
         "locations/view_locations.html",

--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -11,7 +11,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import login_required
+from flask_login import current_user, login_required
 from sqlalchemy import func, or_
 from sqlalchemy.orm import aliased, selectinload
 
@@ -157,7 +157,9 @@ def view_products():
         selectinload(Product.recipe_items).selectinload(ProductRecipeItem.unit),
     )
 
-    products = query.paginate(page=page, per_page=20)
+    products = query.paginate(
+        page=page, per_page=current_user.pagination_limit
+    )
     sales_gl_codes = (
         GLCode.query.filter(GLCode.code.like("4%")).order_by(GLCode.code).all()
     )

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -115,10 +115,8 @@ def view_purchase_orders():
         selectinload(PurchaseOrder.items).selectinload(PurchaseOrderItem.unit),
     )
 
-    orders = (
-        query.order_by(PurchaseOrder.order_date.desc()).paginate(
-            page=page, per_page=20
-        )
+    orders = query.order_by(PurchaseOrder.order_date.desc()).paginate(
+        page=page, per_page=current_user.pagination_limit
     )
 
     vendors = Vendor.query.filter_by(archived=False).all()
@@ -510,7 +508,7 @@ def view_purchase_invoices():
 
     invoices = query.order_by(
         PurchaseInvoice.received_date.desc(), PurchaseInvoice.id.desc()
-    ).paginate(page=page, per_page=20)
+    ).paginate(page=page, per_page=current_user.pagination_limit)
 
     vendors = Vendor.query.order_by(Vendor.first_name, Vendor.last_name).all()
     locations = Location.query.order_by(Location.name).all()

--- a/app/routes/transfer_routes.py
+++ b/app/routes/transfer_routes.py
@@ -173,7 +173,9 @@ def view_transfers():
     elif filter_option == "not_completed":
         query = query.filter(~Transfer.completed)
 
-    transfers = query.paginate(page=page, per_page=20)
+    transfers = query.paginate(
+        page=page, per_page=current_user.pagination_limit
+    )
 
     form = TransferForm()
     add_form = TransferForm(prefix="add")

--- a/app/routes/vendor_routes.py
+++ b/app/routes/vendor_routes.py
@@ -8,7 +8,7 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import login_required
+from flask_login import current_user, login_required
 
 from app import db
 from app.forms import CustomerForm, DeleteForm
@@ -23,7 +23,9 @@ vendor = Blueprint("vendor", __name__)
 def view_vendors():
     """Display all vendors."""
     page = request.args.get("page", 1, type=int)
-    vendors = Vendor.query.filter_by(archived=False).paginate(page=page, per_page=20)
+    vendors = Vendor.query.filter_by(archived=False).paginate(
+        page=page, per_page=current_user.pagination_limit
+    )
     delete_form = DeleteForm()
     return render_template(
         "vendors/view_vendors.html", vendors=vendors, delete_form=delete_form

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -29,6 +29,17 @@
     <button type="submit" class="btn btn-primary mt-2">{{ tz_form.submit.label.text }}</button>
 </form>
 <form method="post" class="mt-3">
+    {{ pagination_form.hidden_tag() }}
+    <div class="form-group">
+        {{ pagination_form.items_per_page.label(class_='form-label') }}
+        {{ pagination_form.items_per_page(class_='form-control', min=1, max=1000) }}
+        {% for error in pagination_form.items_per_page.errors %}
+        <div class="text-danger">{{ error }}</div>
+        {% endfor %}
+    </div>
+    <button type="submit" class="btn btn-primary mt-2">{{ pagination_form.submit.label.text }}</button>
+</form>
+<form method="post" class="mt-3">
     {{ notif_form.hidden_tag() }}
     <div class="form-group">
         {{ notif_form.phone_number.label(class_='form-label') }}

--- a/migrations/versions/d2e1f5f3e1e4_add_items_per_page_to_user.py
+++ b/migrations/versions/d2e1f5f3e1e4_add_items_per_page_to_user.py
@@ -1,0 +1,62 @@
+"""add items_per_page to user
+
+Revision ID: d2e1f5f3e1e4
+Revises: c2f321f4c8b5
+Create Date: 2025-01-01 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "d2e1f5f3e1e4"
+down_revision = "c2f321f4c8b5"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(table_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    return inspector.has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table_name):
+        return False
+    columns = [col["name"] for col in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+def upgrade():
+    bind = op.get_bind()
+    if not _has_table("user", bind):
+        return
+    if _has_column("user", "items_per_page", bind):
+        return
+
+    with op.batch_alter_table("user", recreate="always") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "items_per_page",
+                sa.Integer(),
+                nullable=False,
+                server_default="20",
+            )
+        )
+
+    with op.batch_alter_table("user", recreate="always") as batch_op:
+        batch_op.alter_column("items_per_page", server_default=None)
+
+
+def downgrade():
+    bind = op.get_bind()
+    if not _has_table("user", bind):
+        return
+    if not _has_column("user", "items_per_page", bind):
+        return
+
+    with op.batch_alter_table("user", recreate="always") as batch_op:
+        batch_op.drop_column("items_per_page")

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -114,3 +114,34 @@ def test_user_can_set_timezone(client, app):
     with app.app_context():
         user = User.query.filter_by(email="tz@example.com").first()
         assert user.timezone == "US/Eastern"
+
+
+def test_user_can_update_pagination_settings(client, app):
+    create_user(app, "paginate@example.com")
+    with client:
+        login(client, "paginate@example.com", "oldpass")
+        resp = client.post(
+            "/auth/profile",
+            data={"items_per_page": 75},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+    with app.app_context():
+        user = User.query.filter_by(email="paginate@example.com").first()
+        assert user.items_per_page == 75
+
+
+def test_pagination_setting_enforces_maximum(client, app):
+    create_user(app, "limit@example.com")
+    with client:
+        login(client, "limit@example.com", "oldpass")
+        resp = client.post(
+            "/auth/profile",
+            data={"items_per_page": 2000},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert b"Number must be between 1 and 1000." in resp.data
+    with app.app_context():
+        user = User.query.filter_by(email="limit@example.com").first()
+        assert user.items_per_page == 20


### PR DESCRIPTION
## Summary
- add a per-user pagination preference persisted on the user model
- expose pagination controls on the profile page for users and admins
- honor the user-configured page size across paginated list views

## Testing
- pytest tests/test_user_profile.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b03a3d2483249f43fc19bb26136d