### PR TITLE
Fix location item removal form submission

### DIFF
--- a/app/templates/locations/location_items.html
+++ b/app/templates/locations/location_items.html
@@ -72,12 +72,16 @@
                         {% if entry.is_protected %}
                             <span class="text-muted" title="This item comes from a product recipe and cannot be removed.">Locked</span>
                         {% else %}
-                            <form method="post" action="{{ url_for('locations.delete_location_item', location_id=location.id, item_id=entry.item_id) }}" class="d-inline">
-                                {{ delete_form.hidden_tag() }}
-                                <input type="hidden" name="page" value="{{ entries.page }}">
-                                <input type="hidden" name="per_page" value="{{ per_page }}">
-                                <button type="submit" class="btn btn-outline-danger btn-sm">Remove</button>
-                            </form>
+                            <input type="hidden" name="page" value="{{ entries.page }}">
+                            <input type="hidden" name="per_page" value="{{ per_page }}">
+                            <button
+                                type="submit"
+                                class="btn btn-outline-danger btn-sm"
+                                formmethod="post"
+                                formaction="{{ url_for('locations.delete_location_item', location_id=location.id, item_id=entry.item_id) }}"
+                            >
+                                Remove
+                            </button>
                         {% endif %}
                     </td>
                 </tr>


### PR DESCRIPTION
## Summary
- update the location item management template so the delete action posts correctly instead of relying on nested forms
- ensure pagination data and CSRF tokens accompany each delete request via the outer form submission

## Testing
- pytest tests/test_location_routes.py::test_location_items_manage_gl_overrides -q

------
https://chatgpt.com/codex/tasks/task_e_68d5cb3a458c8324a2669ac06e64f2c0