### PR TITLE
Add architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ For production deployments using Gunicorn, use the provided configuration to ena
 gunicorn -c gunicorn.conf.py run:app
 ```
 
+## Project Architecture
+
+A high-level overview of the Flask application structure, shared services, and key data models is available in [docs/architecture.md](docs/architecture.md).
+
 ## Docker Setup
 
 The project includes a `Dockerfile` and a `docker-compose.yml` to make running

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,91 @@
+# Project Architecture
+
+This document provides a high-level overview of the InvoiceManager Flask
+application. It is intended to help contributors understand how the
+application is assembled and where to look when adding new features or fixing
+bugs.
+
+## Application Factory (`app/__init__.py`)
+
+InvoiceManager is built around a Flask application factory defined in
+[`app/__init__.py`](../app/__init__.py). The factory creates the Flask
+application, configures core services, and registers blueprints for every
+feature module.
+
+Key responsibilities include:
+
+* Loading environment variables and critical settings (secret key, database
+  location, upload paths, backup directories).
+* Configuring global extensions: SQLAlchemy for persistence, Flask-Login for
+  authentication, Flask-Limiter for rate limiting, Flask-Bootstrap for UI
+  helpers, Flask-SocketIO for real-time updates, and CSRF protection for forms.
+* Initialising the database (creating tables if migrations have not yet been
+  applied) and ensuring the default admin account exists.
+* Registering blueprints under `app/routes/…`, so each functional area (items,
+  transfers, invoices, reports, administration, etc.) owns its URLs and view
+  logic.
+* Adding global template context helpers (navigation links, pagination sizes,
+  GST value, CSP nonce) and HTTP hardening hooks (CSP, security headers,
+  options blocking).
+
+The factory returns both the configured Flask application and the `SocketIO`
+instance so that entry points such as `run.py` can start the appropriate
+server.
+
+## Shared Services and Utilities
+
+Several extension instances are created at module import time in
+`app/__init__.py` and reused throughout the project:
+
+* `db`: The SQLAlchemy instance backing models in `app/models.py` and used in
+  blueprints, CLI tasks, and migrations.
+* `limiter`: Configured with the `get_remote_address` key function. Blueprints
+  can import it to decorate routes that require rate limiting.
+* `socketio`: Created inside the factory and exposed for WebSocket-based
+  interactions (for example, pushing real-time updates to connected clients).
+* `login_manager`: Manages user sessions and integrates with Flask-Login via
+  the `load_user` callback in `app/__init__.py`.
+
+Additional functionality lives under `app/utils/`. These modules encapsulate
+cross-cutting concerns such as pagination helpers, automatic database backups,
+file import routines, and shared validation logic. They are imported where
+needed by blueprints or the factory to keep route files focused on request
+handling.
+
+## Data Models
+
+All persistent data structures are defined in [`app/models.py`](../app/models.py).
+The module declares SQLAlchemy models for core business concepts including
+users, inventory items, products, transfers, invoices, purchase orders, events,
+and configuration settings. Relationships capture how these concepts relate;
+for example, transfers and invoices link back to their creators, items connect
+products to recipes, and events tie locations to terminal sales. A short
+summary of the most important models appears in [Key Data Models](#key-data-models-reference).
+
+## Templates and Static Assets
+
+HTML templates live under `app/templates/` and extend shared layouts. They
+consume context injected by the factory (navigation links, CSP nonce, GST value)
+and render data retrieved by blueprint routes. JavaScript and CSS assets reside
+in `app/static/`, alongside Bootstrap resources. Jinja filters like
+`format_datetime` (registered in the factory) help templates display timezone
+aware timestamps.
+
+## Request Flow Overview
+
+1. An entry point (e.g. `run.py`) calls the application factory to obtain the
+   Flask app and `SocketIO` server.
+2. When a request arrives, Flask routes it to the appropriate blueprint view
+   function. Rate limiting or authentication decorators provided by the shared
+   services may run before the view logic.
+3. Views interact with SQLAlchemy models via the shared `db` session and may
+   call into `app/utils/` helpers to perform domain-specific operations.
+4. Responses render templates or return JSON. Template rendering leverages the
+   shared context processors and filters registered in the factory. Real-time
+   responses can emit `socketio` events when necessary.
+5. Background helpers such as the automatic backup thread (started during app
+   creation) run independently, using the app context as needed.
+
+## Key Data Models Reference
+
+Refer to [Key Data Models](key-data-models.md) to become familiar with the domain entities before exploring routes or templates.

--- a/docs/key-data-models.md
+++ b/docs/key-data-models.md
@@ -1,0 +1,123 @@
+# Key Data Models
+
+This document summarises the primary SQLAlchemy models defined in
+[`app/models.py`](../app/models.py). Understanding these entities and their
+relationships will make it easier to work with routes, templates, and
+background tasks.
+
+## Core Entities
+
+### User
+* **Table**: `user`
+* **Purpose**: Authenticated application user. Supports admin flag, favourites,
+  timezone preferences, and notification toggles.
+* **Key Relationships**: `transfers` and `invoices` backrefs expose the records
+  a user created; `activity_logs` captures audit events.
+
+### Location
+* **Table**: `location`
+* **Purpose**: Physical or logical storage site. Tracks whether the location is
+  archived or used for spoilage.
+* **Key Relationships**: Many-to-many with `Product` via `location_products` to
+  describe availability; one-to-many with `LocationStandItem` for expected
+  inventory; links to events through `EventLocation`.
+
+### Item
+* **Table**: `item`
+* **Purpose**: Stock-keeping unit used in inventory counts and recipes. Stores
+  base unit, GL codes, quantity on hand, and cost.
+* **Key Relationships**: Many-to-many with `Transfer` through `transfer_items`;
+  one-to-many with `ItemUnit` (conversion factors), `ProductRecipeItem`
+  (ingredient usage), and `PurchaseInvoiceItem`. Helper methods resolve GL codes
+  per location.
+
+### ItemUnit
+* **Table**: `item_unit`
+* **Purpose**: Alternative units of measure for an item (e.g. case, bottle).
+* **Key Relationships**: Belongs to an `Item`; referenced by recipe and purchase
+  items to keep quantities consistent.
+
+### Transfer and TransferItem
+* **Tables**: `transfer`, `transfer_item`
+* **Purpose**: Track inventory moved between locations. `Transfer` stores the
+  origin, destination, creator, and completion state. `TransferItem` stores the
+  per-item quantities and retains the item name for history.
+* **Key Relationships**: Each transfer references `Location` twice (`from` and
+  `to`) and has many `TransferItem` records. Users who initiate transfers are
+  linked via `user_id`.
+
+### Product
+* **Table**: `product`
+* **Purpose**: Sellable item with price, cost, and GL codes for accounting.
+* **Key Relationships**: Connected to `InvoiceProduct` (sales history),
+  `ProductRecipeItem` (ingredients), `TerminalSale` (event sales), and optional
+  `GLCode` entries for accounting mappings.
+
+### ProductRecipeItem
+* **Table**: `product_recipe_item`
+* **Purpose**: Defines how much of each `Item` is required to produce a
+  `Product`.
+* **Key Relationships**: Links a product, an item, and an optional `ItemUnit`.
+
+### Invoice and InvoiceProduct
+* **Tables**: `invoice`, `invoice_product`
+* **Purpose**: Customer-facing sales documents. `Invoice` stores the creator,
+  customer, and creation timestamp while `InvoiceProduct` captures line details,
+  tax overrides, and totals.
+* **Key Relationships**: `Invoice` belongs to a `User` and a `Customer`; has
+  many `InvoiceProduct` children. Products sold can be null (archived or deleted
+  products) thanks to `SET NULL` foreign keys.
+
+### Customer and Vendor
+* **Tables**: `customer`, `vendor`
+* **Purpose**: Business contacts for sales and purchasing respectively. Include
+  tax exemption flags and archived states.
+* **Key Relationships**: `Customer` has many invoices; `Vendor` has many
+  `PurchaseOrder` records.
+
+### PurchaseOrder and PurchaseOrderItem
+* **Tables**: `purchase_order`, `purchase_order_item`
+* **Purpose**: Records orders issued to vendors, including expected delivery
+  dates and line items.
+* **Key Relationships**: Each order belongs to a `Vendor` and `User` and has
+  many `PurchaseOrderItem` rows. Line items optionally reference `Product`,
+  `Item`, and `ItemUnit`.
+
+### PurchaseInvoice and PurchaseInvoiceItem
+* **Tables**: `purchase_invoice`, `purchase_invoice_item`
+* **Purpose**: Capture received goods against purchase orders, including taxes,
+  delivery charges, and per-item costs.
+* **Key Relationships**: Purchase invoices belong to a `PurchaseOrder`, `User`,
+  and `Location`. Line items reference `Item` and `ItemUnit` when available and
+  resolve GL codes dynamically through helper methods.
+
+### Event, EventLocation, TerminalSale, and EventStandSheetItem
+* **Tables**: `event`, `event_location`, `terminal_sale`, `event_stand_sheet_item`
+* **Purpose**: Manage temporary events (e.g. festivals). `Event` defines the
+  schedule; `EventLocation` links events to locations and tracks opening/closing
+  counts; `TerminalSale` records product sales at a specific event location;
+  `EventStandSheetItem` logs detailed inventory movements for stands.
+* **Key Relationships**: These models bridge inventory (`Item`, `Product`) and
+  locations within the context of an event.
+
+### GLCode and Setting
+* **Tables**: `gl_code`, `setting`
+* **Purpose**: Support accounting and configuration. `GLCode` entities are
+  referenced by items, products, and purchase invoice lines. `Setting` stores
+  key-value configuration entries (e.g., GST amount, default timezone,
+  automated backup preferences) read during application start-up.
+
+## Auxiliary Tables
+
+* **`transfer_items`**: Association table linking `Transfer` and `Item` with a
+  quantity column for many-to-many relationships.
+* **`location_products`**: Association table mapping which `Product` entries are
+  available at which `Location` instances.
+* **`location_stand_item`**: Materialises expected counts and purchase GL codes
+  for items at a specific location.
+* **`purchase_order_item_archive`**: Keeps historical snapshots of purchase
+  order line items when they are archived.
+
+These models form the backbone of InvoiceManager. Routes query and mutate them,
+templates render their fields, and background tasks (backups, imports) rely on
+consistent relationships to operate correctly.


### PR DESCRIPTION
## Summary
- add a new architecture guide that explains the Flask factory, shared services, and supporting modules
- document the primary SQLAlchemy models and their relationships for quick onboarding
- link to the new architecture guide from the README so contributors can find it easily

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d6186025cc8324a9c84df514db6888