### PR TITLE
Improve CSP enforcement and remove unsafe inline handlers

### DIFF
--- a/app/static/js/security.js
+++ b/app/static/js/security.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener(
+    'click',
+    (event) => {
+      const confirmTarget = event.target.closest('[data-confirm-message]');
+      if (confirmTarget) {
+        const message = confirmTarget.getAttribute('data-confirm-message') || 'Are you sure?';
+        if (!window.confirm(message)) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          return;
+        }
+      }
+
+      const actionTarget = event.target.closest('[data-action]');
+      if (!actionTarget) {
+        return;
+      }
+
+      const action = actionTarget.getAttribute('data-action');
+      switch (action) {
+        case 'reload':
+          event.preventDefault();
+          window.location.reload();
+          break;
+        case 'print':
+          event.preventDefault();
+          window.print();
+          break;
+        default:
+          break;
+      }
+    },
+    true
+  );
+
+  document.addEventListener('change', (event) => {
+    const field = event.target.closest('.js-auto-submit');
+    if (field && field.form) {
+      field.form.submit();
+    }
+  });
+});

--- a/app/templates/admin/view_users.html
+++ b/app/templates/admin/view_users.html
@@ -31,14 +31,14 @@
                 <form action="{{ url_for('admin.users', user_id=user.id) }}" method="post" class="d-inline">
                     {{ form.hidden_tag() }}
                     <button type="submit" name="action" value="toggle_active" class="btn btn-sm btn-primary"
-                            onclick="return confirm('Are you sure you want to toggle the active status?');">
+                            data-confirm-message="Are you sure you want to toggle the active status?">
                         Toggle Active
                     </button>
                 </form>
                 <form action="{{ url_for('admin.users', user_id=user.id) }}" method="post" class="d-inline">
                     {{ form.hidden_tag() }}
                     <button type="submit" name="action" value="toggle_admin" class="btn btn-sm btn-secondary"
-                            onclick="return confirm('Are you sure you want to toggle the admin status?');">
+                            data-confirm-message="Are you sure you want to toggle the admin status?">
                         Toggle Admin
                     </button>
                 </form>
@@ -46,7 +46,7 @@
                 <form action="{{ url_for('admin.delete_user', user_id=user.id) }}" method="post" class="d-inline">
                     {{ form.hidden_tag() }}
                     <button type="submit" class="btn btn-sm btn-danger"
