### PR TITLE
Add location item management view and tests

### DIFF
--- a/app/templates/locations/location_items.html
+++ b/app/templates/locations/location_items.html
@@ -1,0 +1,85 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ location.name }} Items</h2>
+<form method="post" class="mb-3">
+    {{ form.hidden_tag() }}
+    <div class="table-responsive">
+        <table class="table align-middle">
+            <thead>
+                <tr>
+                    <th>Item</th>
+                    <th>Expected Count</th>
+                    <th>Purchase GL Code</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for entry in entries.items %}
+                {% set field_name = 'location_gl_code_' ~ entry.item_id %}
+                {% if request.method == 'POST' %}
+                    {% set selected_value = request.form.get(field_name, '') %}
+                {% else %}
+                    {% set selected_value = entry.purchase_gl_code_id if entry.purchase_gl_code_id else '' %}
+                {% endif %}
+                <tr>
+                    <td>{{ entry.item.name }}</td>
+                    <td>{{ entry.expected_count }}</td>
+                    <td>
+                        <select name="{{ field_name }}" class="form-select">
+                            {% set default_gl = entry.item.purchase_gl_code %}
+                            <option value="" {% if not selected_value %}selected{% endif %}>
+                                Use Item Default
+                                {% if default_gl and default_gl.code %}
+                                    ({{ default_gl.code }}{% if default_gl.description %} - {{ default_gl.description }}{% endif %})
+                                {% endif %}
+                            </option>
+                            {% for gl in purchase_gl_codes %}
+                                <option value="{{ gl.id }}" {% if selected_value and selected_value|int == gl.id %}selected{% endif %}>
+                                    {{ gl.code }}{% if gl.description %} - {{ gl.description }}{% endif %}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </td>
+                </tr>
+            {% endfor %}
+                <tr>
+                    <td><strong>Total</strong></td>
+                    <td><strong>{{ total }}</strong></td>
+                    <td></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <button type="submit" class="btn btn-primary">Save Changes</button>
+</form>
+<div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mt-3">
+    <nav aria-label="Location item pagination">
+        <ul class="pagination mb-0">
+            <li class="page-item {% if not entries.has_prev %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('locations.location_items', location_id=location.id, page=entries.prev_num if entries.has_prev else 1, **pagination_args) }}"{% if not entries.has_prev %} tabindex="-1" aria-disabled="true"{% endif %}>Previous</a>
+            </li>
+            <li class="page-item disabled">
+                <span class="page-link">Page {{ entries.page }} of {{ entries.pages }}</span>
+            </li>
+            <li class="page-item {% if not entries.has_next %}disabled{% endif %}">
+                <a class="page-link" href="{{ url_for('locations.location_items', location_id=location.id, page=entries.next_num if entries.has_next else entries.pages or 1, **pagination_args) }}"{% if not entries.has_next %} tabindex="-1" aria-disabled="true"{% endif %}>Next</a>
+            </li>
+        </ul>
+    </nav>
+    <form method="get" class="d-flex align-items-center gap-2">
+        {% for key, values in request.args.lists() %}
+            {% if key not in ['page', 'per_page'] %}
+                {% for value in values %}
+                    <input type="hidden" name="{{ key }}" value="{{ value }}">
+                {% endfor %}
+            {% endif %}
+        {% endfor %}
+        <input type="hidden" name="page" value="1">
+        <label for="location-items-per-page" class="form-label mb-0">Rows per page</label>
+        <select id="location-items-per-page" name="per_page" class="form-select js-auto-submit">
+            {% for option in PAGINATION_SIZES %}
+                <option value="{{ option }}" {% if per_page == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+        </select>
+    </form>
+</div>
+{% endblock %}

--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -37,6 +37,7 @@
                 <td>
                     <button type="button" class="btn btn-info edit-location-btn" data-id="{{ location.id }}">Edit</button>
                     <a href="{{ url_for('locations.view_stand_sheet', location_id=location.id) }}" class="btn btn-secondary">Stand Sheet</a>
+                    <a href="{{ url_for('locations.location_items', location_id=location.id) }}" class="btn btn-outline-secondary">Manage Items</a>
                     <button type="button" class="btn btn-warning copy-location-btn" data-id="{{ location.id }}">Copy Stand Sheet</button>
                     <form action="{{ url_for('locations.delete_location', location_id=location.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
@@ -195,6 +196,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <td>
                 <button type="button" class="btn btn-info edit-location-btn" data-id="${loc.id}">Edit</button>
                 <a href="/locations/${loc.id}/stand_sheet" class="btn btn-secondary">Stand Sheet</a>
+                <a href="/locations/${loc.id}/items" class="btn btn-outline-secondary">Manage Items</a>
                 <button type="button" class="btn btn-warning copy-location-btn" data-id="${loc.id}">Copy Stand Sheet</button>
                 <form action="/locations/delete/${loc.id}" method="post" class="d-inline">
                     <input type="hidden" name="csrf_token" value="${csrfToken}">


### PR DESCRIPTION
## Summary
- add a `/locations/<location_id>/items` view for managing stand item GL overrides and wire it into the locations list
- create a dedicated template for paginated location item overrides with dropdowns for default and override GL codes
- expand location route tests to exercise the new endpoint including GET, POST and template context validation

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5bc781dc483248917f9da769aa57b