### PR TITLE
Restore modal-based create item workflow

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -68,6 +68,12 @@ class LoginForm(FlaskForm):
     password = PasswordField("Password", validators=[DataRequired()])
 
 
+class CSRFOnlyForm(FlaskForm):
+    """Simple form that only provides CSRF protection."""
+
+    pass
+
+
 class PasswordResetRequestForm(FlaskForm):
     """Form for requesting a password reset email."""
 

--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -17,7 +17,7 @@ from werkzeug.utils import secure_filename
 from sqlalchemy.orm import selectinload
 
 from app import db
-from app.forms import ImportItemsForm, ItemForm
+from app.forms import CSRFOnlyForm, ImportItemsForm, ItemForm
 from app.models import (
     GLCode,
     Invoice,
@@ -133,7 +133,8 @@ def view_items():
     extra_pagination = {}
     if "archived" not in request.args:
         extra_pagination["archived"] = archived
-    form = ItemForm()
+    create_form = ItemForm()
+    bulk_delete_form = CSRFOnlyForm()
     gl_codes = GLCode.query.order_by(GLCode.code).all()
     base_units = [
         u
@@ -151,7 +152,8 @@ def view_items():
     return render_template(
         "items/view_items.html",
         items=items,
-        form=form,
+        create_form=create_form,
+        bulk_delete_form=bulk_delete_form,
         name_query=name_query,
         match_mode=match_mode,
         gl_codes=gl_codes,

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -192,7 +192,7 @@
     </div>
     {% endif %}
     <form id="bulk-delete-form" action="{{ url_for('item.bulk_delete_items') }}" method="post">
-        {{ form.hidden_tag() }}
+        {{ bulk_delete_form.hidden_tag() }}
         <div class="table-responsive">
         <table class="table sortable" id="itemsTable">
             <thead>
@@ -276,13 +276,24 @@ document.addEventListener('DOMContentLoaded', function() {
                 <h5 class="modal-title">Item</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body"></div>
+            <div class="modal-body">
+                {% with form=create_form, item=None %}
+                    {% include 'items/item_form.html' %}
+                {% endwith %}
+            </div>
         </div>
     </div>
 </div>
 
 <script>
 const itemModalEl = document.getElementById('itemModal');
+const itemModalBody = itemModalEl ? itemModalEl.querySelector('.modal-body') : null;
+let createItemTemplate = '';
+
+if (itemModalBody) {
+    createItemTemplate = itemModalBody.innerHTML.trim();
+    itemModalBody.innerHTML = '';
+}
 
 function executeScripts(container) {
     container.querySelectorAll('script').forEach(s => {
@@ -334,55 +345,62 @@ if (createItemBtn) {
             return;
         }
         event.preventDefault();
-        const url = createItemBtn.getAttribute('href');
-        if (!url) {
+        if (!createItemTemplate) {
             return;
         }
-        fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-            .then(r => r.text())
-            .then(html => {
-                itemModalEl.querySelector('.modal-title').textContent = 'Add Item';
-                itemModalEl.querySelector('.modal-body').innerHTML = html;
-                executeScripts(itemModalEl);
-                const modal = new bootstrap.Modal(itemModalEl);
-                modal.show();
-                bindItemForm(url);
-            })
-            .catch(() => {
-                window.location.href = url;
-            });
+        itemModalEl.dataset.mode = 'create';
+        itemModalEl.querySelector('.modal-title').textContent = 'Add Item';
+        itemModalBody.innerHTML = createItemTemplate;
+        executeScripts(itemModalEl);
+        const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
+        modal.show();
+        bindItemForm('{{ url_for('item.add_item') }}');
     });
 }
 
-document.querySelector('#itemsTable').addEventListener('click', function(e) {
-    if (e.target.classList.contains('edit-item-btn')) {
-        const itemId = e.target.getAttribute('data-item-id');
-        const url = '{{ url_for('item.edit_item', item_id=0) }}'.replace('0', itemId);
-        fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-            .then(r => r.text())
-            .then(html => {
-                itemModalEl.querySelector('.modal-title').textContent = 'Edit Item';
-                itemModalEl.querySelector('.modal-body').innerHTML = html;
-                executeScripts(itemModalEl);
-                const modal = new bootstrap.Modal(itemModalEl);
-                modal.show();
-                bindItemForm(url);
-            });
-    } else if (e.target.classList.contains('copy-item-btn')) {
-        const itemId = e.target.getAttribute('data-item-id');
-        const url = '{{ url_for('item.copy_item', item_id=0) }}'.replace('0', itemId);
-        const actionUrl = '{{ url_for('item.add_item') }}';
-        fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-            .then(r => r.text())
-            .then(html => {
-                itemModalEl.querySelector('.modal-title').textContent = 'Copy Item';
-                itemModalEl.querySelector('.modal-body').innerHTML = html;
-                executeScripts(itemModalEl);
-                const modal = new bootstrap.Modal(itemModalEl);
-                modal.show();
-                bindItemForm(actionUrl);
-            });
-    }
-});
+const itemsTableEl = document.querySelector('#itemsTable');
+if (itemsTableEl) {
+    itemsTableEl.addEventListener('click', function(e) {
+        if (e.target.classList.contains('edit-item-btn')) {
+            const itemId = e.target.getAttribute('data-item-id');
+            const url = '{{ url_for('item.edit_item', item_id=0) }}'.replace('0', itemId);
+            fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+                .then(r => r.text())
+                .then(html => {
+                    itemModalEl.dataset.mode = 'edit';
+                    itemModalEl.querySelector('.modal-title').textContent = 'Edit Item';
+                    itemModalEl.querySelector('.modal-body').innerHTML = html;
+                    executeScripts(itemModalEl);
+                    const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
+                    modal.show();
+                    bindItemForm(url);
+                });
+        } else if (e.target.classList.contains('copy-item-btn')) {
+            const itemId = e.target.getAttribute('data-item-id');
+            const url = '{{ url_for('item.copy_item', item_id=0) }}'.replace('0', itemId);
+            const actionUrl = '{{ url_for('item.add_item') }}';
+            fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
+                .then(r => r.text())
+                .then(html => {
+                    itemModalEl.dataset.mode = 'copy';
+                    itemModalEl.querySelector('.modal-title').textContent = 'Copy Item';
+                    itemModalEl.querySelector('.modal-body').innerHTML = html;
+                    executeScripts(itemModalEl);
+                    const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
+                    modal.show();
+                    bindItemForm(actionUrl);
+                });
+        }
+    });
+}
+
+if (itemModalEl) {
+    itemModalEl.addEventListener('hidden.bs.modal', () => {
+        if (itemModalEl.dataset.mode === 'create') {
+            itemModalBody.innerHTML = '';
+        }
+        itemModalEl.dataset.mode = '';
+    });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- embed the create item form in the modal and reuse it from a stored template so the "Add Item" flow always opens in a modal
- add a CSRF-only form so the bulk delete form keeps CSRF protection while the modal uses its own `ItemForm`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c34cac94832484a793ffe78d5811