### PR TITLE
Add per-page selectors to paginated views

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -175,6 +175,13 @@ def create_app(args: list):
         """Provide navigation labels to templates."""
         return dict(NAV_LINKS=NAV_LINKS)
 
+    @app.context_processor
+    def inject_pagination_sizes():
+        """Expose pagination size options to all templates."""
+        from app.utils.pagination import PAGINATION_SIZES
+
+        return {"PAGINATION_SIZES": PAGINATION_SIZES}
+
     with app.app_context():
         # Ensure models are imported and the database schema is created on
         # application start.  This allows the app to run even if migrations

--- a/app/forms.py
+++ b/app/forms.py
@@ -667,10 +667,3 @@ class NotificationForm(FlaskForm):
     notify_transfers = BooleanField("Send text on new transfer")
     submit = SubmitField("Update Notifications")
 
-
-class PaginationForm(FlaskForm):
-    items_per_page = IntegerField(
-        "Items per page",
-        validators=[InputRequired(), NumberRange(min=1, max=1000)],
-    )
-    submit = SubmitField("Update Pagination")

--- a/app/models.py
+++ b/app/models.py
@@ -91,12 +91,6 @@ class User(UserMixin, db.Model):
             favs.add(endpoint)
         self.favorites = ",".join(sorted(favs))
 
-    @property
-    def pagination_limit(self) -> int:
-        """Return the preferred pagination size constrained to sensible bounds."""
-        value = self.items_per_page or 20
-        return max(1, min(value, 1000))
-
 
 class Location(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -30,7 +30,6 @@ from app.forms import (
     InviteUserForm,
     LoginForm,
     NotificationForm,
-    PaginationForm,
     PasswordResetRequestForm,
     RestoreBackupForm,
     SetPasswordForm,
@@ -189,9 +188,6 @@ def profile():
         phone_number=current_user.phone_number or "",
         notify_transfers=current_user.notify_transfers,
     )
-    pagination_form = PaginationForm(
-        items_per_page=current_user.items_per_page
-    )
     if form.validate_on_submit():
         if not check_password_hash(
             current_user.password, form.current_password.data
@@ -219,13 +215,6 @@ def profile():
         db.session.commit()
         flash("Notification settings updated.", "success")
         return redirect(url_for("auth.profile"))
-    elif (
-        "items_per_page" in request.form and pagination_form.validate_on_submit()
-    ):
-        current_user.items_per_page = pagination_form.items_per_page.data
-        db.session.commit()
-        flash("Pagination settings updated.", "success")
-        return redirect(url_for("auth.profile"))
 
     transfers = Transfer.query.filter_by(user_id=current_user.id).all()
     invoices = Invoice.query.filter_by(user_id=current_user.id).all()
@@ -235,7 +224,6 @@ def profile():
         form=form,
         tz_form=tz_form,
         notif_form=notif_form,
-        pagination_form=pagination_form,
         transfers=transfers,
         invoices=invoices,
     )
@@ -273,7 +261,6 @@ def user_profile(user_id):
         phone_number=user.phone_number or "",
         notify_transfers=user.notify_transfers,
     )
-    pagination_form = PaginationForm(items_per_page=user.items_per_page)
     if form.validate_on_submit():
         user.password = generate_password_hash(form.new_password.data)
         db.session.commit()
@@ -292,13 +279,6 @@ def user_profile(user_id):
         db.session.commit()
         flash("Notification settings updated.", "success")
         return redirect(url_for("admin.user_profile", user_id=user_id))
-    elif (
-        "items_per_page" in request.form and pagination_form.validate_on_submit()
-    ):
-        user.items_per_page = pagination_form.items_per_page.data
-        db.session.commit()
-        flash("Pagination settings updated.", "success")
-        return redirect(url_for("admin.user_profile", user_id=user_id))
 
     transfers = Transfer.query.filter_by(user_id=user.id).all()
     invoices = Invoice.query.filter_by(user_id=user.id).all()
@@ -308,7 +288,6 @@ def user_profile(user_id):
         form=form,
         tz_form=tz_form,
         notif_form=notif_form,
-        pagination_form=pagination_form,
         transfers=transfers,
         invoices=invoices,
     )

--- a/app/routes/customer_routes.py
+++ b/app/routes/customer_routes.py
@@ -8,12 +8,13 @@ from flask import (
     url_for,
     jsonify,
 )
-from flask_login import current_user, login_required
+from flask_login import login_required
 
 from app import db
 from app.forms import CustomerForm, DeleteForm
 from app.models import Customer
 from app.utils.activity import log_activity
+from app.utils.pagination import build_pagination_args, get_per_page
 from sqlalchemy import func
 
 customer = Blueprint("customer", __name__)
@@ -49,9 +50,8 @@ def view_customers():
     elif pst_exempt == "no":
         query = query.filter(Customer.pst_exempt.is_(False))
 
-    customers = query.paginate(
-        page=page, per_page=current_user.pagination_limit
-    )
+    per_page = get_per_page()
+    customers = query.paginate(page=page, per_page=per_page)
     delete_form = DeleteForm()
     form = CustomerForm()
     return render_template(
@@ -63,6 +63,8 @@ def view_customers():
         match_mode=match_mode,
         gst_exempt=gst_exempt,
         pst_exempt=pst_exempt,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )
 
 

