### PR TITLE
Refactor item form modal scripts

### DIFF
--- a/app/static/js/item_form.js
+++ b/app/static/js/item_form.js
@@ -1,0 +1,129 @@
+(function (window, document) {
+    'use strict';
+
+    function getTemplateHtml(templateEl) {
+        if (!templateEl) {
+            return '';
+        }
+        if (templateEl.tagName === 'TEMPLATE') {
+            return templateEl.innerHTML.trim();
+        }
+        return (templateEl.innerHTML || templateEl.textContent || '').trim();
+    }
+
+    function createUnitRow(templateHtml, index) {
+        if (!templateHtml) {
+            return null;
+        }
+        var wrapper = document.createElement('div');
+        wrapper.innerHTML = templateHtml.replace(/__index__/g, String(index));
+        return wrapper.firstElementChild;
+    }
+
+    function initDefaultsHandling(unitsContainer) {
+        unitsContainer.addEventListener('change', function (event) {
+            var target = event.target;
+            if (target.classList.contains('default-receiving') && target.checked) {
+                unitsContainer.querySelectorAll('.default-receiving').forEach(function (checkbox) {
+                    if (checkbox !== target) {
+                        checkbox.checked = false;
+                    }
+                });
+            } else if (target.classList.contains('default-transfer') && target.checked) {
+                unitsContainer.querySelectorAll('.default-transfer').forEach(function (checkbox) {
+                    if (checkbox !== target) {
+                        checkbox.checked = false;
+                    }
+                });
+            }
+        });
+    }
+
+    function initRemovalHandling(unitsContainer) {
+        unitsContainer.addEventListener('click', function (event) {
+            var button = event.target.closest('.remove-unit');
+            if (!button) {
+                return;
+            }
+            var row = button.closest('.unit-row');
+            if (row) {
+                row.remove();
+            }
+        });
+    }
+
+    function initItemForm(form) {
+        if (!form || form.dataset.itemFormInitialized === 'true') {
+            return;
+        }
+
+        var unitsContainer = form.querySelector('#units-container');
+        var templateEl = form.querySelector('#unit-row-template');
+        if (!unitsContainer || !templateEl) {
+            form.dataset.itemFormInitialized = 'true';
+            return;
+        }
+
+        var addButton = form.querySelector('#add-unit');
+        if (!addButton) {
+            form.dataset.itemFormInitialized = 'true';
+            return;
+        }
+
+        var templateHtml = getTemplateHtml(templateEl);
+        var nextIndexAttr = form.getAttribute('data-next-index');
+        var nextIndex = parseInt(nextIndexAttr || '', 10);
+        if (isNaN(nextIndex)) {
+            nextIndex = unitsContainer.querySelectorAll('.unit-row').length;
+        }
+
+        addButton.addEventListener('click', function () {
+            var newRow = createUnitRow(templateHtml, nextIndex);
+            if (newRow) {
+                unitsContainer.appendChild(newRow);
+                nextIndex += 1;
+                form.setAttribute('data-next-index', String(nextIndex));
+            }
+        });
+
+        initRemovalHandling(unitsContainer);
+        initDefaultsHandling(unitsContainer);
+
+        form.dataset.itemFormInitialized = 'true';
+    }
+
+    function init(container) {
+        if (!container) {
+            return;
+        }
+
+        if (container.matches && container.matches('form[data-item-form]')) {
+            initItemForm(container);
+            return;
+        }
+
+        var form = container.querySelector && container.querySelector('form[data-item-form]');
+        if (form) {
+            initItemForm(form);
+        }
+    }
+
+    window.ItemForm = window.ItemForm || {};
+    window.ItemForm.init = function (container) {
+        if (!container) {
+            return;
+        }
+        if (container instanceof window.Element || container === window.document) {
+            init(container);
+        } else if (typeof container.length === 'number') {
+            Array.prototype.forEach.call(container, init);
+        }
+    };
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var forms = document.querySelectorAll('form[data-item-form]');
+        if (forms.length) {
+            window.ItemForm.init(forms);
+        }
+    });
+}(window, document));

--- a/app/templates/items/item_form.html
+++ b/app/templates/items/item_form.html
@@ -1,4 +1,4 @@
-<form method="POST">
+<form method="POST" data-item-form data-next-index="{{ form.units|length }}">
         {{ form.hidden_tag() }}
         <div class="row">
             <div class="col-md-6 mb-3">
@@ -56,8 +56,7 @@
         </div>
         <button type="button" class="btn btn-outline-secondary" id="add-unit">Add Unit</button>
         {{ form.submit(class="btn btn-primary") }}
-    </form>
-    <script type="text/template" id="unit-row-template" nonce="{{ csp_nonce }}">
+        <template id="unit-row-template">
         <div class="row g-2 align-items-end unit-row mb-2">
             <div class="col-md-4">
                 <label class="form-label visually-hidden" for="units-__index__-name">Unit of Measure</label>
@@ -89,43 +88,5 @@
                 <button type="button" class="btn btn-outline-danger btn-sm remove-unit mt-4">Delete</button>
             </div>
         </div>
