### PR TITLE
Allow configuring cookie security for HTTP environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ The GST number can now be set from the application control panel after installat
 
 These can be placed in a `.env` file or exported in your shell before starting the app.
 
+### Optional Environment Variables
+
+- `SESSION_COOKIE_SECURE` – set to `false` when running over plain HTTP (for
+  example in local development). Defaults to `true` so cookies are only sent
+  over HTTPS in production.
+- `ENFORCE_HTTPS` – set to `true` to always send the
+  `Strict-Transport-Security` header, even if the request is not detected as
+  secure (useful when SSL termination happens upstream). Defaults to `false`.
+
 ## Database Setup
 
 Run the database migrations to create the tables:


### PR DESCRIPTION
## Summary
- add helpers to read boolean environment variables and expose cookie/HSTS toggles in the Flask factory
- allow disabling secure cookies for demo or local HTTP runs while keeping HTTPS defaults for production
- document the new optional SESSION_COOKIE_SECURE and ENFORCE_HTTPS environment variables in the README

## Testing
- pytest tests/test_event_flow.py::test_bulk_stand_sheets_render_multiple_pages *(fails: existing assertion expecting two stand sheet pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d7317ac91483248d3cd11b45f47ad1