### PR TITLE
Adjust print footer placement

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -94,14 +94,19 @@
   margin-bottom: 8px;
 }
 .standsheet-page {
-  page-break-after: always;
-}
-.standsheet-page:last-child {
   page-break-after: auto;
 }
 @media print {
   .no-print { display: none; }
-  .print-signoffs { display: table-footer-group; }
+  .print-signoffs {
+    display: block;
+    margin-top: 12px;
+    border: none;
+    page-break-after: always;
+  }
+  .report:last-of-type .print-signoffs {
+    page-break-after: auto;
+  }
   .signoffs { display: none; }
 }
 </style>
@@ -180,29 +185,25 @@
         </tr>
         {% endfor %}
       </tbody>
-      <tfoot class="print-signoffs">
-        <tr>
-          <td colspan="11">
-            <div class="columns">
-              <div class="left">
-                <div>Opening Stand Manager  ______________________________</div>
-                <div>Opening Supervisor     ______________________________</div>
-                <div>Closing Stand Manager  ______________________________</div>
-                <div>Closing Supervisor     ______________________________</div>
-                <div>Audit/Review Signature ______________________________</div>
-              </div>
-              <div class="right">
-                <div>Total Sales  ______________________________</div>
-                <div>Total Cash   ______________________________</div>
-                <div>Credit Cards ______________________________</div>
-                <div>Coupons      ______________________________</div>
-                <div>Over/Short   ______________________________</div>
-              </div>
-            </div>
-          </td>
-        </tr>
-      </tfoot>
     </table>
+    <div class="print-signoffs">
+      <div class="columns">
+        <div class="left">
+          <div>Opening Stand Manager  ______________________________</div>
+          <div>Opening Supervisor     ______________________________</div>
+          <div>Closing Stand Manager  ______________________________</div>
+          <div>Closing Supervisor     ______________________________</div>
+          <div>Audit/Review Signature ______________________________</div>
+        </div>
+        <div class="right">
+          <div>Total Sales  ______________________________</div>
+          <div>Total Cash   ______________________________</div>
+          <div>Credit Cards ______________________________</div>
+          <div>Coupons      ______________________________</div>
+          <div>Over/Short   ______________________________</div>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="signoffs no-print">
     <div class="left">


### PR DESCRIPTION
## Summary
- ensure the standsheet section page break happens after the signature block rather than after each printed page
- update the print-only footer styling so it prints once per location and forces the next standsheet onto a new page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d701a3430083248287e5f59cd94327