### PR TITLE
Show GL codes on purchase order item rows

### DIFF
--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -226,8 +226,15 @@ def create_purchase_order():
     item_lookup = {}
     if selected_item_ids:
         item_lookup = {
-            item.id: item.name
-            for item in Item.query.filter(Item.id.in_(selected_item_ids)).all()
+            item.id: {
+                "name": item.name,
+                "gl_code": item.purchase_gl_code.code
+                if item.purchase_gl_code
+                else "",
+            }
+            for item in Item.query.options(selectinload(Item.purchase_gl_code))
+            .filter(Item.id.in_(selected_item_ids))
+            .all()
         }
 
     codes = _purchase_gl_code_choices()
@@ -331,8 +338,15 @@ def edit_purchase_order(po_id):
     item_lookup = {}
     if selected_item_ids:
         item_lookup = {
-            item.id: item.name
-            for item in Item.query.filter(Item.id.in_(selected_item_ids)).all()
+            item.id: {
+                "name": item.name,
+                "gl_code": item.purchase_gl_code.code
+                if item.purchase_gl_code
+                else "",
+            }
+            for item in Item.query.options(selectinload(Item.purchase_gl_code))
+            .filter(Item.id.in_(selected_item_ids))
+            .all()
         }
 
     codes = _purchase_gl_code_choices()

--- a/app/static/js/purchase_order_form.js
+++ b/app/static/js/purchase_order_form.js
@@ -17,6 +17,29 @@
         const saveNewItemButton = config.saveNewItemButton || null;
         const newItemModalEl = config.newItemModal || null;
         const searchTimers = new WeakMap();
+        const defaultGlCodeLabel = "Unassigned";
+
+        function formatGlCode(value) {
+            if (typeof value === "string") {
+                const trimmed = value.trim();
+                if (trimmed) {
+                    return trimmed;
+                }
+            }
+            return defaultGlCodeLabel;
+        }
+
+        function updateRowGlCode(row, glCode) {
+            if (!row) {
+                return;
+            }
+            const display = row.querySelector(".gl-code-display");
+            if (!display) {
+                return;
+            }
+            display.textContent = formatGlCode(glCode || "");
+            display.dataset.glCode = glCode || "";
+        }
 
         let nextIndex = toNumber(
             config.nextIndex !== undefined
@@ -370,6 +393,19 @@
             suggestionList.style.overflowY = "auto";
             itemCol.appendChild(suggestionList);
 
+            const glCodeCol = document.createElement("div");
+            glCodeCol.classList.add("col-auto", "gl-code-column");
+            const glCodeBadge = document.createElement("span");
+            glCodeBadge.classList.add(
+                "gl-code-display",
+                "badge",
+                "bg-light",
+                "text-dark"
+            );
+            glCodeBadge.textContent = formatGlCode(options.glCode || "");
+            glCodeBadge.dataset.glCode = options.glCode || "";
+            glCodeCol.appendChild(glCodeBadge);
+
             const unitCol = document.createElement("div");
             unitCol.classList.add("col");
             const unitSelect = document.createElement("select");
@@ -413,7 +449,14 @@
             removeButton.textContent = "Remove";
             removeCol.appendChild(removeButton);
 
-            row.append(itemCol, unitCol, quantityCol, reorderCol, removeCol);
+            row.append(
+                itemCol,
+                glCodeCol,
+                unitCol,
+                quantityCol,
+                reorderCol,
+                removeCol
+            );
             return row;
         }
 
@@ -424,6 +467,8 @@
             container.dataset.nextIndex = String(nextIndex);
 
             updatePositions();
+
+            updateRowGlCode(row, options.glCode || "");
 
             const unitSelect = row.querySelector(".unit-select");
             if (options.itemId) {
@@ -573,6 +618,7 @@
                         option.textContent = item.name;
                         option.dataset.itemId = item.id;
                         option.dataset.itemName = item.name;
+                        option.dataset.glCode = item.gl_code || "";
                         suggestionList.appendChild(option);
                     });
 