--- a/app/routes/glcode_routes.py
+++ b/app/routes/glcode_routes.py
@@ -7,11 +7,12 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import login_required
 
 from app import db
 from app.forms import DeleteForm, GLCodeForm
 from app.models import GLCode
+from app.utils.pagination import build_pagination_args, get_per_page
 
 glcode_bp = Blueprint("glcode", __name__)
 
@@ -30,9 +31,8 @@ def view_gl_codes():
     if description_query:
         query = query.filter(GLCode.description.ilike(f"%{description_query}%"))
 
-    codes = query.order_by(GLCode.code).paginate(
-        page=page, per_page=current_user.pagination_limit
-    )
+    per_page = get_per_page()
+    codes = query.order_by(GLCode.code).paginate(page=page, per_page=per_page)
     delete_form = DeleteForm()
     form = GLCodeForm()
     return render_template(
@@ -42,6 +42,8 @@ def view_gl_codes():
         form=form,
         code_query=code_query,
         description_query=description_query,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )
 
 

--- a/app/routes/invoice_routes.py
+++ b/app/routes/invoice_routes.py
@@ -16,6 +16,7 @@ from app import GST, db
 from app.forms import DeleteForm, InvoiceFilterForm, InvoiceForm
 from app.models import Customer, Invoice, InvoiceProduct, Product
 from app.utils.activity import log_activity
+from app.utils.pagination import build_pagination_args, get_per_page
 
 invoice = Blueprint("invoice", __name__)
 
@@ -279,10 +280,11 @@ def view_invoices():
     """List invoices with optional filters."""
     form = InvoiceFilterForm()
     page = request.args.get("page", 1, type=int)
+    per_page = get_per_page()
     form.customer_id.choices = [(-1, "All")] + [
         (c.id, f"{c.first_name} {c.last_name}")
         for c in Customer.query.paginate(
-            page=page, per_page=current_user.pagination_limit
+            page=page, per_page=per_page
         ).items
     ]
 
@@ -327,7 +329,7 @@ def view_invoices():
             <= datetime.combine(end_date, datetime.max.time())
         )
     invoices = query.order_by(Invoice.date_created.desc()).paginate(
-        page=page, per_page=current_user.pagination_limit
+        page=page, per_page=per_page
     )
     delete_form = DeleteForm()
     create_form = InvoiceForm()
@@ -340,4 +342,6 @@ def view_invoices():
         form=form,
         delete_form=delete_form,
         create_form=create_form,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )

--- a/app/routes/location_routes.py
+++ b/app/routes/location_routes.py
@@ -8,12 +8,13 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import login_required
 
 from app import db
 from app.forms import DeleteForm, LocationForm
 from app.models import Location, LocationStandItem, Product
 from app.utils.activity import log_activity
+from app.utils.pagination import build_pagination_args, get_per_page
 
 location = Blueprint("locations", __name__)
 
@@ -278,6 +279,7 @@ def view_stand_sheet(location_id):
 def view_locations():
     """List all locations."""
     page = request.args.get("page", 1, type=int)
+    per_page = get_per_page()
     name_query = request.args.get("name_query", "")
     match_mode = request.args.get("match_mode", "contains")
     archived = request.args.get("archived", "active")
@@ -299,7 +301,7 @@ def view_locations():
             query = query.filter(Location.name.like(f"%{name_query}%"))
 
     locations = query.order_by(Location.name).paginate(
-        page=page, per_page=current_user.pagination_limit
+        page=page, per_page=per_page
     )
     delete_form = DeleteForm()
     return render_template(
@@ -309,6 +311,8 @@ def view_locations():
         name_query=name_query,
         match_mode=match_mode,
         archived=archived,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )
 
 

--- a/app/routes/product_routes.py
+++ b/app/routes/product_routes.py
@@ -11,7 +11,7 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import login_required
 from sqlalchemy import func, or_
 from sqlalchemy.orm import aliased, selectinload
 
@@ -34,6 +34,7 @@ from app.models import (
     TerminalSale,
 )
 from app.utils.activity import log_activity
+from app.utils.pagination import build_pagination_args, get_per_page
 
 product = Blueprint("product", __name__)
 
@@ -56,6 +57,7 @@ def view_products():
     bulk_cost_form = BulkProductCostForm()
     create_form = ProductWithRecipeForm()
     page = request.args.get("page", 1, type=int)
+    per_page = get_per_page()
     name_query = request.args.get("name_query", "")
     match_mode = request.args.get("match_mode", "contains")
     sales_gl_code_ids = [
@@ -157,9 +159,7 @@ def view_products():
         selectinload(Product.recipe_items).selectinload(ProductRecipeItem.unit),
     )
 
-    products = query.paginate(
-        page=page, per_page=current_user.pagination_limit
-    )
+    products = query.paginate(page=page, per_page=per_page)
     sales_gl_codes = (
         GLCode.query.filter(GLCode.code.like("4%")).order_by(GLCode.code).all()
     )
@@ -190,6 +190,8 @@ def view_products():
         last_sold_before=last_sold_before_str,
         include_unsold=include_unsold,
         bulk_cost_form=bulk_cost_form,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )
 
 

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -30,6 +30,7 @@ from app.models import (
     Vendor,
 )
 from app.utils.activity import log_activity
+from app.utils.pagination import build_pagination_args, get_per_page
 
 import datetime
 
@@ -78,6 +79,7 @@ def view_purchase_orders():
     """Show purchase orders with optional filters."""
     delete_form = DeleteForm()
     page = request.args.get("page", 1, type=int)
