### PR TITLE
Implement column visibility dropdown across listing pages

### DIFF
--- a/app/templates/admin/activity_logs.html
+++ b/app/templates/admin/activity_logs.html
@@ -1,23 +1,36 @@
 {% extends 'base.html' %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 
 {% block content %}
 <div class="container mt-4">
     <h2>Activity Logs</h2>
+    <div class="d-flex justify-content-end mb-3">
+        {{ column_visibility_dropdown(
+            table_id='activity-logs-table',
+            storage_key='activityLogsTableColumnVisibility',
+            align='end',
+            columns=[
+                {'id': 'toggle-log-timestamp', 'target': 'col-log-timestamp', 'label': 'Timestamp', 'checked': True},
+                {'id': 'toggle-log-user', 'target': 'col-log-user', 'label': 'User', 'checked': True},
+                {'id': 'toggle-log-activity', 'target': 'col-log-activity', 'label': 'Activity', 'checked': True},
+            ]
+        ) }}
+    </div>
     <div class="table-responsive">
-    <table class="table">
+    <table class="table" id="activity-logs-table">
         <thead>
             <tr>
-                <th>Timestamp</th>
-                <th>User</th>
-                <th>Activity</th>
+                <th scope="col" class="col-log-timestamp">Timestamp</th>
+                <th scope="col" class="col-log-user">User</th>
+                <th scope="col" class="col-log-activity">Activity</th>
             </tr>
         </thead>
         <tbody>
             {% for log in logs %}
             <tr>
-                <td>{{ log.timestamp|format_datetime('%Y-%m-%d %H:%M:%S') }}</td>
-                <td>{{ log.user.email if log.user else 'System' }}</td>
-                <td>{{ log.activity }}</td>
+                <td class="col-log-timestamp">{{ log.timestamp|format_datetime('%Y-%m-%d %H:%M:%S') }}</td>
+                <td class="col-log-user">{{ log.user.email if log.user else 'System' }}</td>
+                <td class="col-log-activity">{{ log.activity }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/app/templates/admin/view_users.html
+++ b/app/templates/admin/view_users.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 
 {% block content %}
 <div class="container mt-4">
@@ -10,24 +11,38 @@
             <button type="submit" class="btn btn-success">{{ invite_form.submit.label.text }}</button>
         </div>
     </form>
+    <div class="d-flex justify-content-end mb-2">
+        {{ column_visibility_dropdown(
+            table_id='admin-users-table',
+            storage_key='adminUsersTableColumnVisibility',
+            align='end',
+            columns=[
+                {'id': 'toggle-user-email', 'target': 'col-user-email', 'label': 'Email', 'checked': True},
+                {'id': 'toggle-user-active', 'target': 'col-user-active', 'label': 'Active', 'checked': True},
+                {'id': 'toggle-user-admin', 'target': 'col-user-admin', 'label': 'Admin', 'checked': True},
+                {'id': 'toggle-user-actions', 'target': 'col-user-actions', 'label': 'Actions', 'checked': True},
+                {'id': 'toggle-user-profile', 'target': 'col-user-profile', 'label': 'Profile', 'checked': True},
+            ]
+        ) }}
+    </div>
     <div class="table-responsive">
-    <table class="table">
+    <table class="table" id="admin-users-table">
         <thead>
         <tr>
-            <th>Email</th>
-            <th>Active</th>
-            <th>Admin</th>
-            <th>Actions</th>
-            <th>Profile</th>
+            <th scope="col" class="col-user-email">Email</th>
+            <th scope="col" class="col-user-active">Active</th>
+            <th scope="col" class="col-user-admin">Admin</th>
+            <th scope="col" class="col-user-actions">Actions</th>
+            <th scope="col" class="col-user-profile">Profile</th>
         </tr>
         </thead>
         <tbody>
         {% for user in users %}
         <tr>
-            <td>{{ user.email }}</td>
-            <td>{{ user.active }}</td>
-            <td>{{ user.is_admin }}</td>
-            <td>
+            <td class="col-user-email">{{ user.email }}</td>
+            <td class="col-user-active">{{ user.active }}</td>
+            <td class="col-user-admin">{{ user.is_admin }}</td>
+            <td class="col-user-actions">
                 <form action="{{ url_for('admin.users', user_id=user.id) }}" method="post" class="d-inline">
                     {{ form.hidden_tag() }}
                     <button type="submit" name="action" value="toggle_active" class="btn btn-sm btn-primary"
@@ -51,7 +66,7 @@
                     </button>
                 </form>
             </td>
-            <td>
+            <td class="col-user-profile">
                 <a href="{{ url_for('admin.user_profile', user_id=user.id) }}" class="btn btn-sm btn-info">View Profile</a>
             </td>
         </tr>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -354,6 +354,7 @@
     <!-- Scripts: jQuery must be loaded before Bootstrap -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/table-sort.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
     <script src="{{ url_for('static', filename='js/security.js') }}" defer></script>
 </body>
 

--- a/app/templates/customers/view_customers.html
+++ b/app/templates/customers/view_customers.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros/column_visibility.html" import column_visibility_dropdown %}
 
 {% block title %}View Customers{% endblock %}
 
@@ -9,7 +10,17 @@
         <div class="col-auto">
             <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createCustomerModal">Create Customer</button>
         </div>
-        <div class="col-auto">
+        <div class="col-auto text-end">
+            {{ column_visibility_dropdown(
+                table_id='customerTable',
+                storage_key='customerTableColumnVisibility',
+                columns=[
+                    {'id': 'toggle-customer-name', 'target': 'col-customer-name', 'label': 'Name', 'checked': True},
+                    {'id': 'toggle-customer-gst', 'target': 'col-customer-gst', 'label': 'GST Exempt', 'checked': True},
+                    {'id': 'toggle-customer-pst', 'target': 'col-customer-pst', 'label': 'PST Exempt', 'checked': True},
+                    {'id': 'toggle-customer-actions', 'target': 'col-customer-actions', 'label': 'Actions', 'checked': True},
+                ]
+            ) }}
             <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">Filters</button>
         </div>
     </div>
@@ -74,22 +85,22 @@
     <p>Filtering by PST Exempt: {{ 'Yes' if pst_exempt == 'yes' else 'No' }}</p>
     {% endif %}
     <div class="table-responsive">
-    <table class="table">
+    <table class="table" id="customerTable">
         <thead>
             <tr>
-                <th>Name</th>
-                <th>GST Exempt</th>
-                <th>PST Exempt</th>
-                <th>Action</th>
+                <th scope="col" class="col-customer-name">Name</th>
+                <th scope="col" class="col-customer-gst">GST Exempt</th>
+                <th scope="col" class="col-customer-pst">PST Exempt</th>
+                <th scope="col" class="col-customer-actions">Actions</th>
             </tr>
         </thead>
         <tbody>
             {% for customer in customers.items %}
             <tr>
-                <td>{{ customer.first_name }} {{ customer.last_name }}</td>
-                <td>{{ 'Yes' if customer.gst_exempt else 'No' }}</td>
-                <td>{{ 'Yes' if customer.pst_exempt else 'No' }}</td>
-                <td>
+                <td class="col-customer-name">{{ customer.first_name }} {{ customer.last_name }}</td>
+                <td class="col-customer-gst">{{ 'Yes' if customer.gst_exempt else 'No' }}</td>
+                <td class="col-customer-pst">{{ 'Yes' if customer.pst_exempt else 'No' }}</td>
+                <td class="col-customer-actions">
                     <a href="{{ url_for('customer.edit_customer', customer_id=customer.id) }}" class="btn btn-primary mr-2">Edit</a>
                     <form action="{{ url_for('customer.delete_customer', customer_id=customer.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
@@ -164,10 +175,10 @@
                     const tbody = document.querySelector('table tbody');
                     const row = document.createElement('tr');
                     row.innerHTML = `
-                        <td>${data.customer.first_name} ${data.customer.last_name}</td>
-                        <td>${data.customer.gst_exempt ? 'Yes' : 'No'}</td>
-                        <td>${data.customer.pst_exempt ? 'Yes' : 'No'}</td>
-                        <td>
+                        <td class="col-customer-name">${data.customer.first_name} ${data.customer.last_name}</td>
+                        <td class="col-customer-gst">${data.customer.gst_exempt ? 'Yes' : 'No'}</td>
+                        <td class="col-customer-pst">${data.customer.pst_exempt ? 'Yes' : 'No'}</td>
+                        <td class="col-customer-actions">
                             <a href="/customers/${data.customer.id}/edit" class="btn btn-primary mr-2">Edit</a>
                             <form action="/customers/${data.customer.id}/delete" method="post" class="d-inline">
                                 <input type="hidden" name="csrf_token" value="${data.delete_csrf_token}">

--- a/app/templates/events/_event_row.html
+++ b/app/templates/events/_event_row.html
@@ -1,8 +1,8 @@
 <tr>
-    <td>{{ e.name }}</td>
-    <td>{{ type_labels.get(e.event_type, e.event_type) }}</td>
-    <td>{{ e.start_date }}</td>
-    <td>{{ e.end_date }}</td>
-    <td>{{ 'Yes' if e.closed else 'No' }}</td>
-    <td><a href="{{ url_for('event.view_event', event_id=e.id) }}">View</a></td>
+    <td class="col-event-name">{{ e.name }}</td>
+    <td class="col-event-type">{{ type_labels.get(e.event_type, e.event_type) }}</td>
+    <td class="col-event-start">{{ e.start_date }}</td>
+    <td class="col-event-end">{{ e.end_date }}</td>
+    <td class="col-event-closed">{{ 'Yes' if e.closed else 'No' }}</td>
+    <td class="col-event-actions"><a href="{{ url_for('event.view_event', event_id=e.id) }}">View</a></td>
 </tr>

--- a/app/templates/events/view_events.html
+++ b/app/templates/events/view_events.html
@@ -1,12 +1,38 @@
 {% extends 'base.html' %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 {% block content %}
 <h2>Events</h2>
-<button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createEventModal">Create Event</button>
-<button class="btn btn-secondary ml-2" data-bs-toggle="modal" data-bs-target="#filterModal">Filter</button>
+<div class="d-flex flex-column flex-sm-row justify-content-between align-items-sm-center gap-2 mb-3">
+    <div class="d-flex flex-wrap gap-2">
+        <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createEventModal">Create Event</button>
+        <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#filterModal">Filter</button>
+    </div>
+    <div class="text-sm-end">
+        {{ column_visibility_dropdown(
+            table_id='events-table',
+            storage_key='eventsTableColumnVisibility',
+            columns=[
+                {'id': 'toggle-event-name', 'target': 'col-event-name', 'label': 'Name', 'checked': True},
+                {'id': 'toggle-event-type', 'target': 'col-event-type', 'label': 'Type', 'checked': True},
+                {'id': 'toggle-event-start', 'target': 'col-event-start', 'label': 'Start', 'checked': True},
+                {'id': 'toggle-event-end', 'target': 'col-event-end', 'label': 'End', 'checked': True},
+                {'id': 'toggle-event-closed', 'target': 'col-event-closed', 'label': 'Closed', 'checked': True},
+                {'id': 'toggle-event-actions', 'target': 'col-event-actions', 'label': 'Actions', 'checked': True},
+            ]
+        ) }}
+    </div>
+</div>
 <div class="table-responsive">
-<table class="table mt-3 sortable">
+<table class="table mt-3 sortable" id="events-table">
     <thead>
-        <tr><th>Name</th><th>Type</th><th>Start</th><th>End</th><th>Closed</th><th></th></tr>
+        <tr>
+            <th scope="col" class="col-event-name">Name</th>
+            <th scope="col" class="col-event-type">Type</th>
+            <th scope="col" class="col-event-start">Start</th>
+            <th scope="col" class="col-event-end">End</th>
+            <th scope="col" class="col-event-closed">Closed</th>
+            <th scope="col" class="col-event-actions">Actions</th>
+        </tr>
     </thead>
     <tbody id="events-table-body">
         {% include 'events/_events_table.html' %}

--- a/app/templates/gl_codes/view_gl_codes.html
+++ b/app/templates/gl_codes/view_gl_codes.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 {% block title %}GL Codes{% endblock %}
 {% block content %}
 <div class="container mt-5">
@@ -7,7 +8,16 @@
         <div class="col-auto">
             <button id="add-gl-code" type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#glCodeModal">Add GL Code</button>
         </div>
-        <div class="col-auto">
+        <div class="col-auto text-end">
+            {{ column_visibility_dropdown(
+                table_id='gl-codes-table',
+                storage_key='glCodesTableColumnVisibility',
+                columns=[
+                    {'id': 'toggle-gl-code', 'target': 'col-gl-code', 'label': 'Code', 'checked': True},
+                    {'id': 'toggle-gl-description', 'target': 'col-gl-description', 'label': 'Description', 'checked': True},
+                    {'id': 'toggle-gl-actions', 'target': 'col-gl-actions', 'label': 'Actions', 'checked': True},
+                ]
+            ) }}
             <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">Filters</button>
         </div>
     </div>
@@ -51,17 +61,17 @@
     <table class="table" id="gl-codes-table">
         <thead>
             <tr>
-                <th>Code</th>
-                <th>Description</th>
-                <th>Actions</th>
+                <th scope="col" class="col-gl-code">Code</th>
+                <th scope="col" class="col-gl-description">Description</th>
+                <th scope="col" class="col-gl-actions">Actions</th>
             </tr>
         </thead>
         <tbody id="gl-code-body">
             {% for code in codes.items %}
             <tr data-id="{{ code.id }}">
-                <td class="gl-code">{{ code.code }}</td>
-                <td class="gl-description">{{ code.description or '' }}</td>
-                <td>
+                <td class="col-gl-code gl-code">{{ code.code }}</td>
+                <td class="col-gl-description gl-description">{{ code.description or '' }}</td>
+                <td class="col-gl-actions">
                     <button type="button" class="btn btn-secondary btn-sm edit-gl-code" data-id="{{ code.id }}" data-code="{{ code.code }}" data-description="{{ code.description or '' }}">Edit</button>
                     <form action="{{ url_for('glcode.delete_gl_code', code_id=code.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}

--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -1,18 +1,31 @@
 <!-- templates/view_invoices.html -->
 
 {% extends "base.html" %}
+{% from "macros/column_visibility.html" import column_visibility_dropdown %}
 
 {% block title %}Home{% endblock %}
 
 {% block content %}
 <div class="container mt-5">
     <h2>Invoices</h2>
-    <div class="row mb-3">
+    <div class="row mb-3 align-items-start justify-content-between">
         <div class="col">
-            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createInvoiceModal">Create Invoice</button>
-            <button type="button" class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#filterModal">Filter</button>
-            <a href="{{ url_for('report.vendor_invoice_report') }}" class="btn btn-secondary">Vendor Report</a>
-            <a href="{{ url_for('report.product_sales_report') }}" class="btn btn-secondary">Revenue Report</a>
+            <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createInvoiceModal">Create Invoice</button>
+            <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">Filter</button>
+            <a href="{{ url_for('report.vendor_invoice_report') }}" class="btn btn-secondary mb-3">Vendor Report</a>
+            <a href="{{ url_for('report.product_sales_report') }}" class="btn btn-secondary mb-3">Revenue Report</a>
+        </div>
+        <div class="col-auto text-end">
+            {{ column_visibility_dropdown(
+                table_id='invoiceTable',
+                storage_key='invoiceTableColumnVisibility',
+                columns=[
+                    {'id': 'toggle-invoice-number', 'target': 'col-invoice-number', 'label': 'Invoice Number', 'checked': True},
+                    {'id': 'toggle-invoice-date', 'target': 'col-invoice-date', 'label': 'Date', 'checked': True},
+                    {'id': 'toggle-invoice-customer', 'target': 'col-invoice-customer', 'label': 'Customer Name', 'checked': True},
+                    {'id': 'toggle-invoice-actions', 'target': 'col-invoice-actions', 'label': 'Actions', 'checked': True},
+                ]
+            ) }}
         </div>
     </div>
 
@@ -20,19 +33,19 @@
     <table class="table" id="invoiceTable">
         <thead>
             <tr>
-                <th>Invoice Number</th>
-                <th>Date</th>
-                <th>Customer Name</th>
-                <th>Action</th>
+                <th scope="col" class="col-invoice-number">Invoice Number</th>
+                <th scope="col" class="col-invoice-date">Date</th>
+                <th scope="col" class="col-invoice-customer">Customer Name</th>
+                <th scope="col" class="col-invoice-actions">Actions</th>
             </tr>
         </thead>
         <tbody>
             {% for invoice in invoices.items %}
             <tr>
-                <td>{{ invoice.id }}</td>
-                <td>{{ invoice.date_created|format_datetime('%Y-%m-%d') }}</td>
-                <td>{{ invoice.customer.first_name }} {{ invoice.customer.last_name }}</td>
-                <td>
+                <td class="col-invoice-number">{{ invoice.id }}</td>
+                <td class="col-invoice-date">{{ invoice.date_created|format_datetime('%Y-%m-%d') }}</td>
+                <td class="col-invoice-customer">{{ invoice.customer.first_name }} {{ invoice.customer.last_name }}</td>
+                <td class="col-invoice-actions">
                     <a href="{{ url_for('invoice.view_invoice', invoice_id=invoice.id) }}" class="btn btn-primary mr-2">View</a>
                     <form action="{{ url_for('invoice.delete_invoice', invoice_id=invoice.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
@@ -135,14 +148,14 @@ $(document).ready(function(){
         const tbody = $('#invoiceTable tbody');
         tbody.empty();
         invoices.forEach(function(inv){
-            const row = `<tr>
-                <td>${inv.id}</td>
-                <td>${inv.date}</td>
-                <td>${inv.customer}</td>
-                <td>
-                    <a href="/view_invoice/${inv.id}" class="btn btn-primary mr-2">View</a>
-                    <form action="/delete_invoice/${inv.id}" method="post" class="d-inline">
-                        ${deleteFormHTML}
+        const row = `<tr>
+            <td class="col-invoice-number">${inv.id}</td>
+            <td class="col-invoice-date">${inv.date}</td>
+            <td class="col-invoice-customer">${inv.customer}</td>
+            <td class="col-invoice-actions">
+                <a href="/view_invoice/${inv.id}" class="btn btn-primary mr-2">View</a>
+                <form action="/delete_invoice/${inv.id}" method="post" class="d-inline">
+                    ${deleteFormHTML}
                         <button type="submit" class="btn btn-danger">Delete</button>
                     </form>
                 </td>

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -254,7 +254,6 @@
         </form>
     </div>
 </div>
-<script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 <script src="{{ url_for('static', filename='js/item_form.js') }}"></script>
 <script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {

--- a/app/templates/locations/view_locations.html
+++ b/app/templates/locations/view_locations.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 
 {% block content %}
 <div class="container mt-5">
@@ -7,7 +8,15 @@
         <div class="col-auto">
             <button id="addLocationBtn" class="btn btn-primary mb-3" type="button">Add New Location</button>
         </div>
-        <div class="col-auto">
+        <div class="col-auto text-end">
+            {{ column_visibility_dropdown(
+                table_id='locations-table',
+                storage_key='locationsTableColumnVisibility',
+                columns=[
+                    {'id': 'toggle-location-name', 'target': 'col-location-name', 'label': 'Name', 'checked': True},
+                    {'id': 'toggle-location-actions', 'target': 'col-location-actions', 'label': 'Actions', 'checked': True},
+                ]
+            ) }}
             <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
                 Filters
             </button>
@@ -23,18 +32,18 @@
     <div class="mb-3"><strong>Viewing:</strong> All locations</div>
     {% endif %}
     <div class="table-responsive">
-    <table class="table sortable">
+    <table class="table sortable" id="locations-table">
         <thead>
             <tr>
-                <th>Name</th>
-                <th>Actions</th>
+                <th scope="col" class="col-location-name">Name</th>
+                <th scope="col" class="col-location-actions">Actions</th>
             </tr>
         </thead>
         <tbody>
             {% for location in locations.items %}
             <tr data-id="{{ location.id }}">
-                <td>{{ location.name }}</td>
-                <td>
+                <td class="col-location-name">{{ location.name }}</td>
+                <td class="col-location-actions">
                     <button type="button" class="btn btn-info edit-location-btn" data-id="{{ location.id }}">Edit</button>
                     <a href="{{ url_for('locations.view_stand_sheet', location_id=location.id) }}" class="btn btn-secondary">Stand Sheet</a>
                     <a href="{{ url_for('locations.location_items', location_id=location.id) }}" class="btn btn-outline-secondary">Manage Items</a>
@@ -298,8 +307,8 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function addRow(loc) {
         const row = `<tr data-id="${loc.id}">
-            <td>${loc.name}</td>
-            <td>
+            <td class=\"col-location-name\">${loc.name}</td>
+            <td class=\"col-location-actions\">
                 <button type="button" class="btn btn-info edit-location-btn" data-id="${loc.id}">Edit</button>
                 <a href="/locations/${loc.id}/stand_sheet" class="btn btn-secondary">Stand Sheet</a>
                 <a href="/locations/${loc.id}/items" class="btn btn-outline-secondary">Manage Items</a>
@@ -310,17 +319,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 </form>
             </td>
         </tr>`;
-        $('table tbody').append(row);
+        $('#locations-table tbody').append(row);
     }
 
     function updateRow(loc) {
         const row = $(`tr[data-id='${loc.id}']`);
-        row.find('td:first').text(loc.name);
+        row.find('.col-location-name').text(loc.name);
     }
 
     $(document).on('click', '.copy-location-btn', function() {
         currentSourceId = $(this).data('id');
-        const options = $('table tbody tr').map(function() {
+        const options = $('#locations-table tbody tr').map(function() {
             const id = $(this).data('id');
             const name = $(this).find('td:first').text();
             if (id === currentSourceId) {

--- a/app/templates/macros/column_visibility.html
+++ b/app/templates/macros/column_visibility.html
@@ -1,0 +1,17 @@
+{% macro column_visibility_dropdown(table_id, storage_key=None, columns=[], button_label='Columns', dropdown_id=None, align='end') %}
+    {% set dropdown_id = dropdown_id or table_id ~ '-column-selector' %}
+    <div class="dropdown d-inline-block mb-3 me-2" data-column-visibility data-table-id="{{ table_id }}"{% if storage_key %} data-storage-key="{{ storage_key }}"{% endif %}>
+        <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="{{ dropdown_id }}" data-bs-toggle="dropdown" aria-expanded="false">
+            {{ button_label }}
+        </button>
+        <div class="dropdown-menu dropdown-menu-{{ align }} p-3" aria-labelledby="{{ dropdown_id }}">
+            {% for column in columns %}
+                {% set input_id = column.id or dropdown_id ~ '-option-' ~ loop.index %}
+                <div class="form-check">
+                    <input class="form-check-input column-toggle" type="checkbox" id="{{ input_id }}" data-column-target="{{ column.target }}"{% if column.checked %} checked{% endif %}>
+                    <label class="form-check-label" for="{{ input_id }}">{{ column.label }}</label>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+{% endmacro %}

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -275,7 +275,6 @@
         </form>
     </div>
 </div>
-<script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 <script nonce="{{ csp_nonce }}">
 document.addEventListener('DOMContentLoaded', function() {
     const selectAllProducts = document.getElementById('select-all-products');

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -287,5 +287,4 @@
         </form>
     </div>
 </div>
-<script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 {% endblock %}

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -249,5 +249,4 @@
         </form>
     </div>
 </div>
-<script src="{{ url_for('static', filename='js/column_visibility.js') }}"></script>
 {% endblock %}

--- a/app/templates/spoilage/_table.html
+++ b/app/templates/spoilage/_table.html
@@ -1,37 +1,21 @@
 {% if results %}
-<div class="mb-3">
-    <button type="button" data-action="print" class="btn btn-secondary">Print</button>
-</div>
-<div class="table-responsive">
-<table class="table">
-    <thead>
-        <tr>
-            <th>Date</th>
-            <th>From Location</th>
-            <th>Item</th>
-            <th>Quantity</th>
-            <th>Purchase GL Code</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for ti, tr, item, from_loc, lsi in results %}
-        <tr>
-            <td>{{ tr.date_created.date() }}</td>
-            <td>{{ from_loc.name }}</td>
-            <td>{{ item.name }}</td>
-            <td>{{ ti.quantity }}</td>
-            <td>
-                {{
-                    lsi.purchase_gl_code.code
-                    if lsi and lsi.purchase_gl_code
-                    else (item.purchase_gl_code.code if item.purchase_gl_code else '')
-                }}
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-</div>
+    {% for ti, tr, item, from_loc, lsi in results %}
+    <tr>
+        <td class="col-spoilage-date">{{ tr.date_created.date() }}</td>
+        <td class="col-spoilage-from">{{ from_loc.name }}</td>
+        <td class="col-spoilage-item">{{ item.name }}</td>
+        <td class="col-spoilage-quantity">{{ ti.quantity }}</td>
+        <td class="col-spoilage-gl">
+            {{
+                lsi.purchase_gl_code.code
+                if lsi and lsi.purchase_gl_code
+                else (item.purchase_gl_code.code if item.purchase_gl_code else '')
+            }}
+        </td>
+    </tr>
+    {% endfor %}
 {% else %}
-<p>No spoilage records found.</p>
+    <tr>
+        <td class="text-center text-muted" colspan="5">No spoilage records found.</td>
+    </tr>
 {% endif %}

--- a/app/templates/spoilage/view_spoilage.html
+++ b/app/templates/spoilage/view_spoilage.html
@@ -1,14 +1,46 @@
 {% extends 'base.html' %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 
 {% block content %}
 <div class="container mt-5">
     <h2>Spoilage</h2>
-    <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">
-        Filters
-    </button>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-3">
+        <div class="d-flex flex-wrap gap-2">
+            <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#filterModal">
+                Filters
+            </button>
+            <button type="button" data-action="print" class="btn btn-secondary">Print</button>
+        </div>
+        <div class="text-md-end">
+            {{ column_visibility_dropdown(
+                table_id='spoilage-table',
+                storage_key='spoilageTableColumnVisibility',
+                columns=[
+                    {'id': 'toggle-spoilage-date', 'target': 'col-spoilage-date', 'label': 'Date', 'checked': True},
+                    {'id': 'toggle-spoilage-from', 'target': 'col-spoilage-from', 'label': 'From Location', 'checked': True},
+                    {'id': 'toggle-spoilage-item', 'target': 'col-spoilage-item', 'label': 'Item', 'checked': True},
+                    {'id': 'toggle-spoilage-quantity', 'target': 'col-spoilage-quantity', 'label': 'Quantity', 'checked': True},
+                    {'id': 'toggle-spoilage-gl', 'target': 'col-spoilage-gl', 'label': 'Purchase GL Code', 'checked': True},
+                ]
+            ) }}
+        </div>
+    </div>
 
-    <div id="results-container">
-        {% include 'spoilage/_table.html' %}
+    <div class="table-responsive">
+        <table class="table" id="spoilage-table">
+            <thead>
+                <tr>
+                    <th scope="col" class="col-spoilage-date">Date</th>
+                    <th scope="col" class="col-spoilage-from">From Location</th>
+                    <th scope="col" class="col-spoilage-item">Item</th>
+                    <th scope="col" class="col-spoilage-quantity">Quantity</th>
+                    <th scope="col" class="col-spoilage-gl">Purchase GL Code</th>
+                </tr>
+            </thead>
+            <tbody id="spoilage-table-body">
+                {% include 'spoilage/_table.html' %}
+            </tbody>
+        </table>
     </div>
 </div>
 
@@ -60,7 +92,7 @@
                 data: params,
                 headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 success: function (response) {
-                    $('#results-container').html(response);
+                    $('#spoilage-table-body').html(response);
                     var modalEl = document.getElementById('filterModal');
                     var modal = bootstrap.Modal.getInstance(modalEl);
                     modal.hide();

--- a/app/templates/transfers/_transfer_row.html
+++ b/app/templates/transfers/_transfer_row.html
@@ -1,8 +1,8 @@
 <tr id="transfer-row-{{ transfer.id }}">
-    <th scope="row">{{ transfer.id }}</th>
-    <td>{{ transfer.from_location.name }}</td>
-    <td>{{ transfer.to_location.name }}</td>
-    <td>
+    <th scope="row" class="col-transfer-id">{{ transfer.id }}</th>
+    <td class="col-transfer-from">{{ transfer.from_location.name }}</td>
+    <td class="col-transfer-to">{{ transfer.to_location.name }}</td>
+    <td class="col-transfer-actions">
         <a href="{{ url_for('transfer.view_transfer', transfer_id=transfer.id) }}" class="btn btn-primary" target="_blank">View</a>
         <button type="button" class="btn btn-secondary edit-transfer-btn" data-id="{{ transfer.id }}">Edit</button>
         {% if transfer.completed %}

--- a/app/templates/transfers/view_report.html
+++ b/app/templates/transfers/view_report.html
@@ -1,26 +1,40 @@
 {% extends 'base.html' %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 
 {% block content %}
 <div class="container">
     <h2>Transfer Report</h2>
+    <div class="d-flex justify-content-end mb-3">
+        {{ column_visibility_dropdown(
+            table_id='transfer-report-table',
+            storage_key='transferReportTableColumnVisibility',
+            align='end',
+            columns=[
+                {'id': 'toggle-transfer-report-from', 'target': 'col-transfer-report-from', 'label': 'From Location', 'checked': True},
+                {'id': 'toggle-transfer-report-to', 'target': 'col-transfer-report-to', 'label': 'To Location', 'checked': True},
+                {'id': 'toggle-transfer-report-item', 'target': 'col-transfer-report-item', 'label': 'Item', 'checked': True},
+                {'id': 'toggle-transfer-report-qty', 'target': 'col-transfer-report-quantity', 'label': 'Quantity', 'checked': True},
+            ]
+        ) }}
+    </div>
     <p>Report Period: {{ session.report_start_datetime }} to {{ session.report_end_datetime }}</p>
     <div class="table-responsive">
-    <table class="table">
+    <table class="table" id="transfer-report-table">
         <thead>
             <tr>
-                <th>From Location</th>
-                <th>To Location</th>
-                <th>Item</th>
-                <th>Quantity</th>
+                <th scope="col" class="col-transfer-report-from">From Location</th>
+                <th scope="col" class="col-transfer-report-to">To Location</th>
+                <th scope="col" class="col-transfer-report-item">Item</th>
+                <th scope="col" class="col-transfer-report-quantity">Quantity</th>
             </tr>
         </thead>
         <tbody>
             {% for transfer in session.aggregated_transfers %}
             <tr>
-                <td>{{ transfer.from_location_name }}</td>
-                <td>{{ transfer.to_location_name }}</td>
-                <td>{{ transfer.item_name }}</td>
-                <td>{{ transfer.total_quantity }}</td>
+                <td class="col-transfer-report-from">{{ transfer.from_location_name }}</td>
+                <td class="col-transfer-report-to">{{ transfer.to_location_name }}</td>
+                <td class="col-transfer-report-item">{{ transfer.item_name }}</td>
+                <td class="col-transfer-report-quantity">{{ transfer.total_quantity }}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/app/templates/transfers/view_transfers.html
+++ b/app/templates/transfers/view_transfers.html
@@ -1,9 +1,10 @@
 {% extends 'base.html' %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 
 {% block content %}
 <div class="container mt-5">
     <h2>Transfers List</h2>
-    <div class="row mb-3 align-items-center">
+    <div class="row mb-3 align-items-center justify-content-between">
         <div class="col-12 col-lg-auto mb-2 mb-lg-0 d-flex align-items-center">
             <button class="btn btn-primary me-2" data-bs-toggle="modal" data-bs-target="#addTransferModal">Add New Transfer</button>
             <button id="new-transfer-alert" type="button" class="btn btn-warning me-2" data-action="reload"
@@ -14,15 +15,27 @@
             <a href="{{ url_for('transfer.generate_report') }}" class="btn btn-info me-2">Generate Report</a>
             <button class="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#searchModal">Search/Filter</button>
         </div>
+        <div class="col-auto text-end">
+            {{ column_visibility_dropdown(
+                table_id='transfer-table',
+                storage_key='transferTableColumnVisibility',
+                columns=[
+                    {'id': 'toggle-transfer-id', 'target': 'col-transfer-id', 'label': 'Transfer #', 'checked': True},
+                    {'id': 'toggle-transfer-from', 'target': 'col-transfer-from', 'label': 'From Location', 'checked': True},
+                    {'id': 'toggle-transfer-to', 'target': 'col-transfer-to', 'label': 'To Location', 'checked': True},
+                    {'id': 'toggle-transfer-actions', 'target': 'col-transfer-actions', 'label': 'Actions', 'checked': True},
+                ]
+            ) }}
+        </div>
     </div>
     <div class="table-responsive">
     <table class="table" id="transfer-table">
         <thead>
         <tr>
-            <th scope="col">#</th>
-            <th scope="col">From Location</th>
-            <th scope="col">To Location</th>
-            <th scope="col">Actions</th>
+            <th scope="col" class="col-transfer-id">#</th>
+            <th scope="col" class="col-transfer-from">From Location</th>
+            <th scope="col" class="col-transfer-to">To Location</th>
+            <th scope="col" class="col-transfer-actions">Actions</th>
         </tr>
         </thead>
         <tbody id="transfer-table-body">

--- a/app/templates/vendors/_vendor_row.html
+++ b/app/templates/vendors/_vendor_row.html
@@ -1,8 +1,8 @@
 <tr>
-    <td>{{ vendor.first_name }} {{ vendor.last_name }}</td>
-    <td>{{ 'Yes' if vendor.gst_exempt else 'No' }}</td>
-    <td>{{ 'Yes' if vendor.pst_exempt else 'No' }}</td>
-    <td>
+    <td class="col-vendor-name">{{ vendor.first_name }} {{ vendor.last_name }}</td>
+    <td class="col-vendor-gst">{{ 'Yes' if vendor.gst_exempt else 'No' }}</td>
+    <td class="col-vendor-pst">{{ 'Yes' if vendor.pst_exempt else 'No' }}</td>
+    <td class="col-vendor-actions">
         <a href="{{ url_for('vendor.edit_vendor', vendor_id=vendor.id) }}" class="btn btn-primary mr-2">Edit</a>
         <form action="{{ url_for('vendor.delete_vendor', vendor_id=vendor.id) }}" method="post" class="d-inline">
             {{ delete_form.hidden_tag() }}

--- a/app/templates/vendors/view_vendors.html
+++ b/app/templates/vendors/view_vendors.html
@@ -1,20 +1,37 @@
 <!-- templates=view_vendors.html -->
 {% extends "base.html" %}
+{% from "macros/column_visibility.html" import column_visibility_dropdown %}
 
 {% block title %}View Vendors{% endblock %}
 
 {% block content %}
 <div class="container mt-5">
     <h2>Vendors</h2>
-    <button type="button" class="btn btn-primary mb-3" id="createVendorBtn">Create Vendor</button>
+    <div class="row justify-content-between">
+        <div class="col-auto">
+            <button type="button" class="btn btn-primary mb-3" id="createVendorBtn">Create Vendor</button>
+        </div>
+        <div class="col-auto text-end">
+            {{ column_visibility_dropdown(
+                table_id='vendorTable',
+                storage_key='vendorTableColumnVisibility',
+                columns=[
+                    {'id': 'toggle-vendor-name', 'target': 'col-vendor-name', 'label': 'Name', 'checked': True},
+                    {'id': 'toggle-vendor-gst', 'target': 'col-vendor-gst', 'label': 'GST Exempt', 'checked': True},
+                    {'id': 'toggle-vendor-pst', 'target': 'col-vendor-pst', 'label': 'PST Exempt', 'checked': True},
+                    {'id': 'toggle-vendor-actions', 'target': 'col-vendor-actions', 'label': 'Actions', 'checked': True},
+                ]
+            ) }}
+        </div>
+    </div>
     <div class="table-responsive">
     <table class="table" id="vendorTable">
         <thead>
             <tr>
-                <th>Name</th>
-                <th>GST Exempt</th>
-                <th>PST Exempt</th>
-                <th>Action</th>
+                <th scope="col" class="col-vendor-name">Name</th>
+                <th scope="col" class="col-vendor-gst">GST Exempt</th>
+                <th scope="col" class="col-vendor-pst">PST Exempt</th>
+                <th scope="col" class="col-vendor-actions">Actions</th>
             </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
## Summary
- add a reusable Jinja macro for rendering column visibility dropdowns and load the supporting script globally
- enable persistent column toggle controls on vendors, customers, locations, invoices, transfers, events, spoilage, GL codes, admin user/log tables, and related reports
- update dynamic row rendering scripts to tag table cells with the appropriate column classes so visibility changes persist after AJAX updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d825b401488324b1ed587f77979e76