### PR TITLE
Add event sustainability dashboard with exports

### DIFF
--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -19,6 +19,8 @@
                 <th>Transferred In</th>
                 <th>Transferred Out</th>
                 <th>Sales</th>
+                <th>Eaten</th>
+                <th>Spoiled</th>
                 <th>Closing Count</th>
                 <th>Variance</th>
             </tr>
@@ -32,6 +34,8 @@
                 <td><input type="number" class="form-control" name="in_{{ entry.item.id }}" value="{{ entry.sheet.transferred_in if entry.sheet else '' }}"></td>
                 <td><input type="number" class="form-control" name="out_{{ entry.item.id }}" value="{{ entry.sheet.transferred_out if entry.sheet else '' }}"></td>
                 <td class="sales" data-sales="{{ entry.sales }}">{{ entry.sales }}</td>
+                <td><input type="number" step="0.01" class="form-control" name="eaten_{{ entry.item.id }}" value="{{ entry.sheet.eaten if entry.sheet else '' }}"></td>
+                <td><input type="number" step="0.01" class="form-control" name="spoiled_{{ entry.item.id }}" value="{{ entry.sheet.spoiled if entry.sheet else '' }}"></td>
                 <td><input type="number" class="form-control" name="close_{{ entry.item.id }}" value="{{ entry.sheet.closing_count if entry.sheet else '' }}"></td>
                 <td class="variance">0</td>
             </tr>
@@ -48,8 +52,10 @@
         const pre = parseFloat(row.querySelector('input[name^="open_"]').value) || 0;
         const tin = parseFloat(row.querySelector('input[name^="in_"]').value) || 0;
         const tout = parseFloat(row.querySelector('input[name^="out_"]').value) || 0;
+        const eaten = parseFloat(row.querySelector('input[name^="eaten_"]').value) || 0;
+        const spoiled = parseFloat(row.querySelector('input[name^="spoiled_"]').value) || 0;
         const close = parseFloat(row.querySelector('input[name^="close_"]').value) || 0;
-        const variance = pre + tin - tout - sales - close;
+        const variance = pre + tin - tout - sales - eaten - spoiled - close;
         row.querySelector('.variance').textContent = variance.toFixed(2);
     }
 

