### PR TITLE
Enable multi-location assignment for events

### DIFF
--- a/app/templates/events/add_location.html
+++ b/app/templates/events/add_location.html
@@ -3,7 +3,9 @@
 <h2>Add Location</h2>
 <form method="post">
     {{ form.csrf_token }}
-    {{ form.location_id.label }} {{ form.location_id(class='form-control') }}
+    {{ form.location_id.label }}
+    {{ form.location_id(class='form-control', size=10) }}
+    <small class="form-text text-muted">Hold Ctrl (Windows) or Command (Mac) to select multiple locations.</small>
     {{ form.submit(class='btn btn-primary mt-2') }}
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow event location form to select multiple locations at once while filtering out locations already assigned to the event
- update add-location workflow to create all selected event locations and surface a friendly message when none remain
- adjust the add location template to render the multi-select control with guidance for choosing multiple entries

## Testing
- pytest tests/test_event_flow.py tests/test_count_sheet_items_and_close.py tests/test_inventory_report.py

------
https://chatgpt.com/codex/tasks/task_e_68ca403c48d08324bfcfbe22ec162362