### PR TITLE
Handle CSRF errors with user-friendly page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,7 +6,7 @@ from datetime import timezone as dt_timezone
 from zoneinfo import ZoneInfo
 
 from dotenv import load_dotenv
-from flask import Flask, Response, g, request
+from flask import Flask, Response, g, render_template, request
 from flask_bootstrap import Bootstrap
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -14,6 +14,7 @@ from flask_login import LoginManager
 from flask_socketio import SocketIO
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf import CSRFProtect
+from flask_wtf.csrf import CSRFError
 from werkzeug.security import generate_password_hash
 
 load_dotenv()
@@ -348,5 +349,16 @@ def create_app(args: list):
             pass
 
         CSRFProtect(app)
+
+        @app.errorhandler(CSRFError)
+        def handle_csrf_error(error):
+            """Render a helpful page when CSRF validation fails."""
+            return (
+                render_template(
+                    "errors/csrf_error.html",
+                    reason=error.description,
+                ),
+                400,
+            )
 
     return app, socketio

--- a/app/templates/errors/csrf_error.html
+++ b/app/templates/errors/csrf_error.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+        <div class="card border-warning mt-4">
+            <div class="card-header bg-warning text-dark">
+                <h2 class="h4 mb-0">Session Expired</h2>
+            </div>
+            <div class="card-body">
+                <p class="mb-3">
+                    Your form could not be submitted because the security token was missing or expired.
+                </p>
+                <p class="mb-3">
+                    Please refresh the page and try submitting the form again. If the problem persists, log out and
+                    log back in before retrying.
+                </p>
+                {% if reason %}
+                <p class="text-muted small mb-0">Details: {{ reason }}</p>
+                {% endif %}
+            </div>
+            <div class="card-footer text-end">
+                <a class="btn btn-primary" href="{{ request.path }}" onclick="window.location.reload(); return false;">
+                    Reload and Try Again
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- register a CSRF error handler that renders a helpful template instead of the default message
- add a friendly CSRF error page advising users to refresh and try again

## Testing
- pytest tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d6fba8fd408324aa56bfefba72acad