### PR TITLE
Replace purchase order arrows with drag handles

### DIFF
--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -40,10 +40,7 @@
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data or '' }}"></select></div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col-auto">
-                <div class="d-flex flex-column gap-1">
-                    <button type="button" class="btn btn-outline-secondary btn-sm move-up" aria-label="Move item up">↑</button>
-                    <button type="button" class="btn btn-outline-secondary btn-sm move-down" aria-label="Move item down">↓</button>
-                </div>
+                <button type="button" class="btn btn-outline-secondary btn-sm drag-handle" aria-label="Drag to reorder" title="Drag to reorder">=</button>
             </div>
             <div class="col-auto">
                 <button type="button" class="btn btn-danger remove-item">Remove</button>

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -40,10 +40,7 @@
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data or '' }}"></select></div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col-auto">
-                <div class="d-flex flex-column gap-1">
-                    <button type="button" class="btn btn-outline-secondary btn-sm move-up" aria-label="Move item up">↑</button>
-                    <button type="button" class="btn btn-outline-secondary btn-sm move-down" aria-label="Move item down">↓</button>
-                </div>
+                <button type="button" class="btn btn-outline-secondary btn-sm drag-handle" aria-label="Drag to reorder" title="Drag to reorder">=</button>
             </div>
             <div class="col-auto">
                 <button type="button" class="btn btn-danger remove-item">Remove</button>


### PR DESCRIPTION
## Summary
- replace the up/down arrow controls on purchase order item rows with a drag handle in the create and edit forms
- implement drag-and-drop reordering logic in the purchase order form script to update item order and positions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1aefc60808324bc0b09fad2525c78