### PR TITLE
Ensure standsheet signature prints once per location

### DIFF
--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -78,8 +78,15 @@
 .signoffs .right div {
   margin-bottom: 8px;
 }
-.print-signoffs {
+.table tfoot {
   display: none;
+}
+.table tfoot td {
+  padding: 0;
+  border: none;
+}
+.print-signoffs {
+  padding-top: 12px;
 }
 .print-signoffs .columns {
   display: flex;
@@ -94,14 +101,22 @@
   margin-bottom: 8px;
 }
 .standsheet-page {
-  page-break-after: always;
-}
-.standsheet-page:last-child {
   page-break-after: auto;
 }
 @media print {
   .no-print { display: none; }
-  .print-signoffs { display: table-footer-group; }
+  .table tfoot {
+    display: table-row-group;
+  }
+  .print-signoffs {
+    page-break-inside: avoid;
+  }
+  .report {
+    break-after: page;
+  }
+  .report:last-of-type {
+    break-after: auto;
+  }
   .signoffs { display: none; }
 }
 </style>
@@ -180,23 +195,25 @@
         </tr>
         {% endfor %}
       </tbody>
-      <tfoot class="print-signoffs">
+      <tfoot>
         <tr>
           <td colspan="11">
-            <div class="columns">
-              <div class="left">
-                <div>Opening Stand Manager  ______________________________</div>
-                <div>Opening Supervisor     ______________________________</div>
-                <div>Closing Stand Manager  ______________________________</div>
-                <div>Closing Supervisor     ______________________________</div>
-                <div>Audit/Review Signature ______________________________</div>
-              </div>
-              <div class="right">
-                <div>Total Sales  ______________________________</div>
-                <div>Total Cash   ______________________________</div>
-                <div>Credit Cards ______________________________</div>
-                <div>Coupons      ______________________________</div>
-                <div>Over/Short   ______________________________</div>
+            <div class="print-signoffs">
+              <div class="columns">
+                <div class="left">
+                  <div>Opening Stand Manager  ______________________________</div>
+                  <div>Opening Supervisor     ______________________________</div>
+                  <div>Closing Stand Manager  ______________________________</div>
+                  <div>Closing Supervisor     ______________________________</div>
+                  <div>Audit/Review Signature ______________________________</div>
+                </div>
+                <div class="right">
+                  <div>Total Sales  ______________________________</div>
+                  <div>Total Cash   ______________________________</div>
+                  <div>Credit Cards ______________________________</div>
+                  <div>Coupons      ______________________________</div>
+                  <div>Over/Short   ______________________________</div>
+                </div>
               </div>
             </div>
           </td>


### PR DESCRIPTION
## Summary
- move the print-only sign-off markup into the standsheet table footer so it renders after the final inventory row
- adjust the print styles so the footer row only appears during printing and each location still breaks onto a new page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d701a3430083248287e5f59cd94327