### PR TITLE
Adjust stand sheet print signoffs

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -78,6 +78,21 @@
 .signoffs .right div {
   margin-bottom: 8px;
 }
+.print-signoffs {
+  display: none;
+}
+.print-signoffs .columns {
+  display: flex;
+  justify-content: space-between;
+}
+.print-signoffs .columns .left,
+.print-signoffs .columns .right {
+  width: 48%;
+}
+.print-signoffs .columns .left div,
+.print-signoffs .columns .right div {
+  margin-bottom: 8px;
+}
 .standsheet-page {
   page-break-after: always;
 }
@@ -86,6 +101,8 @@
 }
 @media print {
   .no-print { display: none; }
+  .print-signoffs { display: table-footer-group; }
+  .signoffs { display: none; }
 }
 </style>
 <div class="standsheet-content">
@@ -163,9 +180,31 @@
         </tr>
         {% endfor %}
       </tbody>
+      <tfoot class="print-signoffs">
+        <tr>
+          <td colspan="11">
+            <div class="columns">
+              <div class="left">
+                <div>Opening Stand Manager  ______________________________</div>
+                <div>Opening Supervisor     ______________________________</div>
+                <div>Closing Stand Manager  ______________________________</div>
+                <div>Closing Supervisor     ______________________________</div>
+                <div>Audit/Review Signature ______________________________</div>
+              </div>
+              <div class="right">
+                <div>Total Sales  ______________________________</div>
+                <div>Total Cash   ______________________________</div>
+                <div>Credit Cards ______________________________</div>
+                <div>Coupons      ______________________________</div>
+                <div>Over/Short   ______________________________</div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      </tfoot>
     </table>
   </div>
-  <div class="signoffs">
+  <div class="signoffs no-print">
     <div class="left">
       <div>Opening Stand Manager  ______________________________</div>
       <div>Opening Supervisor     ______________________________</div>


### PR DESCRIPTION
## Summary
- add print-only table footer for sign-off fields on bulk stand sheets
- hide the existing sign-off block during printing so the lines appear at the end of each table

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f9b0568c8324bdd1623bba9cec37