+    per_page = get_per_page()
     vendor_id = request.args.get("vendor_id", type=int)
     status = request.args.get("status", "pending")
     start_date_str = request.args.get("start_date")
@@ -116,7 +118,7 @@ def view_purchase_orders():
     )
 
     orders = query.order_by(PurchaseOrder.order_date.desc()).paginate(
-        page=page, per_page=current_user.pagination_limit
+        page=page, per_page=per_page
     )
 
     vendors = Vendor.query.filter_by(archived=False).all()
@@ -131,6 +133,8 @@ def view_purchase_orders():
         end_date=end_date_str,
         status=status,
         selected_vendor=selected_vendor,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )
 
 
@@ -464,6 +468,7 @@ def receive_invoice(po_id):
 def view_purchase_invoices():
     """List all received purchase invoices."""
     page = request.args.get("page", 1, type=int)
+    per_page = get_per_page()
     invoice_id = request.args.get("invoice_id", type=int)
     po_number = request.args.get("po_number", type=int)
     vendor_id = request.args.get("vendor_id", type=int)
@@ -508,7 +513,7 @@ def view_purchase_invoices():
 
     invoices = query.order_by(
         PurchaseInvoice.received_date.desc(), PurchaseInvoice.id.desc()
-    ).paginate(page=page, per_page=current_user.pagination_limit)
+    ).paginate(page=page, per_page=per_page)
 
     vendors = Vendor.query.order_by(Vendor.first_name, Vendor.last_name).all()
     locations = Location.query.order_by(Location.name).all()
@@ -528,6 +533,8 @@ def view_purchase_invoices():
         end_date=end_date_str,
         active_vendor=active_vendor,
         active_location=active_location,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )
 
 

--- a/app/routes/transfer_routes.py
+++ b/app/routes/transfer_routes.py
@@ -29,6 +29,7 @@ from app.models import (
     User,
 )
 from app.utils.activity import log_activity
+from app.utils.pagination import build_pagination_args, get_per_page
 from app.utils.sms import send_sms
 
 transfer = Blueprint("transfer", __name__)
@@ -173,9 +174,8 @@ def view_transfers():
     elif filter_option == "not_completed":
         query = query.filter(~Transfer.completed)
 
-    transfers = query.paginate(
-        page=page, per_page=current_user.pagination_limit
-    )
+    per_page = get_per_page()
+    transfers = query.paginate(page=page, per_page=per_page)
 
     form = TransferForm()
     add_form = TransferForm(prefix="add")
@@ -186,6 +186,8 @@ def view_transfers():
         form=form,
         add_form=add_form,
         edit_form=edit_form,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )
 
 

--- a/app/routes/vendor_routes.py
+++ b/app/routes/vendor_routes.py
@@ -8,12 +8,13 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import current_user, login_required
+from flask_login import login_required
 
 from app import db
 from app.forms import CustomerForm, DeleteForm
 from app.models import Vendor
 from app.utils.activity import log_activity
+from app.utils.pagination import build_pagination_args, get_per_page
 
 vendor = Blueprint("vendor", __name__)
 
@@ -23,12 +24,17 @@ vendor = Blueprint("vendor", __name__)
 def view_vendors():
     """Display all vendors."""
     page = request.args.get("page", 1, type=int)
+    per_page = get_per_page()
     vendors = Vendor.query.filter_by(archived=False).paginate(
-        page=page, per_page=current_user.pagination_limit
+        page=page, per_page=per_page
     )
     delete_form = DeleteForm()
     return render_template(
-        "vendors/view_vendors.html", vendors=vendors, delete_form=delete_form
+        "vendors/view_vendors.html",
+        vendors=vendors,
+        delete_form=delete_form,
+        per_page=per_page,
+        pagination_args=build_pagination_args(per_page),
     )
 
 

--- a/app/templates/customers/view_customers.html
+++ b/app/templates/customers/view_customers.html
@@ -101,23 +101,37 @@
         </tbody>
     </table>
     </div>
