### PR TITLE
Fix print layout for purchase invoice report

### DIFF
--- a/app/templates/purchase_invoices/invoice_gl_report.html
+++ b/app/templates/purchase_invoices/invoice_gl_report.html
@@ -1,6 +1,18 @@
 {% extends 'base.html' %}
 {% block content %}
-<div class="container mt-4">
+<style>
+@media print {
+    .purchase-invoice-report .row {
+        flex-wrap: wrap !important;
+    }
+
+    .purchase-invoice-report dt[class*='col-'],
+    .purchase-invoice-report dd[class*='col-'] {
+        max-width: 100% !important;
+    }
+}
+</style>
+<div class="container mt-4 purchase-invoice-report">
     <h2>Purchase Invoice Report</h2>
     <div class="card mb-4">
         <div class="card-body">


### PR DESCRIPTION
## Summary
- add print-specific styles to the purchase invoice report so Bootstrap rows wrap properly
- ensure the header details remain visible when printing by widening the layout container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5afc7777483249b761458d76c0f62