-                            onclick="return confirm('Are you sure you want to delete this user?');">
+                            data-confirm-message="Are you sure you want to delete this user?">
                         Delete
                     </button>
                 </form>

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -28,7 +28,7 @@
         {% endif %}
     </div>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.getElementById('toggle-password').addEventListener('click', function() {
     var pwd = document.getElementById('password-field');
     if (pwd.type === 'password') {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -355,6 +355,7 @@
     <!-- Scripts: jQuery must be loaded before Bootstrap -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/table-sort.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/security.js') }}" defer></script>
 </body>
 
 </html>

--- a/app/templates/customers/view_customers.html
+++ b/app/templates/customers/view_customers.html
@@ -93,7 +93,7 @@
                     <a href="{{ url_for('customer.edit_customer', customer_id=customer.id) }}" class="btn btn-primary mr-2">Edit</a>
                     <form action="{{ url_for('customer.delete_customer', customer_id=customer.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
-                        <button type="submit" class="btn btn-danger mr-2" onclick="return confirm('Are you sure you want to delete this customer?')">Delete</button>
+                        <button type="submit" class="btn btn-danger mr-2" data-confirm-message="Are you sure you want to delete this customer?">Delete</button>
                     </form>
                 </td>
             </tr>
@@ -125,7 +125,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="customers-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="customers-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="customers-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}
@@ -148,7 +148,7 @@
         </div>
     </div>
 
-    <script>
+    <script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
         const form = document.getElementById('customerForm');
         if (!form) return;
@@ -171,7 +171,7 @@
                             <a href="/customers/${data.customer.id}/edit" class="btn btn-primary mr-2">Edit</a>
                             <form action="/customers/${data.customer.id}/delete" method="post" class="d-inline">
                                 <input type="hidden" name="csrf_token" value="${data.delete_csrf_token}">
-                                <button type="submit" class="btn btn-danger mr-2" onclick="return confirm('Are you sure you want to delete this customer?')">Delete</button>
+                                <button type="submit" class="btn btn-danger mr-2" data-confirm-message="Are you sure you want to delete this customer?">Delete</button>
                             </form>
                         </td>`;
                     tbody.appendChild(row);

--- a/app/templates/events/count_sheet.html
+++ b/app/templates/events/count_sheet.html
@@ -37,7 +37,7 @@
         </table>
         </div>
         <button type="submit" class="btn btn-primary">Save</button>
-        <button type="button" class="btn btn-secondary" onclick="window.print()">Print</button>
+        <button type="button" class="btn btn-secondary" data-action="print">Print</button>
     </form>
 </div>
 {% endblock %}

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -42,7 +42,7 @@
     <button type="submit" class="btn btn-primary">Save</button>
     </form>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
     function calcVariance(row) {
         const sales = parseFloat(row.querySelector('.sales').dataset.sales) || 0;
         const pre = parseFloat(row.querySelector('input[name^="open_"]').value) || 0;

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -46,7 +46,7 @@
     </div>
 </div>
 {% if not event.closed and unconfirmed_count %}
-<script>
+<script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function () {
         const closeEventButton = document.getElementById('close-event-btn');
         if (!closeEventButton) {

--- a/app/templates/events/view_events.html
+++ b/app/templates/events/view_events.html
@@ -64,7 +64,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 $(function(){
     $('#filterForm').on('submit', function(e){
         e.preventDefault();

--- a/app/templates/gl_codes/view_gl_codes.html
+++ b/app/templates/gl_codes/view_gl_codes.html
@@ -65,7 +65,7 @@
                     <button type="button" class="btn btn-secondary btn-sm edit-gl-code" data-id="{{ code.id }}" data-code="{{ code.code }}" data-description="{{ code.description or '' }}">Edit</button>
                     <form action="{{ url_for('glcode.delete_gl_code', code_id=code.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
-                        <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure?');">Delete</button>
+                        <button type="submit" class="btn btn-danger btn-sm" data-confirm-message="Are you sure?">Delete</button>
                     </form>
                 </td>
             </tr>
@@ -97,7 +97,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="glcodes-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="glcodes-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="glcodes-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}
@@ -134,7 +134,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     const modalEl = document.getElementById('glCodeModal');
     const modal = new bootstrap.Modal(modalEl);
@@ -191,7 +191,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         <button type="button" class="btn btn-secondary btn-sm edit-gl-code" data-id="${data.id}" data-code="${data.code}" data-description="${data.description}">Edit</button>
                         <form action="/gl_codes/${data.id}/delete" method="post" class="d-inline">
                             <input type="hidden" name="csrf_token" value="${csrfToken}">
-                            <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure?');">Delete</button>
+                            <button type="submit" class="btn btn-danger btn-sm" data-confirm-message="Are you sure?">Delete</button>
                         </form>
                     </td>`;
                 tbody.prepend(row);

--- a/app/templates/invoices/create_invoice.html
+++ b/app/templates/invoices/create_invoice.html
@@ -7,7 +7,7 @@
     {% include "invoices/_invoice_form.html" %}
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 $(document).ready(function () {
     let currentTaxStatus = { gst_exempt: false, pst_exempt: false };
 

--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -68,7 +68,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="invoices-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="invoices-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="invoices-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}
@@ -127,7 +127,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 $(document).ready(function(){
     const deleteFormHTML = {{ delete_form.hidden_tag()|tojson }};
 

--- a/app/templates/items/item_form.html
+++ b/app/templates/items/item_form.html
@@ -57,7 +57,7 @@
         <button type="button" class="btn btn-outline-secondary" id="add-unit">Add Unit</button>
         {{ form.submit(class="btn btn-primary") }}
     </form>
-    <script type="text/template" id="unit-row-template">
+    <script type="text/template" id="unit-row-template" nonce="{{ csp_nonce }}">
         <div class="row g-2 align-items-end unit-row mb-2">
             <div class="col-md-4">
                 <label class="form-label visually-hidden" for="units-__index__-name">Unit of Measure</label>
@@ -90,7 +90,7 @@
             </div>
         </div>
     </script>
-    <script data-allow-html>
+    <script data-allow-html nonce="{{ csp_nonce }}">
         let unitIndex = {{ form.units|length }};
         const unitsContainer = document.getElementById('units-container');
         const unitTemplate = document.getElementById('unit-row-template').innerHTML.trim();

--- a/app/templates/items/item_locations.html
+++ b/app/templates/items/item_locations.html
@@ -46,7 +46,7 @@
         {% endfor %}
         <input type="hidden" name="page" value="1">
         <label for="item-locations-per-page" class="form-label mb-0">Rows per page</label>
-        <select id="item-locations-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+        <select id="item-locations-per-page" name="per_page" class="form-select js-auto-submit">
             {% for option in PAGINATION_SIZES %}
                 <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
             {% endfor %}

--- a/app/templates/items/view_item.html
+++ b/app/templates/items/view_item.html
@@ -52,7 +52,7 @@
                     {% endfor %}
                     <input type="hidden" name="purchase_page" value="1">
                     <label for="purchase-per-page" class="form-label mb-0">Rows per page</label>
-                    <select id="purchase-per-page" name="purchase_per_page" class="form-select" onchange="this.form.submit()">
+                    <select id="purchase-per-page" name="purchase_per_page" class="form-select js-auto-submit">
                         {% for option in PAGINATION_SIZES %}
                             <option value="{{ option }}" {% if purchase_per_page == option %}selected{% endif %}>{{ option }}</option>
                         {% endfor %}
@@ -108,7 +108,7 @@
                     {% endfor %}
                     <input type="hidden" name="sales_page" value="1">
                     <label for="sales-per-page" class="form-label mb-0">Rows per page</label>
-                    <select id="sales-per-page" name="sales_per_page" class="form-select" onchange="this.form.submit()">
+                    <select id="sales-per-page" name="sales_per_page" class="form-select js-auto-submit">
                         {% for option in PAGINATION_SIZES %}
                             <option value="{{ option }}" {% if sales_per_page == option %}selected{% endif %}>{{ option }}</option>
                         {% endfor %}
@@ -166,7 +166,7 @@
                     {% endfor %}
                     <input type="hidden" name="transfer_page" value="1">
                     <label for="transfer-per-page" class="form-label mb-0">Rows per page</label>
-                    <select id="transfer-per-page" name="transfer_per_page" class="form-select" onchange="this.form.submit()">
+                    <select id="transfer-per-page" name="transfer_per_page" class="form-select js-auto-submit">
                         {% for option in PAGINATION_SIZES %}
                             <option value="{{ option }}" {% if transfer_per_page == option %}selected{% endif %}>{{ option }}</option>
                         {% endfor %}

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -85,7 +85,7 @@
                 Filters
             </button>
             <a href="{{ url_for('item.import_items') }}" class="btn btn-info mb-3">Import Items</a>
-            <button type="submit" form="bulk-delete-form" class="btn btn-warning mb-3" onclick="return confirm('Are you sure?');">Delete Items</button>
+            <button type="submit" form="bulk-delete-form" class="btn btn-warning mb-3" data-confirm-message="Are you sure?">Delete Items</button>
         </div>
     </div>
 
@@ -246,7 +246,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="items-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="items-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="items-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}
@@ -255,7 +255,7 @@
     </div>
 </div>
 <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     var selectAll = document.getElementById('select-all');
     if (selectAll) {
@@ -285,8 +285,9 @@ document.addEventListener('DOMContentLoaded', function() {
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 const itemModalEl = document.getElementById('itemModal');
+const executingScript = document.currentScript;
 const itemModalBody = itemModalEl ? itemModalEl.querySelector('.modal-body') : null;
 let createItemTemplate = '';
 
@@ -296,6 +297,16 @@ if (itemModalBody) {
 }
 
 const EXECUTABLE_SCRIPT_TYPES = new Set(['', 'text/javascript', 'application/javascript', 'module']);
+
+function runInlineScript(code) {
+    const inlineScript = document.createElement('script');
+    if (executingScript && executingScript.nonce) {
+        inlineScript.setAttribute('nonce', executingScript.nonce);
+    }
+    inlineScript.textContent = code;
+    document.head.appendChild(inlineScript);
+    inlineScript.remove();
+}
 
 function executeScripts(container) {
     container.querySelectorAll('script').forEach((s) => {
@@ -317,7 +328,7 @@ function executeScripts(container) {
         const content = s.textContent;
         const allowHtml = s.dataset.allowHtml !== undefined;
         if (allowHtml || !/<\/?[a-z][\s\S]*>/i.test(content)) {
-            new Function(content)();
+            runInlineScript(content);
         }
         s.remove();
     });

--- a/app/templates/locations/add_location.html
+++ b/app/templates/locations/add_location.html
@@ -26,7 +26,7 @@
         {{ form.submit(class="btn btn-primary") }}
     </div>
 </form>
-<script>
+<script nonce="{{ csp_nonce }}">
 $(document).ready(function () {
     var selectedProducts = {};
     var preselected = {{ selected_products|tojson|safe }};

--- a/app/templates/locations/edit_location.html
+++ b/app/templates/locations/edit_location.html
@@ -26,7 +26,7 @@
         {{ form.submit(class="btn btn-primary") }}
     </div>
 </form>
-<script>
+<script nonce="{{ csp_nonce }}">
 $(document).ready(function () {
     var selectedProducts = {};
     var preselected = {{ selected_products|tojson|safe }};

--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -72,7 +72,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="locations-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="locations-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="locations-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}
@@ -150,7 +150,7 @@
         </div>
     </div>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     const csrfToken = document.getElementById('csrf_token').value;
     const locationModal = new bootstrap.Modal(document.getElementById('locationModal'));

--- a/app/templates/products/_create_product_form.html
+++ b/app/templates/products/_create_product_form.html
@@ -47,7 +47,7 @@
     <button type="button" class="btn btn-secondary" id="calc-cost" {% if product_id %}data-product-id="{{ product_id }}"{% else %}disabled{% endif %}>Set Cost From Recipe</button>
     <button type="submit" class="btn btn-primary">Submit</button>
 </form>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     const btn = document.getElementById('calc-cost');
     if (btn) {

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -267,7 +267,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="products-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="products-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="products-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}
@@ -276,7 +276,7 @@
     </div>
 </div>
 <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     const selectAllProducts = document.getElementById('select-all-products');
     if (selectAllProducts) {

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -279,7 +279,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="purchase-invoices-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="purchase-invoices-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="purchase-invoices-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -94,7 +94,7 @@
 </div>
 
 <script src="{{ url_for('static', filename='js/purchase_order_form.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     initPurchaseOrderForm({
         container: document.getElementById('items'),

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -104,7 +104,7 @@
 </div>
 
 <script src="{{ url_for('static', filename='js/purchase_order_form.js') }}"></script>
-<script>
+<script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     initPurchaseOrderForm({
         container: document.getElementById('items'),

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -53,7 +53,7 @@
         <button type="submit" class="btn btn-primary mt-3">Submit</button>
     </form>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
     const itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
 

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -206,7 +206,7 @@
                     <a href="{{ url_for('purchase.receive_invoice', po_id=order.id) }}" class="btn btn-sm btn-success">Receive</a>
                     <form action="{{ url_for('purchase.delete_purchase_order', po_id=order.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
-                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Are you sure?');">Delete</button>
+                        <button type="submit" class="btn btn-sm btn-danger" data-confirm-message="Are you sure?">Delete</button>
                     </form>
                 </td>
             </tr>
@@ -238,7 +238,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="purchase-orders-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="purchase-orders-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="purchase-orders-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}

--- a/app/templates/report_product_recipe.html
+++ b/app/templates/report_product_recipe.html
@@ -23,7 +23,7 @@
         <button type="submit" class="btn btn-primary">Generate Report</button>
     </form>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
     document.addEventListener('DOMContentLoaded', function() {
         const selectAll = document.querySelector('input[name="select_all"]');
         const checkboxes = document.querySelectorAll('input[name="products"]');

--- a/app/templates/spoilage/_table.html
+++ b/app/templates/spoilage/_table.html
@@ -1,6 +1,6 @@
 {% if results %}
 <div class="mb-3">
-    <button onclick="window.print()" class="btn btn-secondary">Print</button>
+    <button type="button" data-action="print" class="btn btn-secondary">Print</button>
 </div>
 <div class="table-responsive">
 <table class="table">

--- a/app/templates/spoilage/view_spoilage.html
+++ b/app/templates/spoilage/view_spoilage.html
@@ -49,7 +49,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     $(function () {
         $('#filterForm').on('submit', function (e) {
             e.preventDefault();

--- a/app/templates/transfers/_transfer_row.html
+++ b/app/templates/transfers/_transfer_row.html
@@ -12,7 +12,7 @@
         {% endif %}
         <form action="{{ url_for('transfer.delete_transfer', transfer_id=transfer.id) }}" method="post" class="d-inline">
             {{ form.hidden_tag() }}
-            <input type="submit" value="Delete" class="btn btn-danger" onclick="return confirm('Are you sure?');">
+            <input type="submit" value="Delete" class="btn btn-danger" data-confirm-message="Are you sure?">
         </form>
     </td>
 </tr>

--- a/app/templates/transfers/add_transfer.html
+++ b/app/templates/transfers/add_transfer.html
@@ -35,7 +35,7 @@
         {{ form.submit(class="btn btn-success") }}
     </form>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
     document.getElementById('item-name').addEventListener('input', function() {
         var input = this.value;
         if (input === ''){

--- a/app/templates/transfers/edit_transfer.html
+++ b/app/templates/transfers/edit_transfer.html
@@ -35,7 +35,7 @@
         {{ form.submit(class="btn btn-success") }}
     </form>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
     let itemIndex = 0;
     window.addEventListener('DOMContentLoaded', (event) => {
     const existingItems = {{ items | tojson | safe }};

--- a/app/templates/transfers/generate_report.html
+++ b/app/templates/transfers/generate_report.html
@@ -26,7 +26,7 @@
         <button type="submit" class="btn btn-primary mt-2">Generate Report</button>
     </form>
 </div>
-<script>
+<script nonce="{{ csp_nonce }}">
 flatpickr("#start_datetime", {
     enableTime: true,
     dateFormat: "Y-m-d H:i",

--- a/app/templates/transfers/view_transfers.html
+++ b/app/templates/transfers/view_transfers.html
@@ -6,7 +6,7 @@
     <div class="row mb-3 align-items-center">
         <div class="col-12 col-lg-auto mb-2 mb-lg-0 d-flex align-items-center">
             <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#addTransferModal">Add New Transfer</button>
-            <button id="new-transfer-alert" class="btn btn-warning me-2" onclick="window.location.reload();"
+            <button id="new-transfer-alert" type="button" class="btn btn-warning me-2" data-action="reload"
                     style="display: none;">
                 <img src="{{ url_for('static', filename='img/alert_icon.png') }}" alt="Reload"
                      style="width: 20px; height: 20px;"/>
@@ -58,7 +58,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="transfers-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="transfers-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="transfers-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}
@@ -171,7 +171,7 @@
   </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
     var protocol = window.location.protocol;
     var socket = io.connect(protocol + '//' + document.domain + ':' + location.port);
 

--- a/app/templates/vendors/_vendor_row.html
+++ b/app/templates/vendors/_vendor_row.html
@@ -6,7 +6,7 @@
         <a href="{{ url_for('vendor.edit_vendor', vendor_id=vendor.id) }}" class="btn btn-primary mr-2">Edit</a>
         <form action="{{ url_for('vendor.delete_vendor', vendor_id=vendor.id) }}" method="post" class="d-inline">
             {{ delete_form.hidden_tag() }}
-            <button type="submit" class="btn btn-danger mr-2" onclick="return confirm('Are you sure you want to delete this vendor?')">Delete</button>
+            <button type="submit" class="btn btn-danger mr-2" data-confirm-message="Are you sure you want to delete this vendor?">Delete</button>
         </form>
     </td>
 </tr>

--- a/app/templates/vendors/view_vendors.html
+++ b/app/templates/vendors/view_vendors.html
@@ -48,7 +48,7 @@
             {% endfor %}
             <input type="hidden" name="page" value="1">
             <label for="vendors-per-page" class="form-label mb-0">Rows per page</label>
-            <select id="vendors-per-page" name="per_page" class="form-select" onchange="this.form.submit()">
+            <select id="vendors-per-page" name="per_page" class="form-select js-auto-submit">
                 {% for option in PAGINATION_SIZES %}
                     <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
                 {% endfor %}
@@ -70,7 +70,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 const modalEl = document.getElementById('vendorModal');
 
 function bindVendorForm() {


### PR DESCRIPTION
## Summary
- replace the static CSP string with a nonce-aware template, generate a per-request nonce, and expose it to templates so inline scripts can execute safely
- add a centralized security helper script that handles confirmation prompts, print/reload actions, and auto-submit selects without inline handlers
- update templates to use CSP nonces, remove inline event attributes, and adopt the helper hooks for pagination and destructive actions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca4804b4848324ab22cf7cc6820c32