@@ -595,6 +641,7 @@
             if (hiddenField) {
                 hiddenField.value = "";
             }
+            updateRowGlCode(row, "");
             clearUnits(unitSelect);
             closeAllSuggestionLists(suggestionList);
 
@@ -630,6 +677,7 @@
             if (searchInput) {
                 searchInput.value = option.dataset.itemName || "";
             }
+            updateRowGlCode(row, option.dataset.glCode || "");
             clearSuggestions(suggestionList);
             fetchUnits(option.dataset.itemId, unitSelect);
 
@@ -946,6 +994,7 @@
                         const row = addRow({
                             itemId: data.id,
                             itemName: data.name,
+                            glCode: data.gl_code || "",
                         });
                         const unitSelect = row.querySelector(".unit-select");
                         fetchUnits(data.id, unitSelect);

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -25,10 +25,9 @@
         <div id="items" data-next-index="{{ form.items|length }}">
         {% for item in form.items %}
         {% set item_id = item.item.data %}
-        {% set selected_name = '' %}
-        {% if item_id %}
-            {% set selected_name = item_lookup.get(item_id|int, '') %}
-        {% endif %}
+        {% set item_info = item_lookup.get(item_id|int) if item_id else None %}
+        {% set selected_name = item_info['name'] if item_info else '' %}
+        {% set selected_gl_code = item_info['gl_code'] if item_info else '' %}
         {% set input_value = request.form.get('items-' ~ loop.index0 ~ '-item-label', selected_name) %}
         <div class="row g-2 mt-2 item-row align-items-center">
             <div class="col position-relative">
@@ -36,6 +35,9 @@
                 {{ item.item(class="item-id-field") }}
                 <input type="hidden" name="items-{{ loop.index0 }}-position" class="item-position" value="{{ item.position.data or loop.index0 }}">
                 <div class="list-group suggestion-list d-none position-absolute w-100" style="z-index: 1000; max-height: 200px; overflow-y: auto;"></div>
+            </div>
+            <div class="col-auto gl-code-column">
+                <span class="gl-code-display badge bg-light text-dark" data-gl-code="{{ selected_gl_code }}">{{ selected_gl_code or 'Unassigned' }}</span>
             </div>
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data or '' }}"></select></div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -25,10 +25,9 @@
         <div id="items" data-next-index="{{ form.items|length }}">
         {% for item in form.items %}
         {% set item_id = item.item.data %}
-        {% set selected_name = '' %}
-        {% if item_id %}
-            {% set selected_name = item_lookup.get(item_id|int, '') %}
-        {% endif %}
+        {% set item_info = item_lookup.get(item_id|int) if item_id else None %}
+        {% set selected_name = item_info['name'] if item_info else '' %}
+        {% set selected_gl_code = item_info['gl_code'] if item_info else '' %}
         {% set input_value = request.form.get('items-' ~ loop.index0 ~ '-item-label', selected_name) %}
         <div class="row g-2 mt-2 item-row align-items-center">
             <div class="col position-relative">
@@ -36,6 +35,9 @@
                 {{ item.item(class="item-id-field") }}
                 <input type="hidden" name="items-{{ loop.index0 }}-position" class="item-position" value="{{ item.position.data or loop.index0 }}">
                 <div class="list-group suggestion-list d-none position-absolute w-100" style="z-index: 1000; max-height: 200px; overflow-y: auto;"></div>
+            </div>
+            <div class="col-auto gl-code-column">
+                <span class="gl-code-display badge bg-light text-dark" data-gl-code="{{ selected_gl_code }}">{{ selected_gl_code or 'Unassigned' }}</span>
             </div>
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data or '' }}"></select></div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>


### PR DESCRIPTION
## Summary
- surface purchase GL codes alongside each item row on the purchase order create and edit forms
- return purchase GL codes from item lookup endpoints so the UI can populate the new column
- update the purchase order form script to render and maintain GL code badges for existing, searched, and newly created items

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d47dfe976c8324905fe5c5385c39e3