### PR TITLE
Improve table overflow handling

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -80,6 +80,20 @@
             margin-right: 0.5rem;
         }
 
+        .table-responsive > .table {
+            width: max-content;
+            min-width: 100%;
+        }
+
+        .table th,
+        .table td {
+            white-space: nowrap;
+        }
+
+        .table .text-wrap {
+            white-space: normal;
+        }
+
         .narrow-field {
             max-width: 300px;
         }

--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -9,7 +9,7 @@
     <td class="col-gl-desc">{{ item.gl_code_rel.description if item.gl_code_rel and item.gl_code_rel.description else '—' }}</td>
     <td class="col-purchase-gl-code">{{ item.purchase_gl_code.code if item.purchase_gl_code else '—' }}</td>
     <td class="col-purchase-gl-desc">{{ item.purchase_gl_code.description if item.purchase_gl_code and item.purchase_gl_code.description else '—' }}</td>
-    <td class="col-units">
+    <td class="col-units text-wrap">
         {% if item.units %}
             {% for unit in item.units %}
                 <div>{{ unit.name }} (&times;{{ '%.4f'|format(unit.factor) }})</div>

--- a/app/templates/products/_product_row.html
+++ b/app/templates/products/_product_row.html
@@ -13,7 +13,7 @@
     <td class="col-product-sales-gl-desc">{{ product.sales_gl_code.description if product.sales_gl_code and product.sales_gl_code.description else '—' }}</td>
     <td class="col-product-gl-code">{{ product.gl_code_rel.code if product.gl_code_rel else product.gl_code or '—' }}</td>
     <td class="col-product-gl-desc">{{ product.gl_code_rel.description if product.gl_code_rel and product.gl_code_rel.description else '—' }}</td>
-    <td class="col-product-locations">
+    <td class="col-product-locations text-wrap">
         {% if product.locations %}
             {% for location in product.locations %}
                 <div>{{ location.name }}</div>
@@ -24,7 +24,7 @@
     </td>
     {% set recipe_count = product.recipe_items | length %}
     <td class="col-product-recipe-count" data-sort-value="{{ recipe_count }}">{{ recipe_count }}</td>
-    <td class="col-product-recipe-details">
+    <td class="col-product-recipe-details text-wrap">
         {% if product.recipe_items %}
             <ul class="mb-0 ps-3">
                 {% for recipe_item in product.recipe_items %}

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -227,7 +227,7 @@
                 <td class="col-invoice-total" data-sort-value="{{ '%.6f'|format(inv.total or 0) }}">{{ '%.2f'|format(inv.total or 0) }}</td>
                 {% set invoice_item_count = inv.items | length %}
                 <td class="col-invoice-item-count" data-sort-value="{{ invoice_item_count }}">{{ invoice_item_count }}</td>
-                <td class="col-invoice-item-details">
+                <td class="col-invoice-item-details text-wrap">
                     {% if inv.items %}
                         <ul class="mb-0 ps-3">
                             {% for item in inv.items %}

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -180,7 +180,7 @@
                 <td class="col-po-received" data-sort-value="{{ '1' if order.received else '0' }}">{{ 'Yes' if order.received else 'No' }}</td>
                 {% set order_item_count = order.items | length %}
                 <td class="col-po-item-count" data-sort-value="{{ order_item_count }}">{{ order_item_count }}</td>
-                <td class="col-po-items">
+                <td class="col-po-items text-wrap">
                     {% if order.items %}
                         <ul class="mb-0 ps-3">
                             {% for line in order.items %}


### PR DESCRIPTION
## Summary
- allow responsive tables to exceed their container width so horizontal scrolling is available
- default table cells to no-wrap while providing a helper class to re-enable wrapping
- apply the helper class to multi-line detail columns so lengthy lists remain readable

## Testing
- Manual QA: toggled purchase order table columns to confirm horizontal scrolling

------
https://chatgpt.com/codex/tasks/task_e_68d8330356888324b86fd61b76a057de