### PR TITLE
Ensure GL codes available for all invoice receive items

### DIFF
--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -17,6 +17,7 @@ from app.forms import (
     DeleteForm,
     PurchaseOrderForm,
     ReceiveInvoiceForm,
+    load_purchase_gl_code_choices,
 )
 from app.models import (
     GLCode,
@@ -601,6 +602,7 @@ def receive_invoice(po_id):
             item_form.unit.choices = [
                 (u.id, u.name) for u in ItemUnit.query.all()
             ]
+            item_form.gl_code.choices = load_purchase_gl_code_choices()
         for i, poi in enumerate(po.items):
             form.items[i].item.data = poi.item_id
             form.items[i].unit.data = poi.unit_id


### PR DESCRIPTION
## Summary
- ensure appended invoice item forms inherit purchase GL code choices when preparing the receive invoice view

## Testing
- pytest *(fails: tests/test_event_flow.py::test_bulk_stand_sheets_render_multiple_pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d81d389bb883249e4793d05387d914