### PR TITLE
Add demand forecasting recommendations for purchase orders

### DIFF
--- a/app/templates/purchase_orders/recommendations.html
+++ b/app/templates/purchase_orders/recommendations.html
@@ -1,0 +1,211 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Purchase Order Recommendations</h2>
+
+    <form method="get" class="row g-3 align-items-end mb-4">
+        <div class="col-md-2">
+            <label for="lookback_days" class="form-label">Lookback (days)</label>
+            <input type="number" class="form-control" id="lookback_days" name="lookback_days"
+                   value="{{ lookback_days }}" min="1">
+        </div>
+        <div class="col-md-2">
+            <label for="lead_time_days" class="form-label">Lead Time (days)</label>
+            <input type="number" class="form-control" id="lead_time_days" name="lead_time_days"
+                   value="{{ lead_time_days }}" min="0">
+        </div>
+        <div class="col-md-3">
+            <label for="location_id" class="form-label">Location</label>
+            <select name="location_id" id="location_id" class="form-select">
+                <option value="">All Locations</option>
+                {% for location in locations %}
+                <option value="{{ location.id }}" {% if selected_location == location.id %}selected{% endif %}>{{ location.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-3">
+            <label for="item_id" class="form-label">Item</label>
+            <input type="number" class="form-control" id="item_id" name="item_id" value="{{ selected_item or '' }}"
+                   placeholder="Item ID">
+        </div>
+        <div class="col-md-2 d-flex align-items-end">
+            <button type="submit" class="btn btn-primary w-100">Refresh</button>
+        </div>
+        <div class="col-md-3">
+            <label for="attendance_multiplier" class="form-label">Attendance Multiplier</label>
+            <input type="number" step="0.1" min="0" class="form-control" id="attendance_multiplier"
+                   name="attendance_multiplier" value="{{ '%.2f'|format(attendance_multiplier) }}">
+        </div>
+        <div class="col-md-3">
+            <label for="weather_multiplier" class="form-label">Weather Multiplier</label>
+            <input type="number" step="0.1" min="0" class="form-control" id="weather_multiplier"
+                   name="weather_multiplier" value="{{ '%.2f'|format(weather_multiplier) }}">
+        </div>
+        <div class="col-md-3">
+            <label for="promo_multiplier" class="form-label">Promotion Multiplier</label>
+            <input type="number" step="0.1" min="0" class="form-control" id="promo_multiplier"
+                   name="promo_multiplier" value="{{ '%.2f'|format(promo_multiplier) }}">
+        </div>
+    </form>
+
+    <div class="row mb-4">
+        <div class="col-lg-8">
+            <div class="table-responsive">
+                <table class="table table-striped table-sm align-middle">
+                    <thead>
+                    <tr>
+                        <th>Item</th>
+                        <th>Location</th>
+                        <th>Sales</th>
+                        <th>Transfers In</th>
+                        <th>Transfers Out</th>
+                        <th>Invoices</th>
+                        <th>Open POs</th>
+                        <th>Base Demand</th>
+                        <th>Adjusted Demand</th>
+                        <th>Suggested Qty</th>
+                        <th>Suggested Delivery</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for rec in recommendations %}
+                    <tr>
+                        <td>{{ rec.item.name }}</td>
+                        <td>{{ rec.location.name }}</td>
+                        <td>{{ '%.2f'|format(rec.history['sales_qty']) }}</td>
+                        <td>{{ '%.2f'|format(rec.history['transfer_in_qty']) }}</td>
+                        <td>{{ '%.2f'|format(rec.history['transfer_out_qty']) }}</td>
+                        <td>{{ '%.2f'|format(rec.history['invoice_qty']) }}</td>
+                        <td>{{ '%.2f'|format(rec.history['open_po_qty']) }}</td>
+                        <td>{{ '%.2f'|format(rec.base_consumption) }}</td>
+                        <td>{{ '%.2f'|format(rec.adjusted_demand) }}</td>
+                        <td>{{ '%.2f'|format(rec.recommended_quantity) }}</td>
+                        <td>{{ rec.suggested_delivery_date.strftime('%Y-%m-%d') }}</td>
+                    </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="11" class="text-center">No recommendations available for the selected criteria.</td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="col-lg-4">
+            <canvas id="recommendation-chart" height="240"></canvas>
+        </div>
+    </div>
+
+    {% if recommendations %}
+    <div class="card mb-4">
+        <div class="card-body">
+            <h5 class="card-title">Push to Draft Purchase Order</h5>
+            <form method="post">
+                <input type="hidden" name="action" value="seed">
+                <div class="row g-3 align-items-end">
+                    <div class="col-md-4">
+                        <label for="seed_vendor_id" class="form-label">Vendor</label>
+                        <select name="seed_vendor_id" id="seed_vendor_id" class="form-select" required>
+                            <option value="">Select a vendor</option>
+                            {% for vendor in vendors %}
+                            <option value="{{ vendor.id }}" {% if selected_vendor == vendor.id %}selected{% endif %}>{{ vendor.first_name }} {{ vendor.last_name }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label for="seed_order_date" class="form-label">Order Date</label>
+                        <input type="date" class="form-control" id="seed_order_date" name="seed_order_date"
+                               value="{{ today.strftime('%Y-%m-%d') }}">
+                    </div>
+                    <div class="col-md-3">
+                        <label for="seed_expected_date" class="form-label">Expected Delivery</label>
+                        <input type="date" class="form-control" id="seed_expected_date" name="seed_expected_date"
+                               value="{{ recommendations[0].suggested_delivery_date.strftime('%Y-%m-%d') if recommendations else '' }}">
+                    </div>
+                    <div class="col-md-2 d-flex align-items-end">
+                        <button type="submit" class="btn btn-success w-100">Create Draft</button>
+                    </div>
+                </div>
+                <div class="table-responsive mt-3">
+                    <table class="table table-bordered table-sm align-middle">
+                        <thead>
+                        <tr>
+                            <th scope="col">Include</th>
+                            <th scope="col">Item</th>
+                            <th scope="col">Location</th>
+                            <th scope="col">Suggested Qty</th>
+                            <th scope="col">Override Qty</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for rec in recommendations %}
+                        {% set key = rec.item.id ~ ':' ~ rec.location.id %}
+                        <tr>
+                            <td class="text-center">
+                                <input type="checkbox" class="form-check-input" name="selected_lines" value="{{ key }}">
+                            </td>
+                            <td>{{ rec.item.name }}</td>
+                            <td>{{ rec.location.name }}</td>
+                            <td>{{ '%.2f'|format(rec.recommended_quantity) }}</td>
+                            <td>
+                                <input type="number" step="0.01" min="0" class="form-control form-control-sm"
+                                       name="override-{{ key }}" value="{{ '%.2f'|format(rec.recommended_quantity) }}">
+                            </td>
+                        </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </form>
+        </div>
+    </div>
+    {% endif %}
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script nonce="{{ csp_nonce }}">
+document.addEventListener('DOMContentLoaded', function () {
+    const rows = {{ chart_rows|tojson }};
+    const ctx = document.getElementById('recommendation-chart');
+    if (!ctx || !rows.length) {
+        return;
+    }
+    const labels = rows.map(row => row.label);
+    const data = {
+        labels,
+        datasets: [
+            {
+                label: 'Adjusted Demand',
+                backgroundColor: 'rgba(13, 110, 253, 0.7)',
+                data: rows.map(row => row.consumption),
+            },
+            {
+                label: 'Incoming Supply',
+                backgroundColor: 'rgba(25, 135, 84, 0.7)',
+                data: rows.map(row => row.incoming),
+            },
+            {
+                label: 'Recommended Qty',
+                backgroundColor: 'rgba(220, 53, 69, 0.7)',
+                data: rows.map(row => row.recommended),
+            }
+        ]
+    };
+    new Chart(ctx, {
+        type: 'bar',
+        data,
+        options: {
+            responsive: true,
+            scales: {
+                x: {
+                    stacked: true
+                },
+                y: {
+                    beginAtZero: true
+                }
+            }
+        }
+    });
+});
+</script>
+{% endblock %}

--- a/app/utils/forecasting.py
+++ b/app/utils/forecasting.py
@@ -1,0 +1,318 @@
+"""Utilities for generating purchase order demand forecasts."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session, selectinload
+
+from app import db
+from app.models import (
+    EventLocation,
+    Item,
+    ItemUnit,
+    Location,
+    Product,
+    ProductRecipeItem,
+    PurchaseInvoice,
+    PurchaseInvoiceItem,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    TerminalSale,
+    Transfer,
+    TransferItem,
+)
+
+
+@dataclass(frozen=True)
+class ForecastRecommendation:
+    """A single forecast recommendation entry."""
+
+    item: Item
+    location: Location
+    history: Mapping[str, float]
+    base_consumption: float
+    adjusted_demand: float
+    recommended_quantity: float
+    suggested_delivery_date: _dt.date
+    default_unit_id: Optional[int]
+
+
+def _coalesce_factor(column):
+    """Return a SQL expression that coalesces unit factors to 1."""
+
+    return func.coalesce(column, 1.0)
+
+
+class DemandForecastingHelper:
+    """Aggregate recent activity to support demand forecasting.
+
+    The helper consolidates quantities by item/location across several data
+    sources and applies simple multiplicative "what-if" adjustments for
+    attendance, weather, and promotional impacts.
+    """
+
+    def __init__(
+        self,
+        session: Optional[Session] = None,
+        *,
+        lookback_days: int = 30,
+        lead_time_days: int = 3,
+    ) -> None:
+        self.session = session or db.session
+        self.lookback_days = lookback_days
+        self.lead_time_days = lead_time_days
+        self._since = _dt.datetime.utcnow() - _dt.timedelta(days=lookback_days)
+
+    # ------------------------------------------------------------------
+    # Data extractors
+    # ------------------------------------------------------------------
+    def _terminal_sales_totals(
+        self, location_ids: Optional[Sequence[int]], item_ids: Optional[Sequence[int]]
+    ) -> Iterable[Tuple[int, int, float, _dt.datetime]]:
+        factor = _coalesce_factor(ItemUnit.factor)
+        query = (
+            self.session.query(
+                ProductRecipeItem.item_id.label("item_id"),
+                EventLocation.location_id.label("location_id"),
+                func.sum(
+                    TerminalSale.quantity
+                    * ProductRecipeItem.quantity
+                    * factor
+                ).label("quantity"),
+                func.max(TerminalSale.sold_at).label("last_activity"),
+            )
+            .join(EventLocation, TerminalSale.event_location_id == EventLocation.id)
+            .join(Product, TerminalSale.product_id == Product.id)
+            .join(ProductRecipeItem, ProductRecipeItem.product_id == Product.id)
+            .outerjoin(ItemUnit, ProductRecipeItem.unit_id == ItemUnit.id)
+            .filter(TerminalSale.sold_at >= self._since)
+            .group_by(ProductRecipeItem.item_id, EventLocation.location_id)
+        )
+
+        if location_ids:
+            query = query.filter(EventLocation.location_id.in_(location_ids))
+        if item_ids:
+            query = query.filter(ProductRecipeItem.item_id.in_(item_ids))
+
+        return query
+
+    def _transfer_totals(
+        self, location_ids: Optional[Sequence[int]], item_ids: Optional[Sequence[int]]
+    ) -> Tuple[Iterable[Tuple[int, int, float]], Iterable[Tuple[int, int, float]]]:
+        base_query = (
+            self.session.query(
+                TransferItem.item_id,
+                Transfer.from_location_id,
+                Transfer.to_location_id,
+                TransferItem.quantity,
+            )
+            .join(Transfer, TransferItem.transfer_id == Transfer.id)
+            .filter(Transfer.date_created >= self._since)
+        )
+
+        if location_ids:
+            base_query = base_query.filter(
+                Transfer.from_location_id.in_(location_ids)
+                | Transfer.to_location_id.in_(location_ids)
+            )
+        if item_ids:
+            base_query = base_query.filter(TransferItem.item_id.in_(item_ids))
+
+        incoming = {}
+        outgoing = {}
+        for item_id, from_loc, to_loc, quantity in base_query:
+            if to_loc is not None:
+                if not location_ids or to_loc in location_ids:
+                    incoming.setdefault((item_id, to_loc), 0.0)
+                    incoming[(item_id, to_loc)] += float(quantity)
+            if from_loc is not None:
+                if not location_ids or from_loc in location_ids:
+                    outgoing.setdefault((item_id, from_loc), 0.0)
+                    outgoing[(item_id, from_loc)] += float(quantity)
+
+        return incoming.items(), outgoing.items()
+
+    def _invoice_totals(
+        self, location_ids: Optional[Sequence[int]], item_ids: Optional[Sequence[int]]
+    ) -> Iterable[Tuple[int, int, float]]:
+        factor = _coalesce_factor(ItemUnit.factor)
+        query = (
+            self.session.query(
+                PurchaseInvoiceItem.item_id,
+                PurchaseInvoice.location_id,
+                func.sum(PurchaseInvoiceItem.quantity * factor).label("quantity"),
+            )
+            .join(PurchaseInvoice, PurchaseInvoiceItem.invoice_id == PurchaseInvoice.id)
+            .outerjoin(ItemUnit, PurchaseInvoiceItem.unit_id == ItemUnit.id)
+            .filter(PurchaseInvoice.received_date >= self._since)
+            .group_by(PurchaseInvoiceItem.item_id, PurchaseInvoice.location_id)
+        )
+
+        if location_ids:
+            query = query.filter(PurchaseInvoice.location_id.in_(location_ids))
+        if item_ids:
+            query = query.filter(PurchaseInvoiceItem.item_id.in_(item_ids))
+
+        return query
+
+    def _open_po_totals(
+        self, item_ids: Optional[Sequence[int]]
+    ) -> Iterable[Tuple[int, float]]:
+        factor = _coalesce_factor(ItemUnit.factor)
+        query = (
+            self.session.query(
+                PurchaseOrderItem.item_id,
+                func.sum(PurchaseOrderItem.quantity * factor).label("quantity"),
+            )
+            .join(PurchaseOrder, PurchaseOrderItem.purchase_order_id == PurchaseOrder.id)
+            .outerjoin(ItemUnit, PurchaseOrderItem.unit_id == ItemUnit.id)
+            .filter(PurchaseOrder.received.is_(False))
+            .group_by(PurchaseOrderItem.item_id)
+        )
+        if item_ids:
+            query = query.filter(PurchaseOrderItem.item_id.in_(item_ids))
+        return query
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def build_recommendations(
+        self,
+        *,
+        location_ids: Optional[Sequence[int]] = None,
+        item_ids: Optional[Sequence[int]] = None,
+        attendance_multiplier: float = 1.0,
+        weather_multiplier: float = 1.0,
+        promo_multiplier: float = 1.0,
+    ) -> List[ForecastRecommendation]:
+        """Return forecast recommendations for the supplied filters."""
+
+        data: Dict[Tuple[int, int], Dict[str, float]] = {}
+
+        def entry_for(key: Tuple[int, int]) -> Dict[str, float]:
+            record = data.setdefault(
+                key,
+                {
+                    "sales_qty": 0.0,
+                    "transfer_in_qty": 0.0,
+                    "transfer_out_qty": 0.0,
+                    "invoice_qty": 0.0,
+                    "open_po_qty": 0.0,
+                    "last_activity_ts": None,
+                },
+            )
+            return record
+
+        # Terminal sales
+        for item_id, location_id, quantity, last_activity in self._terminal_sales_totals(
+            location_ids, item_ids
+        ):
+            if item_id is None or location_id is None:
+                continue
+            entry = entry_for((item_id, location_id))
+            entry["sales_qty"] += float(quantity or 0.0)
+            if last_activity is not None:
+                current = entry.get("last_activity_ts")
+                if current is None or last_activity > current:
+                    entry["last_activity_ts"] = last_activity
+
+        # Transfers
+        incoming, outgoing = self._transfer_totals(location_ids, item_ids)
+        for (item_id, location_id), quantity in incoming:
+            entry = entry_for((item_id, location_id))
+            entry["transfer_in_qty"] += float(quantity)
+        for (item_id, location_id), quantity in outgoing:
+            entry = entry_for((item_id, location_id))
+            entry["transfer_out_qty"] += float(quantity)
+
+        # Purchase invoices
+        for item_id, location_id, quantity in self._invoice_totals(location_ids, item_ids):
+            if item_id is None or location_id is None:
+                continue
+            entry = entry_for((item_id, location_id))
+            entry["invoice_qty"] += float(quantity or 0.0)
+
+        # Open purchase orders (global by item)
+        open_po_map: Dict[int, float] = {}
+        for item_id, quantity in self._open_po_totals(item_ids):
+            if item_id is None:
+                continue
+            open_po_map[item_id] = open_po_map.get(item_id, 0.0) + float(quantity or 0.0)
+
+        for key in data.keys():
+            item_id, _ = key
+            if item_id in open_po_map:
+                data[key]["open_po_qty"] = open_po_map[item_id]
+
+        if not data:
+            return []
+
+        item_ids_needed = {item_id for item_id, _ in data.keys() if item_id is not None}
+        location_ids_needed = {
+            location_id for _, location_id in data.keys() if location_id is not None
+        }
+
+        items = {
+            item.id: item
+            for item in self.session.query(Item)
+            .options(selectinload(Item.units))
+            .filter(Item.id.in_(item_ids_needed))
+        }
+        locations = {
+            location.id: location
+            for location in self.session.query(Location)
+            .filter(Location.id.in_(location_ids_needed))
+        }
+
+        multiplier = attendance_multiplier * weather_multiplier * promo_multiplier
+        today = _dt.date.today()
+        suggested_date = today + _dt.timedelta(days=self.lead_time_days)
+
+        recommendations: List[ForecastRecommendation] = []
+        for (item_id, location_id), history in data.items():
+            item = items.get(item_id)
+            location = locations.get(location_id)
+            if item is None or location is None:
+                continue
+
+            base_consumption = history["sales_qty"] + history["transfer_out_qty"]
+            adjusted_demand = base_consumption * multiplier
+            incoming = (
+                history["transfer_in_qty"] + history["invoice_qty"] + history["open_po_qty"]
+            )
+            recommended_quantity = max(adjusted_demand - incoming, 0.0)
+
+            default_unit_id = None
+            for unit in item.units:
+                if unit.receiving_default:
+                    default_unit_id = unit.id
+                    break
+            if default_unit_id is None and item.units:
+                default_unit_id = item.units[0].id
+
+            recommendations.append(
+                ForecastRecommendation(
+                    item=item,
+                    location=location,
+                    history=history,
+                    base_consumption=base_consumption,
+                    adjusted_demand=adjusted_demand,
+                    recommended_quantity=recommended_quantity,
+                    suggested_delivery_date=suggested_date,
+                    default_unit_id=default_unit_id,
+                )
+            )
+
+        recommendations.sort(
+            key=lambda rec: (rec.recommended_quantity, rec.base_consumption),
+            reverse=True,
+        )
+        return recommendations
+
+
+__all__ = ["DemandForecastingHelper", "ForecastRecommendation"]
+

--- a/tests/purchase/test_recommendations.py
+++ b/tests/purchase/test_recommendations.py
@@ -1,0 +1,261 @@
+import datetime
+import re
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import (
+    Event,
+    EventLocation,
+    Item,
+    ItemUnit,
+    Location,
+    Product,
+    ProductRecipeItem,
+    PurchaseInvoice,
+    PurchaseInvoiceItem,
+    PurchaseOrder,
+    PurchaseOrderItem,
+    TerminalSale,
+    Transfer,
+    TransferItem,
+    User,
+    Vendor,
+)
+from app.utils.forecasting import DemandForecastingHelper
+from tests.utils import login
+
+
+def _seed_forecasting_data(app):
+    with app.app_context():
+        today = datetime.date.today()
+        now = datetime.datetime.utcnow()
+
+        user = User(
+            email="forecast@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        vendor = Vendor(first_name="Future", last_name="Foods")
+        location_main = Location(name="Main Stand")
+        location_other = Location(name="Warehouse")
+        item = Item(name="Widget", base_unit="each")
+        unit = ItemUnit(
+            item=item,
+            name="each",
+            factor=1,
+            receiving_default=True,
+            transfer_default=True,
+        )
+        product = Product(name="Widget Combo", price=10, cost=4)
+        recipe = ProductRecipeItem(product=product, item=item, unit=unit, quantity=2)
+        event = Event(name="Concert", start_date=today, end_date=today)
+        event_location = EventLocation(event=event, location=location_main)
+
+        db.session.add_all(
+            [
+                user,
+                vendor,
+                location_main,
+                location_other,
+                item,
+                unit,
+                product,
+                recipe,
+                event,
+                event_location,
+            ]
+        )
+        db.session.commit()
+
+        sale = TerminalSale(
+            event_location=event_location,
+            product=product,
+            quantity=5,
+            sold_at=now - datetime.timedelta(days=1),
+        )
+        db.session.add(sale)
+        db.session.commit()
+
+        transfer_out = Transfer(
+            from_location_id=location_main.id,
+            to_location_id=location_other.id,
+            user_id=user.id,
+            from_location_name=location_main.name,
+            to_location_name=location_other.name,
+            date_created=now - datetime.timedelta(days=1),
+            completed=True,
+        )
+        transfer_in = Transfer(
+            from_location_id=location_other.id,
+            to_location_id=location_main.id,
+            user_id=user.id,
+            from_location_name=location_other.name,
+            to_location_name=location_main.name,
+            date_created=now - datetime.timedelta(days=1),
+            completed=True,
+        )
+        db.session.add_all([transfer_out, transfer_in])
+        db.session.flush()
+
+        db.session.add_all(
+            [
+                TransferItem(
+                    transfer_id=transfer_out.id,
+                    item_id=item.id,
+                    quantity=2,
+                    item_name=item.name,
+                ),
+                TransferItem(
+                    transfer_id=transfer_in.id,
+                    item_id=item.id,
+                    quantity=1,
+                    item_name=item.name,
+                ),
+            ]
+        )
+
+        po_closed = PurchaseOrder(
+            vendor_id=vendor.id,
+            user_id=user.id,
+            vendor_name=f"{vendor.first_name} {vendor.last_name}",
+            order_date=today,
+            expected_date=today,
+            delivery_charge=0,
+            received=True,
+        )
+        po_open = PurchaseOrder(
+            vendor_id=vendor.id,
+            user_id=user.id,
+            vendor_name=f"{vendor.first_name} {vendor.last_name}",
+            order_date=today,
+            expected_date=today,
+            delivery_charge=0,
+            received=False,
+        )
+        db.session.add_all([po_closed, po_open])
+        db.session.flush()
+
+        poi = PurchaseOrderItem(
+            purchase_order_id=po_open.id,
+            item_id=item.id,
+            unit_id=unit.id,
+            quantity=3,
+        )
+        db.session.add(poi)
+
+        invoice = PurchaseInvoice(
+            purchase_order_id=po_closed.id,
+            user_id=user.id,
+            location_id=location_main.id,
+            vendor_name=f"{vendor.first_name} {vendor.last_name}",
+            location_name=location_main.name,
+            received_date=today,
+            delivery_charge=0,
+        )
+        db.session.add(invoice)
+        db.session.flush()
+
+        invoice_item = PurchaseInvoiceItem(
+            invoice_id=invoice.id,
+            item_id=item.id,
+            unit_id=unit.id,
+            item_name=item.name,
+            unit_name=unit.name,
+            quantity=2,
+            cost=5,
+        )
+        db.session.add(invoice_item)
+
+        db.session.commit()
+
+        return {
+            "user_email": user.email,
+            "vendor_id": vendor.id,
+            "item_id": item.id,
+            "unit_id": unit.id,
+            "location_id": location_main.id,
+            "recommended_key": f"{item.id}:{location_main.id}",
+        }
+
+
+def test_forecasting_helper_aggregates_sources(app):
+    ctx = _seed_forecasting_data(app)
+    with app.app_context():
+        helper = DemandForecastingHelper(lookback_days=30, lead_time_days=2)
+        results = helper.build_recommendations(
+            location_ids=[ctx["location_id"]]
+        )
+        assert len(results) == 1
+        rec = results[0]
+        assert rec.history["sales_qty"] == pytest.approx(10)
+        assert rec.history["transfer_out_qty"] == pytest.approx(2)
+        assert rec.history["transfer_in_qty"] == pytest.approx(1)
+        assert rec.history["invoice_qty"] == pytest.approx(2)
+        assert rec.history["open_po_qty"] == pytest.approx(3)
+        assert rec.base_consumption == pytest.approx(12)
+        assert rec.adjusted_demand == pytest.approx(12)
+        assert rec.recommended_quantity == pytest.approx(6)
+        assert rec.default_unit_id == ctx["unit_id"]
+
+
+def test_recommendations_route_json_and_seed(client, app):
+    ctx = _seed_forecasting_data(app)
+    order_date = datetime.date.today().isoformat()
+    override_qty = 4
+
+    with client:
+        login(client, ctx["user_email"], "pass")
+
+        json_resp = client.get("/purchase_orders/recommendations?format=json")
+        assert json_resp.status_code == 200
+        payload = json_resp.get_json()
+        assert payload["data"]
+        assert payload["data"][0]["recommended_quantity"] == pytest.approx(6)
+
+        response = client.post(
+            "/purchase_orders/recommendations",
+            data={
+                "action": "seed",
+                "selected_lines": ctx["recommended_key"],
+                f"override-{ctx['recommended_key']}": override_qty,
+                "seed_vendor_id": ctx["vendor_id"],
+                "seed_order_date": order_date,
+                "seed_expected_date": order_date,
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        item_match = re.search(
+            r'name="items-0-item"[^>]*value="(\d+)"', html
+        )
+        assert item_match and int(item_match.group(1)) == ctx["item_id"]
+        quantity_match = re.search(
+            r'name="items-0-quantity"[^>]*value="([^"]+)"', html
+        )
+        assert quantity_match and float(quantity_match.group(1)) == pytest.approx(
+            override_qty
+        )
+
+        create_resp = client.post(
+            "/purchase_orders/create",
+            data={
+                "vendor": ctx["vendor_id"],
+                "order_date": order_date,
+                "expected_date": order_date,
+                "delivery_charge": 0,
+                "items-0-item": ctx["item_id"],
+                "items-0-unit": ctx["unit_id"],
+                "items-0-quantity": override_qty,
+            },
+            follow_redirects=True,
+        )
+        assert create_resp.status_code == 200
+
+    with app.app_context():
+        po = PurchaseOrder.query.order_by(PurchaseOrder.id.desc()).first()
+        assert po is not None
+        assert po.received is False
+        assert po.items[0].quantity == pytest.approx(override_qty)


### PR DESCRIPTION
## Summary
- add a demand forecasting helper that aggregates multi-source item activity and exposes multiplier controls
- surface a purchase order recommendations view with HTML/JSON responses, charts, and PO draft seeding
- extend purchase order creation to hydrate seeded lines and cover the workflow with new tests

## Testing
- pytest tests/purchase/test_recommendations.py

------
https://chatgpt.com/codex/tasks/task_e_68d628a19db88324aec6d5ea45e06e97