-    </script>
-    <script data-allow-html nonce="{{ csp_nonce }}">
-        let unitIndex = {{ form.units|length }};
-        const unitsContainer = document.getElementById('units-container');
-        const unitTemplate = document.getElementById('unit-row-template').innerHTML.trim();
-        document.getElementById('add-unit').addEventListener('click', function() {
-            const rowWrapper = document.createElement('div');
-            rowWrapper.innerHTML = unitTemplate.replace(/__index__/g, unitIndex);
-            const row = rowWrapper.firstElementChild;
-            unitsContainer.appendChild(row);
-            unitIndex++;
-        });
-        unitsContainer.addEventListener('click', function(e) {
-            if (e.target && e.target.classList.contains('remove-unit')) {
-                const row = e.target.closest('.unit-row');
-                if (row) {
-                    row.remove();
-                }
-            }
-        });
-        unitsContainer.addEventListener('change', function(e) {
-            if (e.target.classList.contains('default-receiving') && e.target.checked) {
-                unitsContainer
-                    .querySelectorAll('.default-receiving')
-                    .forEach(cb => {
-                        if (cb !== e.target) {
-                            cb.checked = false;
-                        }
-                    });
-            } else if (e.target.classList.contains('default-transfer') && e.target.checked) {
-                unitsContainer
-                    .querySelectorAll('.default-transfer')
-                    .forEach(cb => {
-                        if (cb !== e.target) {
-                            cb.checked = false;
-                        }
-                    });
-            }
-        });
-    </script>
+        </template>
+    </form>

--- a/app/templates/items/item_form_page.html
+++ b/app/templates/items/item_form_page.html
@@ -2,4 +2,5 @@
 
 {% block form_content %}
     {% include 'items/item_form.html' %}
+    <script src="{{ url_for('static', filename='js/item_form.js') }}"></script>
 {% endblock %}

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -255,6 +255,7 @@
     </div>
 </div>
 <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
+<script src="{{ url_for('static', filename='js/item_form.js') }}"></script>
 <script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     var selectAll = document.getElementById('select-all');
@@ -287,7 +288,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
 <script nonce="{{ csp_nonce }}">
 const itemModalEl = document.getElementById('itemModal');
-const executingScript = document.currentScript;
 const itemModalBody = itemModalEl ? itemModalEl.querySelector('.modal-body') : null;
 let createItemTemplate = '';
 
@@ -296,42 +296,10 @@ if (itemModalBody) {
     itemModalBody.innerHTML = '';
 }
 
-const EXECUTABLE_SCRIPT_TYPES = new Set(['', 'text/javascript', 'application/javascript', 'module']);
-
-function runInlineScript(code) {
-    const inlineScript = document.createElement('script');
-    if (executingScript && executingScript.nonce) {
-        inlineScript.setAttribute('nonce', executingScript.nonce);
+function initializeItemForm() {
+    if (window.ItemForm && typeof window.ItemForm.init === 'function') {
+        window.ItemForm.init(itemModalEl);
     }
-    inlineScript.textContent = code;
-    document.head.appendChild(inlineScript);
-    inlineScript.remove();
-}
-
-function executeScripts(container) {
-    container.querySelectorAll('script').forEach((s) => {
-        const src = s.getAttribute('src');
-        const typeAttr = (s.getAttribute('type') || '').trim().toLowerCase();
-
-        if (src) {
-            const script = document.createElement('script');
-            script.src = src;
-            document.head.appendChild(script);
-            s.remove();
-            return;
-        }
-
-        if (!EXECUTABLE_SCRIPT_TYPES.has(typeAttr)) {
-            return;
-        }
-
-        const content = s.textContent;
-        const allowHtml = s.dataset.allowHtml !== undefined;
-        if (allowHtml || !/<\/?[a-z][\s\S]*>/i.test(content)) {
-            runInlineScript(content);
-        }
-        s.remove();
-    });
 }
 
 function bindItemForm(actionUrl) {
@@ -359,7 +327,7 @@ function bindItemForm(actionUrl) {
                 bootstrap.Modal.getInstance(itemModalEl).hide();
             } else if (data.form_html) {
                 itemModalEl.querySelector('.modal-body').innerHTML = data.form_html;
-                executeScripts(itemModalEl);
+                initializeItemForm();
                 bindItemForm(actionUrl);
             }
         });
@@ -379,7 +347,7 @@ if (createItemBtn) {
         itemModalEl.dataset.mode = 'create';
         itemModalEl.querySelector('.modal-title').textContent = 'Add Item';
         itemModalBody.innerHTML = createItemTemplate;
-        executeScripts(itemModalEl);
+        initializeItemForm();
         const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
         modal.show();
         bindItemForm('{{ url_for('item.add_item') }}');
@@ -398,7 +366,7 @@ if (itemsTableEl) {
                     itemModalEl.dataset.mode = 'edit';
                     itemModalEl.querySelector('.modal-title').textContent = 'Edit Item';
                     itemModalEl.querySelector('.modal-body').innerHTML = html;
-                    executeScripts(itemModalEl);
+                    initializeItemForm();
                     const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
                     modal.show();
                     bindItemForm(url);
@@ -413,7 +381,7 @@ if (itemsTableEl) {
                     itemModalEl.dataset.mode = 'copy';
                     itemModalEl.querySelector('.modal-title').textContent = 'Copy Item';
                     itemModalEl.querySelector('.modal-body').innerHTML = html;
-                    executeScripts(itemModalEl);
+                    initializeItemForm();
                     const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
                     modal.show();
                     bindItemForm(actionUrl);


### PR DESCRIPTION
## Summary
- move the item form’s client-side logic into a reusable static script and store the dynamic unit row markup in a `<template>` element
- initialize item modal content with the new helper instead of evaluating inline scripts so CSP no longer blocks the page when editing items
- load the shared item form script on both the modal view and standalone item form page

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb24a2a3cc8324b89ff46091cbabbc