--- a/app/templates/events/sustainability_dashboard.html
+++ b/app/templates/events/sustainability_dashboard.html
@@ -1,0 +1,156 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Sustainability Dashboard - {{ event.name }}</h1>
+    {% if not print_view %}
+    <div class="btn-group" role="group">
+      <a class="btn btn-outline-secondary" href="{{ url_for('event.sustainability_dashboard_csv', event_id=event.id) }}">Export CSV</a>
+      <a class="btn btn-outline-secondary" href="{{ url_for('event.sustainability_dashboard_print', event_id=event.id) }}" target="_blank">Print View</a>
+    </div>
+    {% endif %}
+  </div>
+
+  <div class="row mb-4">
+    <div class="col-md-4 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">Total Waste</h5>
+          <p class="display-6">{{ '%.2f'|format(report.totals.waste) }} units</p>
+          <p class="text-muted mb-0">Captured from stand sheet eaten and spoiled entries.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">Waste Cost</h5>
+          <p class="display-6">${{ '%.2f'|format(report.totals.cost) }}</p>
+          <p class="text-muted mb-0">Based on item costs associated with waste.</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-4 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">Carbon Impact</h5>
+          <p class="display-6">{{ '%.2f'|format(report.totals.carbon) }} kg CO₂e</p>
+          <p class="text-muted mb-0">Calculated using configured carbon equivalence factors.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row mb-4">
+    <div class="col-lg-8 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">Waste & Carbon by Location</h5>
+          {% if report.location_breakdown %}
+          <canvas id="wasteChart" height="200"></canvas>
+          {% else %}
+          <p class="text-muted mb-0">No stand sheet data yet. Encourage stands to submit closing sheets to populate this dashboard.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+    <div class="col-lg-4 mb-3">
+      <div class="card h-100">
+        <div class="card-body">
+          <h5 class="card-title">Waste Reduction Goal</h5>
+          {% if report.goal.target %}
+          <p class="mb-1">Target: {{ '%.2f'|format(report.goal.target) }} units</p>
+          <p class="mb-1">Remaining: {{ '%.2f'|format(report.goal.remaining) if report.goal.remaining is not none else 'N/A' }}</p>
+          {% if report.goal.progress_pct is not none %}
+          <div class="progress mb-2" style="height: 1.25rem;">
+            <div class="progress-bar bg-success" role="progressbar" style="width: {{ report.goal.progress_pct }}%;" aria-valuenow="{{ report.goal.progress_pct }}" aria-valuemin="0" aria-valuemax="100">{{ '%.2f'|format(report.goal.progress_pct) }}%</div>
+          </div>
+          {% endif %}
+          <p class="mb-0 {{ 'text-success' if report.goal.met else 'text-danger' }}">{{ 'On track' if report.goal.met else 'Over target' }}</p>
+          {% else %}
+          <p class="text-muted mb-0">Set <code>SUSTAINABILITY_WASTE_GOAL</code> in configuration to track goal progress.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2>Location Breakdown</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Location</th>
+        <th>Waste (units)</th>
+        <th>Cost</th>
+        <th>Carbon (kg CO₂e)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for entry in report.location_breakdown %}
+      <tr>
+        <td>{{ entry.location }}</td>
+        <td>{{ '%.2f'|format(entry.waste) }}</td>
+        <td>${{ '%.2f'|format(entry.cost) }}</td>
+        <td>{{ '%.2f'|format(entry.carbon) }}</td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="4" class="text-center text-muted">No stand sheet items recorded for this event.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <h2>Item Waste Leaderboard</h2>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Item</th>
+        <th>Waste (units)</th>
+        <th>Cost</th>
+        <th>Carbon (kg CO₂e)</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for entry in report.item_leaderboard %}
+      <tr>
+        <td>{{ entry.item }}</td>
+        <td>{{ '%.2f'|format(entry.waste) }}</td>
+        <td>${{ '%.2f'|format(entry.cost) }}</td>
+        <td>{{ '%.2f'|format(entry.carbon) }}</td>
+      </tr>
+      {% else %}
+      <tr>
+        <td colspan="4" class="text-center text-muted">No waste captured at the item level.</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+{% if not print_view and report.location_breakdown %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script nonce="{{ csp_nonce }}">
+  const chartPayload = {{ chart_json|safe }};
+  const ctx = document.getElementById('wasteChart');
+  if (ctx && chartPayload.labels.length) {
+    new Chart(ctx, {
+      type: 'bar',
+      data: chartPayload,
+      options: {
+        responsive: true,
+        plugins: {
+          legend: { position: 'bottom' }
+        },
+        scales: {
+          y: {
+            beginAtZero: true,
+            ticks: { precision: 0 }
+          }
+        }
+      }
+    });
+  }
+</script>
+{% endif %}
+{% endblock %}

--- a/tests/events/test_sustainability_dashboard.py
+++ b/tests/events/test_sustainability_dashboard.py
@@ -1,0 +1,159 @@
+from datetime import datetime, timedelta
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import (
+    Event,
+    EventLocation,
+    EventStandSheetItem,
+    Item,
+    Location,
+    User,
+)
+from app.routes.event_routes import build_sustainability_report
+from tests.utils import login
+
+
+@pytest.fixture
+def sustainability_event(app):
+    """Create a user, event, and two locations for sustainability tests."""
+    with app.app_context():
+        user = User(
+            email="sustain@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        event = Event(
+            name="Sustainability Summit",
+            start_date=datetime.utcnow(),
+            end_date=datetime.utcnow() + timedelta(days=1),
+            event_type="inventory",
+        )
+        loc_a = Location(name="Green Stand A")
+        loc_b = Location(name="Green Stand B")
+        item_a = Item(name="Compostable Plate", base_unit="each", cost=2.5)
+        item_b = Item(name="Reusable Cup", base_unit="each", cost=1.0)
+        db.session.add_all([user, event, loc_a, loc_b, item_a, item_b])
+        db.session.commit()
+
+        el_a = EventLocation(event_id=event.id, location_id=loc_a.id)
+        el_b = EventLocation(event_id=event.id, location_id=loc_b.id)
+        db.session.add_all([el_a, el_b])
+        db.session.commit()
+
+        data = {
+            "user_email": user.email,
+            "event_id": event.id,
+            "event_location_ids": {"A": el_a.id, "B": el_b.id},
+            "location_ids": {"A": loc_a.id, "B": loc_b.id},
+            "item_ids": {"A": item_a.id, "B": item_b.id},
+            "user_id": user.id,
+        }
+
+        yield data
+
+        EventStandSheetItem.query.filter(
+            EventStandSheetItem.event_location_id.in_(
+                data["event_location_ids"].values()
+            )
+        ).delete(synchronize_session=False)
+        for el_id in data["event_location_ids"].values():
+            el = db.session.get(EventLocation, el_id)
+            if el:
+                db.session.delete(el)
+        for item_id in data["item_ids"].values():
+            item = db.session.get(Item, item_id)
+            if item:
+                db.session.delete(item)
+        for loc_id in data["location_ids"].values():
+            loc = db.session.get(Location, loc_id)
+            if loc:
+                db.session.delete(loc)
+        event_obj = db.session.get(Event, data["event_id"])
+        if event_obj:
+            db.session.delete(event_obj)
+        user_obj = db.session.get(User, data["user_id"])
+        if user_obj:
+            db.session.delete(user_obj)
+        db.session.commit()
+
+
+def test_sustainability_dashboard_aggregates_metrics(client, app, sustainability_event):
+    app.config.update({"CARBON_EQ_PER_UNIT": 1.5, "SUSTAINABILITY_WASTE_GOAL": 10})
+    payload = sustainability_event
+
+    with app.app_context():
+        sheet_a = EventStandSheetItem(
+            event_location_id=payload["event_location_ids"]["A"],
+            item_id=payload["item_ids"]["A"],
+            opening_count=0,
+            transferred_in=0,
+            transferred_out=0,
+            eaten=2,
+            spoiled=1,
+            closing_count=0,
+        )
+        sheet_b = EventStandSheetItem(
+            event_location_id=payload["event_location_ids"]["B"],
+            item_id=payload["item_ids"]["B"],
+            opening_count=0,
+            transferred_in=0,
+            transferred_out=0,
+            eaten=0,
+            spoiled=4,
+            closing_count=0,
+        )
+        db.session.add_all([sheet_a, sheet_b])
+        db.session.commit()
+
+    with app.app_context():
+        report = build_sustainability_report(payload["event_id"])
+
+    assert pytest.approx(report["totals"]["waste"], rel=1e-6) == 7.0
+    assert pytest.approx(report["totals"]["cost"], rel=1e-6) == 11.5
+    assert pytest.approx(report["totals"]["carbon"], rel=1e-6) == 10.5
+    assert report["goal"]["target"] == 10
+    assert pytest.approx(report["goal"]["remaining"], rel=1e-6) == 3.0
+    assert pytest.approx(report["goal"]["progress_pct"], rel=1e-6) == 30.0
+    assert report["goal"]["met"] is True
+    assert report["location_breakdown"][0]["location"] == "Green Stand B"
+    assert report["item_leaderboard"][0]["item"] == "Reusable Cup"
+
+    with client:
+        login(client, payload["user_email"], "pass")
+        resp = client.get(f"/events/{payload['event_id']}/sustainability")
+        assert resp.status_code == 200
+        assert b"7.00 units" in resp.data
+        assert b"$11.50" in resp.data
+        assert b"30.00%" in resp.data
+
+        csv_resp = client.get(
+            f"/events/{payload['event_id']}/sustainability/export.csv"
+        )
+        assert csv_resp.status_code == 200
+        assert "Totals,7.00,11.50,10.50" in csv_resp.get_data(as_text=True)
+
+
+def test_sustainability_dashboard_handles_events_without_data(
+    client, app, sustainability_event
+):
+    payload = sustainability_event
+
+    with client:
+        login(client, payload["user_email"], "pass")
+        resp = client.get(f"/events/{payload['event_id']}/sustainability")
+        assert resp.status_code == 200
+        assert b"No stand sheet data yet" in resp.data
+        assert b"No stand sheet items recorded for this event." in resp.data
+
+    with app.app_context():
+        report = build_sustainability_report(payload["event_id"])
+    assert report["totals"]["waste"] == 0
+    assert report["totals"]["cost"] == 0
+    assert report["totals"]["carbon"] == 0
+    assert report["location_breakdown"] == []
+    assert report["item_leaderboard"] == []
+    assert report["goal"]["target"] is None
+    assert report["goal"]["progress_pct"] is None


### PR DESCRIPTION
## Summary
- surface eaten and spoiled tracking on stand sheets and update variance calculations
- add sustainability reporting helpers, dashboard views, and export endpoints for events
- cover sustainability aggregates and empty states with new regression tests

## Testing
- pytest tests/events/test_sustainability_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d628aaab908324b8419702a4024132