### PR TITLE
Allow creating products without recipe items

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -350,10 +350,11 @@ class ProductRecipeForm(FlaskForm):
 class ProductWithRecipeForm(ProductForm):
     """Form used on product create/edit pages to also manage recipe items."""
 
-    items = FieldList(FormField(RecipeItemForm), min_entries=1)
+    items = FieldList(FormField(RecipeItemForm), min_entries=0)
 
     def __init__(self, *args, **kwargs):
         super(ProductWithRecipeForm, self).__init__(*args, **kwargs)
+        self.countable_label = RecipeItemForm().countable.label.text
         items = load_item_choices()
         units = load_unit_choices()
         for item_form in self.items:

--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -304,7 +304,7 @@ def copy_product(product_id):
     form.gl_code.data = product_obj.gl_code
     form.gl_code_id.data = product_obj.gl_code_id
     form.sales_gl_code.data = product_obj.sales_gl_code_id
-    form.items.min_entries = max(1, len(product_obj.recipe_items))
+    form.items.min_entries = len(product_obj.recipe_items)
     item_choices = [
         (itm.id, itm.name) for itm in Item.query.filter_by(archived=False).all()
     ]
@@ -373,7 +373,7 @@ def edit_product(product_id):
         form.gl_code.data = product.gl_code
         form.gl_code_id.data = product.gl_code_id
         form.sales_gl_code.data = product.sales_gl_code_id
-        form.items.min_entries = max(1, len(product.recipe_items))
+        form.items.min_entries = len(product.recipe_items)
         item_choices = [
             (itm.id, itm.name)
             for itm in Item.query.filter_by(archived=False).all()

--- a/app/templates/products/_create_product_form.html
+++ b/app/templates/products/_create_product_form.html
@@ -66,7 +66,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    const countableLabel = "{{ form.items[0].countable.label.text }}";
+    const countableLabel = {{ form.countable_label|default('Countable', true)|tojson }};
     let itemIndex = {{ form.items|length }};
 
     function fetchUnits(row, itemId, selected) {

--- a/tests/test_product_crud_with_recipe.py
+++ b/tests/test_product_crud_with_recipe.py
@@ -36,6 +36,27 @@ def setup_user_and_items(app):
         return user.email, item1.id, item2.id, iu1.id, iu2.id
 
 
+def test_create_product_without_recipe_items(client, app):
+    email, *_ = setup_user_and_items(app)
+    with client:
+        login(client, email, "pass")
+        resp = client.post(
+            "/products/create",
+            data={
+                "name": "Simple Item",
+                "price": 7,
+                "cost": 3,
+                "gl_code": "4000",
+            },
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+    with app.app_context():
+        product = Product.query.filter_by(name="Simple Item").first()
+        assert product is not None
+        assert len(product.recipe_items) == 0
+
+
 def test_create_product_with_recipe_items(client, app):
     email, item1_id, item2_id, unit1_id, unit2_id = setup_user_and_items(app)
     with client:


### PR DESCRIPTION
## Summary
- allow product forms to initialize without recipe entries and expose the countable label for the UI script
- adjust product copy/edit flows so they no longer force a placeholder recipe row
- update the create product form JavaScript and add coverage for products without recipe items

## Testing
- pytest tests/test_product_crud_with_recipe.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b1b9df7c83248d4dd92ab33a3fa3