### PR TITLE
Adjust bulk standsheet footer print behavior

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -101,7 +101,10 @@
 }
 @media print {
   .no-print { display: none; }
-  .print-signoffs { display: table-footer-group; }
+  .print-signoffs {
+    display: table-row-group;
+    page-break-inside: avoid;
+  }
   .signoffs { display: none; }
 }
 </style>


### PR DESCRIPTION
## Summary
- update the bulk stand sheet print stylesheet so the sign-off footer renders only once on the final page of a multi-page table
- prevent the print footer block from being split across pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d701a3430083248287e5f59cd94327