### PR TITLE
Add GL code column to receiving form and enhance invoice report

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -624,6 +624,13 @@ def item_units(item_id):
     item = db.session.get(Item, item_id)
     if item is None:
         abort(404)
+
+    location_id = request.args.get("location_id", type=int)
+    if location_id:
+        gl_obj = item.purchase_gl_code_for_location(location_id)
+    else:
+        gl_obj = item.purchase_gl_code
+
     data = {
         "base_unit": item.base_unit,
         "units": [
@@ -636,6 +643,11 @@ def item_units(item_id):
             }
             for u in item.units
         ],
+        "purchase_gl_code": {
+            "id": gl_obj.id if gl_obj else None,
+            "code": gl_obj.code if gl_obj else "",
+            "description": gl_obj.description if gl_obj and gl_obj.description else "",
+        },
     }
     return jsonify(data)
 

--- a/app/templates/purchase_invoices/invoice_gl_report.html
+++ b/app/templates/purchase_invoices/invoice_gl_report.html
@@ -1,25 +1,83 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="container mt-4">
-    <h2>GL Report for Invoice {{ invoice.id }}</h2>
-    <p>Invoice Number: {{ invoice.invoice_number }}</p>
+    <h2>Purchase Invoice Report</h2>
+    <div class="card mb-4">
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-sm-4 col-md-3">Invoice ID</dt>
+                <dd class="col-sm-8 col-md-9">{{ invoice.id }}</dd>
+                <dt class="col-sm-4 col-md-3">Invoice Number</dt>
+                <dd class="col-sm-8 col-md-9">{{ invoice.invoice_number or '—' }}</dd>
+                <dt class="col-sm-4 col-md-3">Location Received To</dt>
+                <dd class="col-sm-8 col-md-9">{{ invoice.location_name }}</dd>
+                <dt class="col-sm-4 col-md-3">Received Date</dt>
+                <dd class="col-sm-8 col-md-9">{{ invoice.received_date|format_datetime('%Y-%m-%d') }}</dd>
+                <dt class="col-sm-4 col-md-3">Received By</dt>
+                <dd class="col-sm-8 col-md-9">{{ invoice_user.email if invoice_user else '—' }}</dd>
+            </dl>
+        </div>
+    </div>
+
+    <h3 class="h5">Items Received</h3>
+    <div class="table-responsive mb-4">
+        <table class="table table-sm align-middle">
+            <thead>
+                <tr>
+                    <th>Item</th>
+                    <th>Unit</th>
+                    <th class="text-end">Quantity</th>
+                    <th class="text-end">Price</th>
+                    <th class="text-end">Line Total</th>
+                    <th>GL Code</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for detail in item_details %}
+                <tr>
+                    <td>{{ detail.name }}</td>
+                    <td>{{ detail.unit or '—' }}</td>
+                    <td class="text-end">{{ '%.2f'|format(detail.quantity) }}</td>
+                    <td class="text-end">{{ '%.2f'|format(detail.cost) }}</td>
+                    <td class="text-end">{{ '%.2f'|format(detail.line_total) }}</td>
+                    <td>
+                        {{ detail.gl_code }}
+                        {% if detail.gl_description %}
+                            <br><small class="text-muted">{{ detail.gl_description }}</small>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% else %}
+                <tr>
+                    <td colspan="6" class="text-center text-muted">No items were found for this invoice.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <h3 class="h5">GL Code Totals</h3>
     <div class="table-responsive">
-    <table class="table">
-        <thead>
-            <tr>
-                <th>GL Code</th>
-                <th>Total</th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for code, total in report %}
-            <tr>
-                <td>{{ code }}</td>
-                <td>{{ '%.2f'|format(total) }}</td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
+        <table class="table table-sm">
+            <thead>
+                <tr>
+                    <th>GL Code</th>
+                    <th class="text-end">Total</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for code, total in report %}
+                <tr>
+                    <td>{{ code }}</td>
+                    <td class="text-end">{{ '%.2f'|format(total) }}</td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="2" class="text-center text-muted">No GL totals available.</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
     </div>
 </div>
 {% endblock %}

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -39,6 +39,7 @@
             <div class="col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data }}"></select></div>
             <div class="col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col">{{ item.cost(class="form-control cost") }}</div>
