### PR TITLE
Add recommendations button to purchase orders page

### DIFF
--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -5,6 +5,9 @@
     <div class="row justify-content-between">
         <div class="col-auto">
             <a class="btn btn-primary mb-3" href="{{ url_for('purchase.create_purchase_order') }}">Create Purchase Order</a>
+            <a class="btn btn-outline-primary mb-3 ms-2" href="{{ url_for('purchase.purchase_order_recommendations') }}">
+                View Recommendations
+            </a>
         </div>
         <div class="col-auto text-end">
             <div class="dropdown d-inline-block mb-3 me-2" data-column-visibility data-table-id="purchase-orders-table" data-storage-key="purchaseOrderTableColumnVisibility">


### PR DESCRIPTION
## Summary
- add a shortcut button on the purchase orders list to open the recommendations view

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6312552408324872adfda7808d2db