### PR TITLE
Render full standsheet per location

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -793,18 +793,9 @@ def bulk_stand_sheets(event_id):
     if ev is None:
         abort(404)
     data = []
-    PAGE_SIZE = 20  # number of items per stand sheet page
     for el in ev.locations:
         loc, items = _get_stand_items(el.location_id, event_id)
-        if not items:
-            chunks = [[]]
-        else:
-            chunks = [
-                items[i : i + PAGE_SIZE]  # noqa: E203
-                for i in range(0, len(items), PAGE_SIZE)
-            ]
-        for chunk in chunks:
-            data.append({"location": loc, "stand_items": chunk})
+        data.append({"location": loc, "stand_items": items})
     dt = datetime.now()
     generated_at_local = (
         f"{dt.month}/{dt.day}/{dt.year} {dt.strftime('%I:%M %p').lstrip('0')}"

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -80,6 +80,7 @@
 }
 .print-signoffs {
   display: none;
+  padding-top: 12px;
 }
 .print-signoffs .columns {
   display: flex;
@@ -94,14 +95,18 @@
   margin-bottom: 8px;
 }
 .standsheet-page {
-  page-break-after: always;
-}
-.standsheet-page:last-child {
   page-break-after: auto;
 }
 @media print {
   .no-print { display: none; }
-  .print-signoffs { display: table-footer-group; }
+  .print-signoffs {
+    display: block;
+    break-inside: avoid;
+    page-break-after: always;
+  }
+  .report:last-of-type .print-signoffs {
+    page-break-after: auto;
+  }
   .signoffs { display: none; }
 }
 </style>
@@ -180,29 +185,25 @@
         </tr>
         {% endfor %}
       </tbody>
-      <tfoot class="print-signoffs">
-        <tr>
-          <td colspan="11">
-            <div class="columns">
-              <div class="left">
-                <div>Opening Stand Manager  ______________________________</div>
-                <div>Opening Supervisor     ______________________________</div>
-                <div>Closing Stand Manager  ______________________________</div>
-                <div>Closing Supervisor     ______________________________</div>
-                <div>Audit/Review Signature ______________________________</div>
-              </div>
-              <div class="right">
-                <div>Total Sales  ______________________________</div>
-                <div>Total Cash   ______________________________</div>
-                <div>Credit Cards ______________________________</div>
-                <div>Coupons      ______________________________</div>
-                <div>Over/Short   ______________________________</div>
-              </div>
-            </div>
-          </td>
-        </tr>
-      </tfoot>
     </table>
+  </div>
+  <div class="print-signoffs">
+    <div class="columns">
+      <div class="left">
+        <div>Opening Stand Manager  ______________________________</div>
+        <div>Opening Supervisor     ______________________________</div>
+        <div>Closing Stand Manager  ______________________________</div>
+        <div>Closing Supervisor     ______________________________</div>
+        <div>Audit/Review Signature ______________________________</div>
+      </div>
+      <div class="right">
+        <div>Total Sales  ______________________________</div>
+        <div>Total Cash   ______________________________</div>
+        <div>Credit Cards ______________________________</div>
+        <div>Coupons      ______________________________</div>
+        <div>Over/Short   ______________________________</div>
+      </div>
+    </div>
   </div>
   <div class="signoffs no-print">
     <div class="left">


### PR DESCRIPTION
## Summary
- stop chunking stand sheet items server-side so each location renders a single table regardless of length
- move the print-only signature block outside the table and update print styles so it shows once after the final row with a trailing page break per location

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d701a3430083248287e5f59cd94327