### PR TITLE
Add UPC field and inventory scan counting endpoint

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -150,6 +150,7 @@ class ItemUnitForm(FlaskForm):
 
 class ItemForm(FlaskForm):
     name = StringField("Name", validators=[DataRequired()])
+    upc = StringField("UPC", validators=[Optional(), Length(max=32)])
     gl_code = SelectField("GL Code", validators=[Optional()])
     base_unit = SelectField(
         "Base Unit",
@@ -668,6 +669,14 @@ class EventLocationForm(FlaskForm):
 
 class EventLocationConfirmForm(FlaskForm):
     submit = SubmitField("Confirm")
+
+
+class ScanCountForm(FlaskForm):
+    upc = StringField("UPC", validators=[DataRequired(), Length(max=32)])
+    quantity = DecimalField(
+        "Quantity", validators=[InputRequired()], default=1
+    )
+    submit = SubmitField("Add Count")
 
 
 class ConfirmForm(FlaskForm):

--- a/app/models.py
+++ b/app/models.py
@@ -123,6 +123,7 @@ class Item(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
     base_unit = db.Column(db.String(20), nullable=False)
+    upc = db.Column(db.String(32), unique=True, nullable=True)
     gl_code = db.Column(db.String(10), nullable=True)
     gl_code_id = db.Column(
         db.Integer, db.ForeignKey("gl_code.id"), nullable=True

--- a/app/templates/events/scan_count.html
+++ b/app/templates/events/scan_count.html
@@ -1,0 +1,193 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <h2>Scan Inventory Counts - {{ location.name }}</h2>
+    <form method="post"
+          action="{{ url_for('event.scan_counts', event_id=event.id, location_id=location.id) }}"
+          data-scan-form>
+        {{ form.hidden_tag() }}
+        <div class="row g-3 align-items-end">
+            <div class="col-md-6">
+                {{ form.upc.label(class="form-label") }}
+                {{ form.upc(class="form-control", placeholder="Scan UPC", autofocus=True) }}
+            </div>
+            <div class="col-md-3">
+                {{ form.quantity.label(class="form-label") }}
+                {{ form.quantity(class="form-control", step="any") }}
+            </div>
+            <div class="col-md-3">
+                {{ form.submit(class="btn btn-primary w-100") }}
+            </div>
+        </div>
+    </form>
+    <div class="mt-3" data-scan-feedback></div>
+
+    <div class="d-flex align-items-center justify-content-between mt-4">
+        <h3 class="h5 mb-0">Running Totals</h3>
+        <button type="button" class="btn btn-outline-secondary btn-sm" data-scan-refresh>
+            Refresh Totals
+        </button>
+    </div>
+    <div class="table-responsive mt-2">
+        <table class="table table-striped align-middle">
+            <thead>
+                <tr>
+                    <th scope="col">Item</th>
+                    <th scope="col">Counted</th>
+                    <th scope="col">Expected</th>
+                </tr>
+            </thead>
+            <tbody data-scan-totals>
+                {% for entry in totals %}
+                <tr data-item-id="{{ entry.item_id }}">
+                    <td>
+                        <div class="fw-semibold">{{ entry.name }}</div>
+                        {% if entry.upc %}
+                        <div class="text-muted small">UPC: {{ entry.upc }}</div>
+                        {% endif %}
+                    </td>
+                    <td>
+                        {{ "{:.2f}".format(entry.counted) }} {{ entry.base_unit }}
+                    </td>
+                    <td>
+                        {{ "{:.2f}".format(entry.expected) }} {{ entry.base_unit }}
+                    </td>
+                </tr>
+                {% else %}
+                <tr>
+                    <td colspan="3" class="text-center text-muted">No counts recorded yet.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script nonce="{{ csp_nonce }}">
+    document.addEventListener('DOMContentLoaded', () => {
+        const form = document.querySelector('[data-scan-form]');
+        const feedback = document.querySelector('[data-scan-feedback]');
+        const totalsBody = document.querySelector('[data-scan-totals]');
+        const refreshButton = document.querySelector('[data-scan-refresh]');
+        if (!form) {
+            return;
+        }
+
+        const upcInput = form.querySelector('input[name="{{ form.upc.name }}"]');
+        const quantityInput = form.querySelector('input[name="{{ form.quantity.name }}"]');
+        const csrfInput = form.querySelector('input[name="csrf_token"]');
+
+        if (upcInput) {
+            upcInput.focus();
+        }
+
+        const showMessage = (message, type = 'success') => {
+            if (!feedback) {
+                return;
+            }
+            feedback.innerHTML = `
+                <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+                    ${message}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+            `;
+        };
+
+        const renderTotals = (totals) => {
+            if (!totalsBody) {
+                return;
+            }
+            if (!totals || totals.length === 0) {
+                totalsBody.innerHTML = '<tr><td colspan="3" class="text-center text-muted">No counts recorded yet.</td></tr>';
+                return;
+            }
+            const rows = totals.map((entry) => {
+                const counted = Number.isFinite(entry.counted) ? entry.counted.toFixed(2) : '0.00';
+                const expected = Number.isFinite(entry.expected) ? entry.expected.toFixed(2) : '0.00';
+                const upcLine = entry.upc ? `<div class="text-muted small">UPC: ${entry.upc}</div>` : '';
+                return `
+                    <tr data-item-id="${entry.item_id}">
+                        <td><div class="fw-semibold">${entry.name}</div>${upcLine}</td>
+                        <td>${counted} ${entry.base_unit || ''}</td>
+                        <td>${expected} ${entry.base_unit || ''}</td>
+                    </tr>
+                `;
+            });
+            totalsBody.innerHTML = rows.join('');
+        };
+
+        const refreshTotals = async (notify = false) => {
+            try {
+                const response = await fetch(form.action, {
+                    method: 'GET',
+                    headers: { 'Accept': 'application/json' },
+                    credentials: 'same-origin'
+                });
+                if (!response.ok) {
+                    throw new Error('Unable to refresh totals.');
+                }
+                const data = await response.json();
+                if (data && data.success) {
+                    renderTotals(data.totals || []);
+                    if (notify) {
+                        showMessage('Totals refreshed.', 'info');
+                    }
+                } else if (notify) {
+                    showMessage(data && data.error ? data.error : 'Unable to refresh totals.', 'danger');
+                }
+            } catch (err) {
+                if (notify) {
+                    showMessage('Unable to refresh totals.', 'danger');
+                }
+            }
+        };
+
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const upcValue = upcInput ? upcInput.value.trim() : '';
+            const quantityValue = quantityInput ? quantityInput.value : '0';
+            const headers = {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json'
+            };
+            if (csrfInput) {
+                headers['X-CSRFToken'] = csrfInput.value;
+            }
+
+            try {
+                const response = await fetch(form.action, {
+                    method: 'POST',
+                    headers,
+                    credentials: 'same-origin',
+                    body: JSON.stringify({
+                        upc: upcValue,
+                        quantity: quantityValue
+                    })
+                });
+                const data = await response.json();
+                if (!response.ok || !data.success) {
+                    const message = data && data.error ? data.error : 'Unable to record the count.';
+                    showMessage(message, 'danger');
+                    return;
+                }
+                renderTotals(data.totals || []);
+                showMessage(`Recorded ${data.item.total.toFixed(2)} ${data.item.base_unit || ''} total for ${data.item.name}.`, 'success');
+                if (upcInput) {
+                    upcInput.value = '';
+                    upcInput.focus();
+                }
+                if (quantityInput) {
+                    quantityInput.value = '1';
+                }
+            } catch (error) {
+                showMessage('Unable to record the count.', 'danger');
+            }
+        });
+
+        if (refreshButton) {
+            refreshButton.addEventListener('click', () => refreshTotals(true));
+        }
+    });
+</script>
+{% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -32,7 +32,10 @@
                     <td>
                         {% if not el.confirmed and not event.closed %}
                             <a href="{{ url_for('event.stand_sheet', event_id=event.id, location_id=el.location_id) }}">Stand Sheet</a>
-                            {% if event.event_type == 'inventory' %}| <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a>{% endif %} |
+                            {% if event.event_type == 'inventory' %}
+                                | <a href="{{ url_for('event.count_sheet', event_id=event.id, location_id=el.location_id) }}">Count Sheet</a>
+                                | <a href="{{ url_for('event.scan_counts', event_id=event.id, location_id=el.location_id) }}">Scan Counts</a>
+                            {% endif %} |
                             <a href="{{ url_for('event.add_terminal_sale', event_id=event.id, el_id=el.id) }}">Enter Sales</a> |
                             <a href="{{ url_for('event.confirm_location', event_id=event.id, el_id=el.id) }}">Confirm</a>
                         {% else %}

--- a/app/templates/items/item_form.html
+++ b/app/templates/items/item_form.html
@@ -23,6 +23,10 @@
             {{ form.purchase_gl_code.label(class="form-label") }}
             {{ form.purchase_gl_code(class="form-control") }}
         </div>
+        <div class="col-md-6 mb-3">
+            {{ form.upc.label(class="form-label") }}
+            {{ form.upc(class="form-control", placeholder="Scan or enter UPC") }}
+        </div>
     </div>
     {% if current_item %}
     <div class="form-group">

--- a/migrations/versions/f1c2d3e4a5b6_add_upc_to_item.py
+++ b/migrations/versions/f1c2d3e4a5b6_add_upc_to_item.py
@@ -1,0 +1,57 @@
+"""add upc column to item
+
+Revision ID: f1c2d3e4a5b6
+Revises: e1b5c3f4d6a7
+Create Date: 2025-09-10 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def _has_column(table_name: str, column_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table_name):
+        return False
+    return column_name in {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def _has_unique_constraint(table_name: str, constraint_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table_name):
+        return False
+    return constraint_name in {
+        constraint["name"] for constraint in inspector.get_unique_constraints(table_name)
+    }
+
+
+# revision identifiers, used by Alembic.
+revision = "f1c2d3e4a5b6"
+down_revision = "e1b5c3f4d6a7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if not bind:
+        return
+
+    with op.batch_alter_table("item", recreate="always") as batch_op:
+        if not _has_column("item", "upc", bind):
+            batch_op.add_column(sa.Column("upc", sa.String(length=32), nullable=True))
+        if not _has_unique_constraint("item", "uq_item_upc", bind):
+            batch_op.create_unique_constraint("uq_item_upc", ["upc"])
+
+
+def downgrade():
+    bind = op.get_bind()
+    if not bind:
+        return
+
+    with op.batch_alter_table("item", recreate="always") as batch_op:
+        if _has_unique_constraint("item", "uq_item_upc", bind):
+            batch_op.drop_constraint("uq_item_upc", type_="unique")
+        if _has_column("item", "upc", bind):
+            batch_op.drop_column("upc")

--- a/tests/test_event_scan_counts.py
+++ b/tests/test_event_scan_counts.py
@@ -1,0 +1,122 @@
+from datetime import date
+from uuid import uuid4
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import (
+    Event,
+    EventLocation,
+    EventStandSheetItem,
+    Item,
+    ItemUnit,
+    Location,
+    LocationStandItem,
+    User,
+)
+from tests.utils import login
+
+
+def _setup_event(app, *, event_type="inventory", closed=False):
+    with app.app_context():
+        email = f"scanner_{uuid4().hex[:8]}@example.com"
+        user = User(
+            email=email,
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        location = Location(name=f"Scan Booth {uuid4().hex[:6]}")
+        upc = f"{uuid4().int % 10**12:012d}"
+        item = Item(name=f"Scannable Item {uuid4().hex[:6]}", base_unit="each", upc=upc)
+        db.session.add_all([user, location, item])
+        db.session.commit()
+
+        unit = ItemUnit(
+            item_id=item.id,
+            name="each",
+            factor=1,
+            receiving_default=True,
+            transfer_default=True,
+        )
+        db.session.add(unit)
+        db.session.add(
+            LocationStandItem(
+                location_id=location.id,
+                item_id=item.id,
+                expected_count=5,
+            )
+        )
+
+        event = Event(
+            name="Inventory Scan",
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 2),
+            event_type=event_type,
+            closed=closed,
+        )
+        db.session.add(event)
+        db.session.commit()
+
+        event_location = EventLocation(event_id=event.id, location_id=location.id)
+        db.session.add(event_location)
+        db.session.commit()
+
+        return {
+            "email": email,
+            "event_id": event.id,
+            "location_id": location.id,
+            "event_location_id": event_location.id,
+            "item_upc": upc,
+            "item_id": item.id,
+        }
+
+
+def test_scan_counts_rejects_non_inventory(client, app):
+    context = _setup_event(app, event_type="other")
+    url = f"/events/{context['event_id']}/locations/{context['location_id']}/scan_counts"
+
+    with client:
+        login(client, context["email"], "pass")
+        get_resp = client.get(url)
+        assert get_resp.status_code == 404
+        post_resp = client.post(url, json={"upc": context["item_upc"], "quantity": 1})
+        assert post_resp.status_code == 404
+
+
+def test_scan_counts_records_totals(client, app):
+    context = _setup_event(app)
+    url = f"/events/{context['event_id']}/locations/{context['location_id']}/scan_counts"
+
+    with client:
+        login(client, context["email"], "pass")
+        get_resp = client.get(url)
+        assert get_resp.status_code == 200
+        assert b"Scan Inventory Counts" in get_resp.data
+
+        post_resp = client.post(url, json={"upc": context["item_upc"], "quantity": 3})
+        assert post_resp.status_code == 200
+        payload = post_resp.get_json()
+        assert payload["success"] is True
+        assert payload["item"]["total"] == pytest.approx(3)
+
+        second_resp = client.post(url, json={"upc": context["item_upc"], "quantity": 2})
+        assert second_resp.status_code == 200
+        payload = second_resp.get_json()
+        assert payload["item"]["total"] == pytest.approx(5)
+
+        refresh = client.get(url, headers={"Accept": "application/json"})
+        assert refresh.status_code == 200
+        refresh_payload = refresh.get_json()
+        assert refresh_payload["success"] is True
+        assert refresh_payload["totals"]
+        assert refresh_payload["totals"][0]["counted"] == pytest.approx(5)
+
+    with app.app_context():
+        sheet = EventStandSheetItem.query.filter_by(
+            event_location_id=context["event_location_id"],
+            item_id=context["item_id"],
+        ).first()
+        assert sheet is not None
+        assert sheet.transferred_out == pytest.approx(5)
+        assert sheet.closing_count == pytest.approx(5)


### PR DESCRIPTION
## Summary
- add a UPC column to items with a migration and expose it on item forms
- implement an inventory scan-count workflow with JSON responses and a scanner UI
- link the scanner page from inventory events and cover the new flow with tests

## Testing
- pytest tests/test_event_scan_counts.py

------
https://chatgpt.com/codex/tasks/task_e_68d719d62598832484ccd0d5403afcc1