### PR TITLE
Fix add item button fallback behaviour

### DIFF
--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -5,7 +5,7 @@
     <h2>Items List</h2>
     <div class="row justify-content-between">
         <div class="col-auto">
-            <button type="button" class="btn btn-primary mb-3" id="createItemBtn">Add New Item</button>
+            <a href="{{ url_for('item.add_item') }}" class="btn btn-primary mb-3" id="createItemBtn">Add New Item</a>
         </div>
         <div class="col-auto">
             <div class="dropdown d-inline-block mb-3 me-2" data-column-visibility data-table-id="itemsTable" data-storage-key="itemsTableColumnVisibility">
@@ -313,19 +313,32 @@ function bindItemForm(actionUrl) {
     });
 }
 
-document.getElementById('createItemBtn').addEventListener('click', function() {
-    const url = '{{ url_for('item.add_item') }}';
-    fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-        .then(r => r.text())
-        .then(html => {
-            itemModalEl.querySelector('.modal-title').textContent = 'Add Item';
-            itemModalEl.querySelector('.modal-body').innerHTML = html;
-            executeScripts(itemModalEl);
-            const modal = new bootstrap.Modal(itemModalEl);
-            modal.show();
-            bindItemForm(url);
-        });
-});
+const createItemBtn = document.getElementById('createItemBtn');
+if (createItemBtn) {
+    createItemBtn.addEventListener('click', function(event) {
+        if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
+        }
+        event.preventDefault();
+        const url = createItemBtn.getAttribute('href');
+        if (!url) {
+            return;
+        }
+        fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+            .then(r => r.text())
+            .then(html => {
+                itemModalEl.querySelector('.modal-title').textContent = 'Add Item';
+                itemModalEl.querySelector('.modal-body').innerHTML = html;
+                executeScripts(itemModalEl);
+                const modal = new bootstrap.Modal(itemModalEl);
+                modal.show();
+                bindItemForm(url);
+            })
+            .catch(() => {
+                window.location.href = url;
+            });
+    });
+}
 
 document.querySelector('#itemsTable').addEventListener('click', function(e) {
     if (e.target.classList.contains('edit-item-btn')) {


### PR DESCRIPTION
## Summary
- convert the items page "Add New Item" control into a normal link so it still navigates when JavaScript is unavailable
- update the click handler to prevent default only for standard clicks, reuse the link target for AJAX requests, and fall back to navigation on errors

## Testing
- pytest tests/test_item_column_selector.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b136cc64832498e64e0c12cc81bc