-    <nav aria-label="Customer pagination">
-        <ul class="pagination">
-            {% if customers.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.prev_num, name_query=name_query, match_mode=match_mode, gst_exempt=gst_exempt, pst_exempt=pst_exempt) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ customers.page }} of {{ customers.pages }}</span>
-            </li>
-            {% if customers.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.next_num, name_query=name_query, match_mode=match_mode, gst_exempt=gst_exempt, pst_exempt=pst_exempt) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Customer pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not customers.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.prev_num if customers.has_prev else 1, **pagination_args) }}"{% if not customers.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ customers.page }} of {{ customers.pages }}</span>
+                </li>
+                <li class="page-item {% if not customers.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('customer.view_customers', page=customers.next_num if customers.has_next else customers.pages or 1, **pagination_args) }}"{% if not customers.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="customers-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="customers-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 
     <!-- Create Customer Modal -->
     <div class="modal fade" id="createCustomerModal" tabindex="-1" aria-labelledby="createCustomerModalLabel" aria-hidden="true">

--- a/app/templates/gl_codes/view_gl_codes.html
+++ b/app/templates/gl_codes/view_gl_codes.html
@@ -73,23 +73,37 @@
         </tbody>
     </table>
     </div>
-    <nav aria-label="GL code pagination">
-        <ul class="pagination">
-            {% if codes.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.prev_num, code_query=code_query, description_query=description_query) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ codes.page }} of {{ codes.pages }}</span>
-            </li>
-            {% if codes.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.next_num, code_query=code_query, description_query=description_query) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="GL code pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not codes.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.prev_num if codes.has_prev else 1, **pagination_args) }}"{% if not codes.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ codes.page }} of {{ codes.pages }}</span>
+                </li>
+                <li class="page-item {% if not codes.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('glcode.view_gl_codes', page=codes.next_num if codes.has_next else codes.pages or 1, **pagination_args) }}"{% if not codes.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="glcodes-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="glcodes-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 </div>
 
 <div class="modal fade" id="glCodeModal" tabindex="-1" aria-hidden="true">

--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -44,23 +44,37 @@
         </tbody>
     </table>
     </div>
-    <nav aria-label="Invoice pagination">
-        <ul class="pagination">
-            {% if invoices.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('invoice.view_invoices', page=invoices.prev_num) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ invoices.page }} of {{ invoices.pages }}</span>
-            </li>
-            {% if invoices.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('invoice.view_invoices', page=invoices.next_num) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Invoice pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not invoices.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('invoice.view_invoices', page=invoices.prev_num if invoices.has_prev else 1, **pagination_args) }}"{% if not invoices.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ invoices.page }} of {{ invoices.pages }}</span>
+                </li>
+                <li class="page-item {% if not invoices.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('invoice.view_invoices', page=invoices.next_num if invoices.has_next else invoices.pages or 1, **pagination_args) }}"{% if not invoices.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="invoices-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="invoices-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 </div>
 
 <!-- Filter Modal -->

--- a/app/templates/items/item_locations.html
+++ b/app/templates/items/item_locations.html
@@ -22,21 +22,35 @@
     </tbody>
 </table>
 </div>
-<nav aria-label="Location pagination">
-    <ul class="pagination">
-        {% if entries.has_prev %}
-        <li class="page-item">
-            <a class="page-link" href="{{ url_for('item.item_locations', item_id=item.id, page=entries.prev_num) }}">Previous</a>
-        </li>
-        {% endif %}
-        <li class="page-item disabled">
-            <span class="page-link">Page {{ entries.page }} of {{ entries.pages }}</span>
-        </li>
-        {% if entries.has_next %}
-        <li class="page-item">
-            <a class="page-link" href="{{ url_for('item.item_locations', item_id=item.id, page=entries.next_num) }}">Next</a>
-        </li>
-        {% endif %}
-    </ul>
-</nav>
+<div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+    <nav aria-label="Location pagination">
+        <ul class="pagination mb-0">
+            <li class="page-item {% if not entries.has_prev %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('item.item_locations', item_id=item.id, page=entries.prev_num if entries.has_prev else 1, **pagination_args) }}"{% if not entries.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+            </li>
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ entries.page }} of {{ entries.pages }}</span>
+            </li>
+            <li class="page-item {% if not entries.has_next %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('item.item_locations', item_id=item.id, page=entries.next_num if entries.has_next else entries.pages or 1, **pagination_args) }}"{% if not entries.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+            </li>
+        </ul>
+    </nav>
+    <form method="get" class="d-flex align-items-center gap-2">
+        {% for key, values in request.args.lists() %}
+            {% if key not in ['page', 'per_page'] %}
+                {% for value in values %}
+                    <input type="hidden" name="{{ key }}" value="{{ value }}">
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+        <input type="hidden" name="page" value="1">
+        <label for="item-locations-per-page" class="form-label mb-0">Rows per page</label>
+        <select id="item-locations-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            {% for option in PAGINATION_SIZES %}
+                <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+        </select>
+    </form>
+</div>
 {% endblock %}

--- a/app/templates/items/view_item.html
+++ b/app/templates/items/view_item.html
@@ -30,21 +30,35 @@
                     </tbody>
                 </table>
             </div>
-            <nav aria-label="Purchase invoice pagination">
-                <ul class="pagination">
-                    {% if purchase_items.has_prev %}
-                    <li class="page-item">
-                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.prev_num, sales_page=sales_items.page, transfer_page=transfer_items.page) }}">Previous</a>
-                    </li>
-                    {% endif %}
-                    <li class="page-item disabled"><span class="page-link">Page {{ purchase_items.page }} of {{ purchase_items.pages }}</span></li>
-                    {% if purchase_items.has_next %}
-                    <li class="page-item">
-                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.next_num, sales_page=sales_items.page, transfer_page=transfer_items.page) }}">Next</a>
-                    </li>
-                    {% endif %}
-                </ul>
-            </nav>
+            <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-2">
+                <nav aria-label="Purchase invoice pagination">
+                    <ul class="pagination mb-0">
+                        <li class="page-item {% if not purchase_items.has_prev %}disabled{% endif %}">
+                            <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.prev_num if purchase_items.has_prev else 1, **purchase_pagination_args) }}"{% if not purchase_items.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                        </li>
+                        <li class="page-item disabled"><span class="page-link">Page {{ purchase_items.page }} of {{ purchase_items.pages }}</span></li>
+                        <li class="page-item {% if not purchase_items.has_next %}disabled{% endif %}">
+                            <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.next_num if purchase_items.has_next else purchase_items.pages or 1, **purchase_pagination_args) }}"{% if not purchase_items.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                        </li>
+                    </ul>
+                </nav>
+                <form method="get" class="d-flex align-items-center gap-2">
+                    {% for key, values in request.args.lists() %}
+                        {% if key not in ['purchase_page', 'purchase_per_page'] %}
+                            {% for value in values %}
+                                <input type="hidden" name="{{ key }}" value="{{ value }}">
+                            {% endfor %}
+                        {% endif %}
+                    {% endfor %}
+                    <input type="hidden" name="purchase_page" value="1">
+                    <label for="purchase-per-page" class="form-label mb-0">Rows per page</label>
+                    <select id="purchase-per-page" name="purchase_per_page" class="form-select" onchange="this.form.submit()">
+                        {% for option in PAGINATION_SIZES %}
+                            <option value="{{ option }}" {% if purchase_per_page == option %}selected{% endif %}>{{ option }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
+            </div>
         </div>
         <div class="col-12 mt-4">
             <h4>Recent Sales Invoices</h4>
@@ -72,21 +86,35 @@
                     </tbody>
                 </table>
             </div>
-            <nav aria-label="Sales invoice pagination">
-                <ul class="pagination">
-                    {% if sales_items.has_prev %}
-                    <li class="page-item">
-                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.page, sales_page=sales_items.prev_num, transfer_page=transfer_items.page) }}">Previous</a>
-                    </li>
-                    {% endif %}
-                    <li class="page-item disabled"><span class="page-link">Page {{ sales_items.page }} of {{ sales_items.pages }}</span></li>
-                    {% if sales_items.has_next %}
-                    <li class="page-item">
-                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.page, sales_page=sales_items.next_num, transfer_page=transfer_items.page) }}">Next</a>
-                    </li>
-                    {% endif %}
-                </ul>
-            </nav>
+            <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-2">
+                <nav aria-label="Sales invoice pagination">
+                    <ul class="pagination mb-0">
+                        <li class="page-item {% if not sales_items.has_prev %}disabled{% endif %}">
+                            <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, sales_page=sales_items.prev_num if sales_items.has_prev else 1, **sales_pagination_args) }}"{% if not sales_items.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                        </li>
+                        <li class="page-item disabled"><span class="page-link">Page {{ sales_items.page }} of {{ sales_items.pages }}</span></li>
+                        <li class="page-item {% if not sales_items.has_next %}disabled{% endif %}">
+                            <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, sales_page=sales_items.next_num if sales_items.has_next else sales_items.pages or 1, **sales_pagination_args) }}"{% if not sales_items.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                        </li>
+                    </ul>
+                </nav>
+                <form method="get" class="d-flex align-items-center gap-2">
+                    {% for key, values in request.args.lists() %}
+                        {% if key not in ['sales_page', 'sales_per_page'] %}
+                            {% for value in values %}
+                                <input type="hidden" name="{{ key }}" value="{{ value }}">
+                            {% endfor %}
+                        {% endif %}
+                    {% endfor %}
+                    <input type="hidden" name="sales_page" value="1">
+                    <label for="sales-per-page" class="form-label mb-0">Rows per page</label>
+                    <select id="sales-per-page" name="sales_per_page" class="form-select" onchange="this.form.submit()">
+                        {% for option in PAGINATION_SIZES %}
+                            <option value="{{ option }}" {% if sales_per_page == option %}selected{% endif %}>{{ option }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
+            </div>
         </div>
         <div class="col-12 mt-4">
             <h4>Recent Transfers</h4>
@@ -116,21 +144,35 @@
                     </tbody>
                 </table>
             </div>
-            <nav aria-label="Transfer pagination">
-                <ul class="pagination">
-                    {% if transfer_items.has_prev %}
-                    <li class="page-item">
-                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.page, sales_page=sales_items.page, transfer_page=transfer_items.prev_num) }}">Previous</a>
-                    </li>
-                    {% endif %}
-                    <li class="page-item disabled"><span class="page-link">Page {{ transfer_items.page }} of {{ transfer_items.pages }}</span></li>
-                    {% if transfer_items.has_next %}
-                    <li class="page-item">
-                        <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, purchase_page=purchase_items.page, sales_page=sales_items.page, transfer_page=transfer_items.next_num) }}">Next</a>
-                    </li>
-                    {% endif %}
-                </ul>
-            </nav>
+            <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-2">
+                <nav aria-label="Transfer pagination">
+                    <ul class="pagination mb-0">
+                        <li class="page-item {% if not transfer_items.has_prev %}disabled{% endif %}">
+                            <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, transfer_page=transfer_items.prev_num if transfer_items.has_prev else 1, **transfer_pagination_args) }}"{% if not transfer_items.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                        </li>
+                        <li class="page-item disabled"><span class="page-link">Page {{ transfer_items.page }} of {{ transfer_items.pages }}</span></li>
+                        <li class="page-item {% if not transfer_items.has_next %}disabled{% endif %}">
+                            <a class="page-link" href="{{ url_for('item.view_item', item_id=item.id, transfer_page=transfer_items.next_num if transfer_items.has_next else transfer_items.pages or 1, **transfer_pagination_args) }}"{% if not transfer_items.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                        </li>
+                    </ul>
+                </nav>
+                <form method="get" class="d-flex align-items-center gap-2">
+                    {% for key, values in request.args.lists() %}
+                        {% if key not in ['transfer_page', 'transfer_per_page'] %}
+                            {% for value in values %}
+                                <input type="hidden" name="{{ key }}" value="{{ value }}">
+                            {% endfor %}
+                        {% endif %}
+                    {% endfor %}
+                    <input type="hidden" name="transfer_page" value="1">
+                    <label for="transfer-per-page" class="form-label mb-0">Rows per page</label>
+                    <select id="transfer-per-page" name="transfer_per_page" class="form-select" onchange="this.form.submit()">
+                        {% for option in PAGINATION_SIZES %}
+                            <option value="{{ option }}" {% if transfer_per_page == option %}selected{% endif %}>{{ option }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
+            </div>
         </div>
     </div>
 </div>

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -222,23 +222,37 @@
         </table>
         </div>
     </form>
-    <nav aria-label="Item pagination">
-        <ul class="pagination">
-            {% if items.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_ids, base_unit=base_unit, cost_min=cost_min, cost_max=cost_max, archived=archived, vendor_id=vendor_ids) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ items.page }} of {{ items.pages }}</span>
-            </li>
-            {% if items.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num, name_query=name_query, match_mode=match_mode, gl_code_id=gl_code_ids, base_unit=base_unit, cost_min=cost_min, cost_max=cost_max, archived=archived, vendor_id=vendor_ids) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Item pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not items.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('item.view_items', page=items.prev_num if items.has_prev else 1, **pagination_args) }}"{% if not items.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ items.page }} of {{ items.pages }}</span>
+                </li>
+                <li class="page-item {% if not items.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('item.view_items', page=items.next_num if items.has_next else items.pages or 1, **pagination_args) }}"{% if not items.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="items-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="items-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 </div>
 <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 <script>

--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -48,23 +48,37 @@
         </tbody>
     </table>
     </div>
-    <nav aria-label="Location pagination">
-        <ul class="pagination">
-            {% if locations.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.prev_num, name_query=name_query, match_mode=match_mode, archived=archived) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ locations.page }} of {{ locations.pages }}</span>
-            </li>
-            {% if locations.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.next_num, name_query=name_query, match_mode=match_mode, archived=archived) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Location pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not locations.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.prev_num if locations.has_prev else 1, **pagination_args) }}"{% if not locations.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ locations.page }} of {{ locations.pages }}</span>
+                </li>
+                <li class="page-item {% if not locations.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('locations.view_locations', page=locations.next_num if locations.has_next else locations.pages or 1, **pagination_args) }}"{% if not locations.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="locations-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="locations-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 </div>
 <!-- Filter Modal -->
 <div class="modal fade" id="filterModal" tabindex="-1" aria-labelledby="filterModalLabel" aria-hidden="true">

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -243,23 +243,37 @@
         </table>
         </div>
     </form>
-    <nav aria-label="Product pagination">
-        <ul class="pagination">
-            {% if products.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_ids, customer_id=customer_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max, last_sold_before=last_sold_before, include_unsold=1 if include_unsold else None) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ products.page }} of {{ products.pages }}</span>
-            </li>
-            {% if products.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num, name_query=name_query, match_mode=match_mode, sales_gl_code_id=sales_gl_code_ids, customer_id=customer_id, cost_min=cost_min, cost_max=cost_max, price_min=price_min, price_max=price_max, last_sold_before=last_sold_before, include_unsold=1 if include_unsold else None) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Product pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not products.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('product.view_products', page=products.prev_num if products.has_prev else 1, **pagination_args) }}"{% if not products.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ products.page }} of {{ products.pages }}</span>
+                </li>
+                <li class="page-item {% if not products.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('product.view_products', page=products.next_num if products.has_next else products.pages or 1, **pagination_args) }}"{% if not products.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="products-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="products-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 </div>
 <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 <script>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -29,17 +29,6 @@
     <button type="submit" class="btn btn-primary mt-2">{{ tz_form.submit.label.text }}</button>
 </form>
 <form method="post" class="mt-3">
-    {{ pagination_form.hidden_tag() }}
-    <div class="form-group">
-        {{ pagination_form.items_per_page.label(class_='form-label') }}
-        {{ pagination_form.items_per_page(class_='form-control', min=1, max=1000) }}
-        {% for error in pagination_form.items_per_page.errors %}
-        <div class="text-danger">{{ error }}</div>
-        {% endfor %}
-    </div>
-    <button type="submit" class="btn btn-primary mt-2">{{ pagination_form.submit.label.text }}</button>
-</form>
-<form method="post" class="mt-3">
     {{ notif_form.hidden_tag() }}
     <div class="form-group">
         {{ notif_form.phone_number.label(class_='form-label') }}

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -255,23 +255,37 @@
         </tbody>
     </table>
     </div>
-    <nav aria-label="Purchase invoice pagination">
-        <ul class="pagination">
-            {% if invoices.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('purchase.view_purchase_invoices', page=invoices.prev_num, invoice_id=invoice_id, po_number=po_number, vendor_id=vendor_id, location_id=location_id, start_date=start_date, end_date=end_date) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ invoices.page }} of {{ invoices.pages }}</span>
-            </li>
-            {% if invoices.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('purchase.view_purchase_invoices', page=invoices.next_num, invoice_id=invoice_id, po_number=po_number, vendor_id=vendor_id, location_id=location_id, start_date=start_date, end_date=end_date) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Purchase invoice pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not invoices.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('purchase.view_purchase_invoices', page=invoices.prev_num if invoices.has_prev else 1, **pagination_args) }}"{% if not invoices.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ invoices.page }} of {{ invoices.pages }}</span>
+                </li>
+                <li class="page-item {% if not invoices.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('purchase.view_purchase_invoices', page=invoices.next_num if invoices.has_next else invoices.pages or 1, **pagination_args) }}"{% if not invoices.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="purchase-invoices-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="purchase-invoices-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 </div>
 <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 {% endblock %}

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -214,23 +214,37 @@
         </tbody>
     </table>
     </div>
-    <nav aria-label="Purchase order pagination">
-        <ul class="pagination">
-            {% if orders.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.prev_num, vendor_id=vendor_id, start_date=start_date, end_date=end_date, status=status) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ orders.page }} of {{ orders.pages }}</span>
-            </li>
-            {% if orders.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.next_num, vendor_id=vendor_id, start_date=start_date, end_date=end_date, status=status) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Purchase order pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not orders.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.prev_num if orders.has_prev else 1, **pagination_args) }}"{% if not orders.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ orders.page }} of {{ orders.pages }}</span>
+                </li>
+                <li class="page-item {% if not orders.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('purchase.view_purchase_orders', page=orders.next_num if orders.has_next else orders.pages or 1, **pagination_args) }}"{% if not orders.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="purchase-orders-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="purchase-orders-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 </div>
 <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 {% endblock %}

--- a/app/templates/transfers/view_transfers.html
+++ b/app/templates/transfers/view_transfers.html
@@ -34,23 +34,37 @@
     </table>
     </div>
     {% if transfers is defined %}
-    <nav aria-label="Transfer pagination">
-        <ul class="pagination">
-            {% if transfers.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('transfer.view_transfers', page=transfers.prev_num, filter=request.args.get('filter'), transfer_id=request.args.get('transfer_id'), from_location=request.args.get('from_location'), to_location=request.args.get('to_location')) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ transfers.page }} of {{ transfers.pages }}</span>
-            </li>
-            {% if transfers.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('transfer.view_transfers', page=transfers.next_num, filter=request.args.get('filter'), transfer_id=request.args.get('transfer_id'), from_location=request.args.get('from_location'), to_location=request.args.get('to_location')) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Transfer pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not transfers.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('transfer.view_transfers', page=transfers.prev_num if transfers.has_prev else 1, **pagination_args) }}"{% if not transfers.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ transfers.page }} of {{ transfers.pages }}</span>
+                </li>
+                <li class="page-item {% if not transfers.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('transfer.view_transfers', page=transfers.next_num if transfers.has_next else transfers.pages or 1, **pagination_args) }}"{% if not transfers.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="transfers-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="transfers-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
     {% endif %}
     </div>
 <!-- Add Transfer Modal -->

--- a/app/templates/vendors/view_vendors.html
+++ b/app/templates/vendors/view_vendors.html
@@ -24,23 +24,37 @@
         </tbody>
     </table>
     </div>
-    <nav aria-label="Vendor pagination">
-        <ul class="pagination">
-            {% if vendors.has_prev %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('vendor.view_vendors', page=vendors.prev_num) }}">Previous</a>
-            </li>
-            {% endif %}
-            <li class="page-item disabled">
-                <span class="page-link">Page {{ vendors.page }} of {{ vendors.pages }}</span>
-            </li>
-            {% if vendors.has_next %}
-            <li class="page-item">
-                <a class="page-link" href="{{ url_for('vendor.view_vendors', page=vendors.next_num) }}">Next</a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+        <nav aria-label="Vendor pagination">
+            <ul class="pagination mb-0">
+                <li class="page-item {% if not vendors.has_prev %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('vendor.view_vendors', page=vendors.prev_num if vendors.has_prev else 1, **pagination_args) }}"{% if not vendors.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+                </li>
+                <li class="page-item disabled">
+                    <span class="page-link">Page {{ vendors.page }} of {{ vendors.pages }}</span>
+                </li>
+                <li class="page-item {% if not vendors.has_next %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('vendor.view_vendors', page=vendors.next_num if vendors.has_next else vendors.pages or 1, **pagination_args) }}"{% if not vendors.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+                </li>
+            </ul>
+        </nav>
+        <form method="get" class="d-flex align-items-center gap-2">
+            {% for key, values in request.args.lists() %}
+                {% if key not in ['page', 'per_page'] %}
+                    {% for value in values %}
+                        <input type="hidden" name="{{ key }}" value="{{ value }}">
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <input type="hidden" name="page" value="1">
+            <label for="vendors-per-page" class="form-label mb-0">Rows per page</label>
+            <select id="vendors-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+                {% for option in PAGINATION_SIZES %}
+                    <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+                {% endfor %}
+            </select>
+        </form>
+    </div>
 </div>
 
 <!-- Vendor Modal -->

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -1,0 +1,79 @@
+"""Helpers for handling paginated views."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Tuple, Union
+
+from flask import request
+
+PAGINATION_SIZES: Tuple[int, ...] = (25, 50, 100, 250, 500, 1000)
+
+
+def get_per_page(param: str = "per_page", default: int = 25) -> int:
+    """Return a validated per-page value from the query string.
+
+    Parameters
+    ----------
+    param:
+        Query string parameter containing the requested page size.
+    default:
+        Fallback value used when the parameter is missing or invalid.
+
+    Returns
+    -------
+    int
+        A value from :data:`PAGINATION_SIZES`.
+    """
+
+    value = request.args.get(param, type=int)
+    if value in PAGINATION_SIZES:
+        return value
+    if default in PAGINATION_SIZES:
+        return default
+    return PAGINATION_SIZES[0]
+
+
+def build_pagination_args(
+    per_page: int,
+    *,
+    page_param: str = "page",
+    per_page_param: str = "per_page",
+    extra_params: Mapping[str, Any] | None = None,
+) -> Dict[str, Union[str, List[str]]]:
+    """Assemble arguments for pagination links.
+
+    Parameters
+    ----------
+    per_page:
+        The validated per-page value.
+    page_param:
+        Name of the page number query parameter to exclude.
+    per_page_param:
+        Name of the per-page query parameter to include.
+
+    Returns
+    -------
+    dict
+        Mapping of query parameter names to values suitable for ``url_for``.
+    """
+
+    args: Dict[str, Union[str, List[str]]] = {}
+    for key, values in request.args.lists():
+        if key in {page_param, per_page_param}:
+            continue
+        if not values:
+            continue
+        if len(values) == 1:
+            args[key] = values[0]
+        else:
+            args[key] = values
+    args[per_page_param] = str(per_page)
+    if extra_params:
+        for key, value in extra_params.items():
+            if value is None or key in args:
+                continue
+            if isinstance(value, (list, tuple)):
+                args[key] = [str(v) for v in value]
+            else:
+                args[key] = str(value)
+    return args

--- a/tests/test_pagination_utils.py
+++ b/tests/test_pagination_utils.py
@@ -1,0 +1,67 @@
+from app.utils.pagination import (
+    PAGINATION_SIZES,
+    build_pagination_args,
+    get_per_page,
+)
+
+def test_get_per_page_defaults(app):
+    with app.test_request_context("/"):
+        assert get_per_page() == PAGINATION_SIZES[0]
+
+
+def test_get_per_page_accepts_allowed_values(app):
+    with app.test_request_context("/?per_page=100"):
+        assert get_per_page() == 100
+
+
+def test_get_per_page_rejects_invalid_values(app):
+    with app.test_request_context("/?per_page=7"):
+        assert get_per_page() == PAGINATION_SIZES[0]
+
+
+def test_get_per_page_with_custom_parameter(app):
+    with app.test_request_context("/?purchase_per_page=250"):
+        assert get_per_page("purchase_per_page") == 250
+
+
+def test_build_pagination_args_includes_other_params(app):
+    url = "/?per_page=50&page=3&name_query=test&filter=active"
+    with app.test_request_context(url):
+        args = build_pagination_args(50)
+    assert args["per_page"] == "50"
+    assert args["name_query"] == "test"
+    assert args["filter"] == "active"
+    assert "page" not in args
+
+
+def test_build_pagination_args_preserves_list_values(app):
+    url = "/?per_page=25&page=2&gl_code_id=1&gl_code_id=2"
+    with app.test_request_context(url):
+        args = build_pagination_args(25)
+    assert args["gl_code_id"] == ["1", "2"]
+
+
+def test_build_pagination_args_with_custom_names(app):
+    url = (
+        "/?purchase_page=4&purchase_per_page=500&sales_page=2&sales_per_page=50"
+    )
+    with app.test_request_context(url):
+        args = build_pagination_args(
+            500, page_param="purchase_page", per_page_param="purchase_per_page"
+        )
+    assert args["purchase_per_page"] == "500"
+    assert "purchase_page" not in args
+    # Other pagination controls remain untouched
+    assert args["sales_page"] == "2"
+    assert args["sales_per_page"] == "50"
+
+
+def test_build_pagination_args_with_extra_params(app):
+    with app.test_request_context("/?page=3"):
+        args = build_pagination_args(25, extra_params={"archived": "active"})
+    assert args["archived"] == "active"
+    assert "page" not in args
+
+    with app.test_request_context("/?archived=archived"):
+        args = build_pagination_args(25, extra_params={"archived": "active"})
+    assert args["archived"] == "archived"

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -116,32 +116,3 @@ def test_user_can_set_timezone(client, app):
         assert user.timezone == "US/Eastern"
 
 
-def test_user_can_update_pagination_settings(client, app):
-    create_user(app, "paginate@example.com")
-    with client:
-        login(client, "paginate@example.com", "oldpass")
-        resp = client.post(
-            "/auth/profile",
-            data={"items_per_page": 75},
-            follow_redirects=True,
-        )
-        assert resp.status_code == 200
-    with app.app_context():
-        user = User.query.filter_by(email="paginate@example.com").first()
-        assert user.items_per_page == 75
-
-
-def test_pagination_setting_enforces_maximum(client, app):
-    create_user(app, "limit@example.com")
-    with client:
-        login(client, "limit@example.com", "oldpass")
-        resp = client.post(
-            "/auth/profile",
-            data={"items_per_page": 2000},
-            follow_redirects=True,
-        )
-        assert resp.status_code == 200
-        assert b"Number must be between 1 and 1000." in resp.data
-    with app.app_context():
-        user = User.query.filter_by(email="limit@example.com").first()
-        assert user.items_per_page == 20


### PR DESCRIPTION
## Summary
- add pagination utilities to resolve per-page selections from query parameters
- update paginated routes and templates to show dropdown selectors and preserve existing filters
- remove the profile pagination setting and add targeted tests for the new helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b68e3f64832486dc629167ca11de