### PR TITLE
Fix edit item modal script execution without eval

### DIFF
--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -287,6 +287,41 @@ document.addEventListener('DOMContentLoaded', function() {
 </div>
 
 <script nonce="{{ csp_nonce }}">
+const currentScript = document.currentScript;
+const scriptNonce = currentScript ? currentScript.nonce : '';
+
+function executeInlineScripts(container) {
+    if (!container) {
+        return;
+    }
+
+    const scripts = container.querySelectorAll('script');
+    scripts.forEach((oldScript) => {
+        const replacement = document.createElement('script');
+        const oldNonce = oldScript.nonce || (oldScript.getAttribute('nonce') || '');
+        const finalNonce = oldNonce || scriptNonce;
+
+        Array.from(oldScript.attributes).forEach((attr) => {
+            if (attr.name.toLowerCase() === 'nonce') {
+                return;
+            }
+            replacement.setAttribute(attr.name, attr.value);
+        });
+
+        if (finalNonce) {
+            replacement.setAttribute('nonce', finalNonce);
+        }
+
+        if (oldScript.src) {
+            replacement.src = oldScript.src;
+        } else {
+            replacement.textContent = oldScript.textContent;
+        }
+
+        oldScript.replaceWith(replacement);
+    });
+}
+
 const itemModalEl = document.getElementById('itemModal');
 const itemModalBody = itemModalEl ? itemModalEl.querySelector('.modal-body') : null;
 let createItemTemplate = '';
@@ -327,6 +362,7 @@ function bindItemForm(actionUrl) {
                 bootstrap.Modal.getInstance(itemModalEl).hide();
             } else if (data.form_html) {
                 itemModalEl.querySelector('.modal-body').innerHTML = data.form_html;
+                executeInlineScripts(itemModalEl.querySelector('.modal-body'));
                 initializeItemForm();
                 bindItemForm(actionUrl);
             }
@@ -347,6 +383,7 @@ if (createItemBtn) {
         itemModalEl.dataset.mode = 'create';
         itemModalEl.querySelector('.modal-title').textContent = 'Add Item';
         itemModalBody.innerHTML = createItemTemplate;
+        executeInlineScripts(itemModalBody);
         initializeItemForm();
         const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
         modal.show();
@@ -366,6 +403,7 @@ if (itemsTableEl) {
                     itemModalEl.dataset.mode = 'edit';
                     itemModalEl.querySelector('.modal-title').textContent = 'Edit Item';
                     itemModalEl.querySelector('.modal-body').innerHTML = html;
+                    executeInlineScripts(itemModalEl.querySelector('.modal-body'));
                     initializeItemForm();
                     const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
                     modal.show();
@@ -381,6 +419,7 @@ if (itemsTableEl) {
                     itemModalEl.dataset.mode = 'copy';
                     itemModalEl.querySelector('.modal-title').textContent = 'Copy Item';
                     itemModalEl.querySelector('.modal-body').innerHTML = html;
+                    executeInlineScripts(itemModalEl.querySelector('.modal-body'));
                     initializeItemForm();
                     const modal = bootstrap.Modal.getOrCreateInstance(itemModalEl);
                     modal.show();


### PR DESCRIPTION
## Summary
- add a helper that replays any script tags inserted into the item modal without relying on `new Function`
- re-run the helper whenever AJAX responses replace the modal body so validation errors keep working under the stricter CSP

## Testing
- `pytest tests/test_item_detail_page.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68cc79c7c8c08324843dae152228fe87