### PR TITLE
Allow managing standalone location items

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -121,6 +121,26 @@ class LocationForm(FlaskForm):
     submit = SubmitField("Submit")
 
 
+class LocationItemAddForm(FlaskForm):
+    """Form used to add standalone items to a location."""
+
+    item_id = SelectField(
+        "Item", coerce=int, validators=[DataRequired()], validate_choice=False
+    )
+    expected_count = DecimalField(
+        "Expected Count", validators=[Optional()], places=None, default=0
+    )
+    submit = SubmitField("Add Item")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Default choices are populated with all active items. Views using this
+        # form typically override ``item_id.choices`` to remove already-added
+        # items, but setting the base list here ensures the field works when the
+        # view does not provide its own list.
+        self.item_id.choices = load_item_choices()
+
+
 class ItemUnitForm(FlaskForm):
     name = StringField("Unit Name", validators=[DataRequired()])
     factor = DecimalField("Factor", validators=[InputRequired()])

--- a/app/templates/locations/location_items.html
+++ b/app/templates/locations/location_items.html
@@ -1,6 +1,34 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>{{ location.name }} Items</h2>
+{% if can_add_items %}
+<form method="post" action="{{ url_for('locations.add_location_item', location_id=location.id) }}" class="row g-2 align-items-end mb-4">
+    {{ add_form.hidden_tag() }}
+    <input type="hidden" name="page" value="{{ entries.page }}">
+    <input type="hidden" name="per_page" value="{{ per_page }}">
+    <div class="col-md-6 col-lg-5">
+        {{ add_form.item_id.label(class="form-label") }}
+        {{ add_form.item_id(class="form-select" + (' is-invalid' if add_form.item_id.errors else '')) }}
+        {% for error in add_form.item_id.errors %}
+            <div class="invalid-feedback d-block">{{ error }}</div>
+        {% endfor %}
+    </div>
+    <div class="col-md-3 col-lg-3">
+        {{ add_form.expected_count.label(class="form-label") }}
+        {{ add_form.expected_count(class="form-control" + (' is-invalid' if add_form.expected_count.errors else ''), step="any") }}
+        {% for error in add_form.expected_count.errors %}
+            <div class="invalid-feedback d-block">{{ error }}</div>
+        {% endfor %}
+    </div>
+    <div class="col-md-3 col-lg-2">
+        {{ add_form.submit(class="btn btn-success w-100") }}
+    </div>
+</form>
+{% else %}
+<div class="alert alert-info" role="status">
+    All active items are already assigned to this location.
+</div>
+{% endif %}
 <form method="post" class="mb-3">
     {{ form.hidden_tag() }}
     <div class="table-responsive">
@@ -10,6 +38,7 @@
                     <th>Item</th>
                     <th>Expected Count</th>
                     <th>Purchase GL Code</th>
+                    <th class="text-end">Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -39,12 +68,24 @@
                             {% endfor %}
                         </select>
                     </td>
+                    <td class="text-end">
+                        {% if entry.is_protected %}
+                            <span class="text-muted" title="This item comes from a product recipe and cannot be removed.">Locked</span>
+                        {% else %}
+                            <form method="post" action="{{ url_for('locations.delete_location_item', location_id=location.id, item_id=entry.item_id) }}" class="d-inline">
+                                {{ delete_form.hidden_tag() }}
+                                <input type="hidden" name="page" value="{{ entries.page }}">
+                                <input type="hidden" name="per_page" value="{{ per_page }}">
+                                <button type="submit" class="btn btn-outline-danger btn-sm">Remove</button>
+                            </form>
+                        {% endif %}
+                    </td>
                 </tr>
             {% endfor %}
                 <tr>
                     <td><strong>Total</strong></td>
                     <td><strong>{{ total }}</strong></td>
-                    <td></td>
+                    <td colspan="2"></td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- add a dedicated form for attaching standalone items to a location
- extend the location items view with endpoints that add or remove non-recipe items while protecting recipe requirements
- update the location items template to expose add/remove controls and cover the behaviour with new route tests

## Testing
- pytest tests/test_location_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d5c8362b2083248f439405b6ea0d15