+            <div class="col"><span class="gl-code">—</span></div>
             <div class="col"><span class="line-total">0.00</span></div>
             <div class="col-auto">
                 <div class="d-flex flex-column gap-1">
@@ -74,9 +75,10 @@
                 <select name="items-${index}-item" id="items-${index}-item" class="form-control item-select">${itemOptions}</select>
                 <input type="hidden" name="items-${index}-position" class="item-position" value="">
             </div>
-            <div class="col"><select name="items-${index}-unit" id="items-${index}-unit" class="form-control unit-select"></select></div>
+            <div class="col"><select name="items-${index}-unit" id="items-${index}-unit" class="form-control unit-select" data-selected=""></select></div>
             <div class="col"><input type="number" step="any" name="items-${index}-quantity" id="items-${index}-quantity" class="form-control quantity"></div>
             <div class="col"><input type="number" step="any" name="items-${index}-cost" id="items-${index}-cost" class="form-control cost"></div>
+            <div class="col"><span class="gl-code">—</span></div>
             <div class="col"><span class="line-total">0.00</span></div>
             <div class="col-auto">
                 <div class="d-flex flex-column gap-1">
@@ -123,19 +125,43 @@
     function fetchUnits(selectEl, selectedUnitId=null) {
         const itemId = selectEl.value;
         const unitSelect = selectEl.closest('.item-row').querySelector('.unit-select');
+        const row = selectEl.closest('.item-row');
         if (!itemId) {
             unitSelect.innerHTML = '';
+            updateGlCode(row, null);
             return;
         }
-        fetch(`/items/${itemId}/units`).then(r => r.json()).then(data => {
+        const locationField = document.getElementById('location_id');
+        const params = new URLSearchParams();
+        if (locationField && locationField.value) {
+            params.append('location_id', locationField.value);
+        }
+        const url = params.toString() ? `/items/${itemId}/units?${params.toString()}` : `/items/${itemId}/units`;
+        fetch(url).then(r => r.json()).then(data => {
             let opts = '';
             data.units.forEach(u => {
                 const selected = (selectedUnitId && parseInt(selectedUnitId) === u.id) || (!selectedUnitId && u.receiving_default) ? 'selected' : '';
                 opts += `<option value="${u.id}" ${selected}>${u.name}</option>`;
             });
             unitSelect.innerHTML = opts;
+            updateGlCode(row, data.purchase_gl_code);
             fetchCost(selectEl.closest('.item-row'));
         });
+    }
+
+    function updateGlCode(row, glData) {
+        const glSpan = row ? row.querySelector('.gl-code') : null;
+        if (!glSpan) return;
+        if (!glData || !glData.code) {
+            glSpan.textContent = '—';
+            glSpan.dataset.code = '';
+            glSpan.dataset.description = '';
+            return;
+        }
+        const description = glData.description ? ` - ${glData.description}` : '';
+        glSpan.textContent = `${glData.code}${description}`;
+        glSpan.dataset.code = glData.code;
+        glSpan.dataset.description = glData.description || '';
     }
 
     function updateTotals() {
@@ -195,6 +221,22 @@
             updateTotals();
         }
     });
+
+    const locationField = document.getElementById('location_id');
+    if (locationField) {
+        locationField.addEventListener('change', () => {
+            document.querySelectorAll('#items .item-row').forEach(row => {
+                const itemSelect = row.querySelector('.item-select');
+                if (itemSelect && itemSelect.value) {
+                    const unitSelect = row.querySelector('.unit-select');
+                    const selectedUnit = unitSelect ? unitSelect.value : null;
+                    fetchUnits(itemSelect, selectedUnit);
+                } else {
+                    updateGlCode(row, null);
+                }
+            });
+        });
+    }
 
     document.getElementById('items').addEventListener('input', function(e) {
         if (e.target && (e.target.classList.contains('quantity') || e.target.classList.contains('cost'))) {


### PR DESCRIPTION
## Summary
- add a GL code column to the receive purchase invoice form and keep it in sync with the selected location
- return purchase GL metadata from the item units endpoint so the UI can display the correct code
- expand the purchase invoice report with invoice details, item breakdowns, and the existing GL code totals

## Testing
- pytest tests/test_purchase_flow.py::test_purchase_invoice_gl_report

------
https://chatgpt.com/codex/tasks/task_e_68d57f5598dc8324a4f1ea79559dcc72