### PR TITLE
Add shared notes feature across entities

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -286,6 +286,7 @@ def create_app(args: list):
         from app.routes.item_routes import item
         from app.routes.location_routes import location
         from app.routes.main_routes import main
+        from app.routes.note_routes import notes
         from app.routes.product_routes import product
         from app.routes.purchase_routes import purchase
         from app.routes.report_routes import report
@@ -303,6 +304,7 @@ def create_app(args: list):
         app.register_blueprint(customer)
         app.register_blueprint(invoice)
         app.register_blueprint(product)
+        app.register_blueprint(notes)
         app.register_blueprint(purchase)
         app.register_blueprint(report)
         app.register_blueprint(vendor)

--- a/app/forms.py
+++ b/app/forms.py
@@ -20,6 +20,7 @@ from wtforms import (
     SelectField,
     SelectMultipleField,
     StringField,
+    TextAreaField,
     SubmitField,
 )
 from wtforms.validators import (
@@ -762,4 +763,12 @@ class NotificationForm(FlaskForm):
     )
     notify_transfers = BooleanField("Send text on new transfer")
     submit = SubmitField("Update Notifications")
+
+
+class NoteForm(FlaskForm):
+    content = TextAreaField(
+        "Note", validators=[DataRequired(), Length(max=2000)]
+    )
+    pinned = BooleanField("Pin note")
+    submit = SubmitField("Save Note")
 

--- a/app/models.py
+++ b/app/models.py
@@ -584,6 +584,39 @@ class ActivityLog(db.Model):
     user = relationship("User", backref="activity_logs")
 
 
+class Note(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    entity_type = db.Column(db.String(50), nullable=False)
+    entity_id = db.Column(db.String(64), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    content = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    pinned = db.Column(
+        db.Boolean, default=False, nullable=False, server_default="0"
+    )
+    pinned_at = db.Column(db.DateTime, nullable=True)
+
+    user = relationship("User", backref="notes")
+
+    __table_args__ = (
+        db.Index("ix_note_entity", "entity_type", "entity_id"),
+        db.Index("ix_note_pinned", "entity_type", "pinned"),
+    )
+
+    def set_pinned(self, value: bool) -> None:
+        """Update the pinned state and timestamp."""
+
+        if value and not self.pinned:
+            self.pinned = True
+            self.pinned_at = datetime.utcnow()
+        elif not value and self.pinned:
+            self.pinned = False
+            self.pinned_at = None
+
+
 class Event(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)

--- a/app/routes/note_routes.py
+++ b/app/routes/note_routes.py
@@ -1,0 +1,367 @@
+"""Blueprint providing entity note management views."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Tuple
+
+from flask import Blueprint, abort, flash, redirect, render_template, url_for
+from flask_login import current_user, login_required
+from sqlalchemy.orm import joinedload
+
+from app import db
+from app.forms import CSRFOnlyForm, DeleteForm, NoteForm
+from app.models import (
+    Customer,
+    Invoice,
+    Item,
+    Location,
+    Note,
+    Product,
+    PurchaseInvoice,
+    PurchaseOrder,
+    Transfer,
+    Vendor,
+)
+from app.utils.activity import log_activity
+
+notes = Blueprint("notes", __name__)
+
+
+@dataclass(frozen=True)
+class EntityConfig:
+    model: type
+    label: str
+    name_getter: Callable[[Any], str]
+    parse_identifier: Callable[[str], Any]
+    identifier_getter: Callable[[Any], str]
+    back_getter: Callable[[Any], Tuple[str, str]]
+    activity_getter: Callable[[Any], str]
+
+
+def _person_name(person: Any) -> str:
+    first = getattr(person, "first_name", "") or ""
+    last = getattr(person, "last_name", "") or ""
+    full = f"{first} {last}".strip()
+    return full or f"#{getattr(person, 'id', '')}"
+
+
+ENTITY_CONFIG: dict[str, EntityConfig] = {
+    "location": EntityConfig(
+        model=Location,
+        label="Location",
+        name_getter=lambda obj: obj.name,
+        parse_identifier=lambda raw: int(raw),
+        identifier_getter=lambda obj: str(obj.id),
+        back_getter=lambda obj: (
+            url_for("locations.location_items", location_id=obj.id),
+            f"{obj.name} Items",
+        ),
+        activity_getter=lambda obj: f"location {obj.name}",
+    ),
+    "item": EntityConfig(
+        model=Item,
+        label="Item",
+        name_getter=lambda obj: obj.name,
+        parse_identifier=lambda raw: int(raw),
+        identifier_getter=lambda obj: str(obj.id),
+        back_getter=lambda obj: (
+            url_for("item.view_item", item_id=obj.id),
+            obj.name,
+        ),
+        activity_getter=lambda obj: f"item {obj.name}",
+    ),
+    "product": EntityConfig(
+        model=Product,
+        label="Product",
+        name_getter=lambda obj: obj.name,
+        parse_identifier=lambda raw: int(raw),
+        identifier_getter=lambda obj: str(obj.id),
+        back_getter=lambda obj: (
+            url_for("product.edit_product", product_id=obj.id),
+            f"Edit {obj.name}",
+        ),
+        activity_getter=lambda obj: f"product {obj.name}",
+    ),
+    "vendor": EntityConfig(
+        model=Vendor,
+        label="Vendor",
+        name_getter=_person_name,
+        parse_identifier=lambda raw: int(raw),
+        identifier_getter=lambda obj: str(obj.id),
+        back_getter=lambda obj: (
+            url_for("vendor.edit_vendor", vendor_id=obj.id),
+            f"Edit {_person_name(obj)}",
+        ),
+        activity_getter=lambda obj: f"vendor {_person_name(obj)}",
+    ),
+    "customer": EntityConfig(
+        model=Customer,
+        label="Customer",
+        name_getter=_person_name,
+        parse_identifier=lambda raw: int(raw),
+        identifier_getter=lambda obj: str(obj.id),
+        back_getter=lambda obj: (
+            url_for("customer.edit_customer", customer_id=obj.id),
+            f"Edit {_person_name(obj)}",
+        ),
+        activity_getter=lambda obj: f"customer {_person_name(obj)}",
+    ),
+    "transfer": EntityConfig(
+        model=Transfer,
+        label="Transfer",
+        name_getter=lambda obj: f"Transfer #{obj.id}",
+        parse_identifier=lambda raw: int(raw),
+        identifier_getter=lambda obj: str(obj.id),
+        back_getter=lambda obj: (
+            url_for("transfer.view_transfer", transfer_id=obj.id),
+            f"Transfer #{obj.id}",
+        ),
+        activity_getter=lambda obj: f"transfer {obj.id}",
+    ),
+    "purchase_order": EntityConfig(
+        model=PurchaseOrder,
+        label="Purchase Order",
+        name_getter=lambda obj: f"PO #{obj.id}",
+        parse_identifier=lambda raw: int(raw),
+        identifier_getter=lambda obj: str(obj.id),
+        back_getter=lambda obj: (
+            url_for("purchase.edit_purchase_order", po_id=obj.id),
+            f"Edit PO #{obj.id}",
+        ),
+        activity_getter=lambda obj: f"purchase order {obj.id}",
+    ),
+    "purchase_invoice": EntityConfig(
+        model=PurchaseInvoice,
+        label="Purchase Invoice",
+        name_getter=lambda obj: obj.invoice_number or f"Invoice #{obj.id}",
+        parse_identifier=lambda raw: int(raw),
+        identifier_getter=lambda obj: str(obj.id),
+        back_getter=lambda obj: (
+            url_for("purchase.view_purchase_invoice", invoice_id=obj.id),
+            obj.invoice_number or f"Invoice #{obj.id}",
+        ),
+        activity_getter=lambda obj: (
+            f"purchase invoice {obj.invoice_number}" if obj.invoice_number else f"purchase invoice {obj.id}"
+        ),
+    ),
+    "sales_invoice": EntityConfig(
+        model=Invoice,
+        label="Sales Invoice",
+        name_getter=lambda obj: obj.id,
+        parse_identifier=lambda raw: raw,
+        identifier_getter=lambda obj: obj.id,
+        back_getter=lambda obj: (
+            url_for("invoice.view_invoice", invoice_id=obj.id),
+            f"Invoice {obj.id}",
+        ),
+        activity_getter=lambda obj: f"sales invoice {obj.id}",
+    ),
+}
+
+
+def _get_entity_context(entity_type: str, raw_entity_id: str) -> tuple[EntityConfig, Any, str]:
+    config = ENTITY_CONFIG.get(entity_type)
+    if config is None:
+        abort(404)
+
+    try:
+        lookup_id = config.parse_identifier(raw_entity_id)
+    except (TypeError, ValueError):
+        abort(404)
+
+    entity = db.session.get(config.model, lookup_id)
+    if entity is None:
+        abort(404)
+
+    identifier = config.identifier_getter(entity)
+    return config, entity, identifier
+
+
+def _ensure_content(form: NoteForm) -> str:
+    content = (form.content.data or "").strip()
+    if not content:
+        form.content.errors.append("Note cannot be empty.")
+    return content
+
+
+def _note_query(entity_type: str, identifier: str):
+    return (
+        Note.query.options(joinedload(Note.user))
+        .filter_by(entity_type=entity_type, entity_id=identifier)
+        .order_by(
+            Note.pinned.desc(),
+            Note.pinned_at.desc(),
+            Note.created_at.desc(),
+        )
+    )
+
+
+@notes.route("/notes/<entity_type>/<entity_id>", methods=["GET", "POST"])
+@login_required
+def entity_notes(entity_type: str, entity_id: str):
+    config, entity, identifier = _get_entity_context(entity_type, entity_id)
+    form = NoteForm()
+    delete_form = DeleteForm()
+    pin_form = CSRFOnlyForm()
+    can_pin = current_user.is_admin
+
+    if form.validate_on_submit():
+        content = _ensure_content(form)
+        if content:
+            note = Note(
+                entity_type=entity_type,
+                entity_id=identifier,
+                user_id=current_user.id,
+                content=content,
+            )
+            if can_pin and form.pinned.data:
+                note.set_pinned(True)
+            db.session.add(note)
+            db.session.commit()
+            log_activity(
+                f"Added note to {config.activity_getter(entity)}"
+            )
+            flash("Note added.", "success")
+            return redirect(
+                url_for(
+                    "notes.entity_notes",
+                    entity_type=entity_type,
+                    entity_id=identifier,
+                )
+            )
+
+    back_url, back_label = config.back_getter(entity)
+    notes_list = _note_query(entity_type, identifier).all()
+    return render_template(
+        "notes/entity_notes.html",
+        entity_label=config.label,
+        entity_name=config.name_getter(entity),
+        entity_type=entity_type,
+        entity_id=identifier,
+        notes=notes_list,
+        form=form,
+        delete_form=delete_form,
+        pin_form=pin_form,
+        can_pin=can_pin,
+        back_url=back_url,
+        back_label=back_label,
+    )
+
+
+def _load_note_or_404(
+    entity_type: str, raw_entity_id: str, note_id: int
+) -> tuple[EntityConfig, Any, str, Note]:
+    config, entity, identifier = _get_entity_context(entity_type, raw_entity_id)
+    note = Note.query.filter_by(
+        id=note_id, entity_type=entity_type, entity_id=identifier
+    ).first()
+    if note is None:
+        abort(404)
+    return config, entity, identifier, note
+
+
+@notes.route(
+    "/notes/<entity_type>/<entity_id>/edit/<int:note_id>",
+    methods=["GET", "POST"],
+)
+@login_required
+def edit_note(entity_type: str, entity_id: str, note_id: int):
+    config, entity, identifier, note = _load_note_or_404(
+        entity_type, entity_id, note_id
+    )
+    if not (current_user.is_admin or note.user_id == current_user.id):
+        abort(403)
+
+    form = NoteForm(obj=note)
+    can_pin = current_user.is_admin
+
+    if form.validate_on_submit():
+        content = _ensure_content(form)
+        if content:
+            note.content = content
+            if can_pin:
+                note.set_pinned(bool(form.pinned.data))
+            db.session.commit()
+            log_activity(
+                f"Updated note on {config.activity_getter(entity)}"
+            )
+            flash("Note updated.", "success")
+            return redirect(
+                url_for(
+                    "notes.entity_notes",
+                    entity_type=entity_type,
+                    entity_id=identifier,
+                )
+            )
+    else:
+        form.content.data = note.content
+        form.pinned.data = note.pinned
+
+    back_url, back_label = config.back_getter(entity)
+    return render_template(
+        "notes/edit_note.html",
+        form=form,
+        entity_label=config.label,
+        entity_name=config.name_getter(entity),
+        entity_type=entity_type,
+        entity_id=identifier,
+        can_pin=can_pin,
+        back_url=back_url,
+        back_label=back_label,
+    )
+
+
+@notes.route(
+    "/notes/<entity_type>/<entity_id>/delete/<int:note_id>",
+    methods=["POST"],
+)
+@login_required
+def delete_note(entity_type: str, entity_id: str, note_id: int):
+    form = DeleteForm()
+    if not form.validate_on_submit():
+        abort(400)
+    config, entity, identifier, note = _load_note_or_404(
+        entity_type, entity_id, note_id
+    )
+    db.session.delete(note)
+    db.session.commit()
+    log_activity(
+        f"Deleted note from {config.activity_getter(entity)}"
+    )
+    flash("Note deleted.", "success")
+    return redirect(
+        url_for(
+            "notes.entity_notes",
+            entity_type=entity_type,
+            entity_id=identifier,
+        )
+    )
+
+
+@notes.route(
+    "/notes/<entity_type>/<entity_id>/toggle-pin/<int:note_id>",
+    methods=["POST"],
+)
+@login_required
+def toggle_pin(entity_type: str, entity_id: str, note_id: int):
+    if not current_user.is_admin:
+        abort(403)
+    form = CSRFOnlyForm()
+    if not form.validate_on_submit():
+        abort(400)
+    config, entity, identifier, note = _load_note_or_404(
+        entity_type, entity_id, note_id
+    )
+    note.set_pinned(not note.pinned)
+    db.session.commit()
+    action = "Pinned" if note.pinned else "Unpinned"
+    log_activity(f"{action} note on {config.activity_getter(entity)}")
+    flash(f"Note {action.lower()}.", "success")
+    return redirect(
+        url_for(
+            "notes.entity_notes",
+            entity_type=entity_type,
+            entity_id=identifier,
+        )
+    )

--- a/app/templates/customers/view_customers.html
+++ b/app/templates/customers/view_customers.html
@@ -102,6 +102,7 @@
                 <td class="col-customer-pst">{{ 'Yes' if customer.pst_exempt else 'No' }}</td>
                 <td class="col-customer-actions">
                     <a href="{{ url_for('customer.edit_customer', customer_id=customer.id) }}" class="btn btn-primary mr-2">Edit</a>
+                    <a href="{{ url_for('notes.entity_notes', entity_type='customer', entity_id=customer.id) }}" class="btn btn-outline-secondary mr-2">Notes</a>
                     <form action="{{ url_for('customer.delete_customer', customer_id=customer.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}
                         <button type="submit" class="btn btn-danger mr-2" data-confirm-message="Are you sure you want to delete this customer?">Delete</button>
@@ -180,6 +181,7 @@
                         <td class="col-customer-pst">${data.customer.pst_exempt ? 'Yes' : 'No'}</td>
                         <td class="col-customer-actions">
                             <a href="/customers/${data.customer.id}/edit" class="btn btn-primary mr-2">Edit</a>
+                            <a href="/notes/customer/${data.customer.id}" class="btn btn-outline-secondary mr-2">Notes</a>
                             <form action="/customers/${data.customer.id}/delete" method="post" class="d-inline">
                                 <input type="hidden" name="csrf_token" value="${data.delete_csrf_token}">
                                 <button type="submit" class="btn btn-danger mr-2" data-confirm-message="Are you sure you want to delete this customer?">Delete</button>

--- a/app/templates/invoices/view_invoice.html
+++ b/app/templates/invoices/view_invoice.html
@@ -12,7 +12,10 @@
                 style="margin-bottom: 50px; margin-top: -30px; max-width: 500px; width: 100%; height: auto;">
         </div>
     </div>
-    <h1>Invoice - {{ invoice.customer.first_name }} {{ invoice.customer.last_name }}</h1>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-2">
+        <h1 class="mb-0">Invoice - {{ invoice.customer.first_name }} {{ invoice.customer.last_name }}</h1>
+        <a class="btn btn-outline-secondary" href="{{ url_for('notes.entity_notes', entity_type='sales_invoice', entity_id=invoice.id) }}">View Notes</a>
+    </div>
     <div class="row">
         <div class="col">
             <p><strong>Invoice Number:</strong> {{ invoice.id }}</p>

--- a/app/templates/items/view_item.html
+++ b/app/templates/items/view_item.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="container mt-5">
-    <h2>{{ item.name }}</h2>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-2">
+        <h2 class="mb-0">{{ item.name }}</h2>
+        <a class="btn btn-outline-secondary" href="{{ url_for('notes.entity_notes', entity_type='item', entity_id=item.id) }}">View Notes</a>
+    </div>
     <p><strong>Base Unit:</strong> {{ item.base_unit }}</p>
     <div class="row">
         <div class="col-12">

--- a/app/templates/locations/location_items.html
+++ b/app/templates/locations/location_items.html
@@ -1,6 +1,11 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>{{ location.name }} Items</h2>
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-2">
+    <h2 class="mb-0">{{ location.name }} Items</h2>
+    <a class="btn btn-outline-secondary" href="{{ url_for('notes.entity_notes', entity_type='location', entity_id=location.id) }}">
+        View Notes
+    </a>
+</div>
 {% if can_add_items %}
 <form method="post" action="{{ url_for('locations.add_location_item', location_id=location.id) }}" class="row g-2 align-items-end mb-4">
     {{ add_form.hidden_tag() }}

--- a/app/templates/notes/edit_note.html
+++ b/app/templates/notes/edit_note.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block title %}Edit Note{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4 gap-3">
+    <div>
+        <h1 class="h3 mb-1">Edit Note</h1>
+        <p class="text-muted mb-0">{{ entity_label }} – {{ entity_name }}</p>
+    </div>
+    <div>
+        <a class="btn btn-outline-secondary" href="{{ url_for('notes.entity_notes', entity_type=entity_type, entity_id=entity_id) }}">Back to Notes</a>
+        <a class="btn btn-outline-secondary ms-2" href="{{ back_url }}">Back to {{ back_label }}</a>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header">Update Note</div>
+    <div class="card-body">
+        <form method="post">
+            {{ form.hidden_tag() }}
+            <div class="mb-3">
+                {{ form.content.label(class="form-label") }}
+                {{ form.content(class="form-control" + (' is-invalid' if form.content.errors else ''), rows=5) }}
+                {% for error in form.content.errors %}
+                    <div class="invalid-feedback d-block">{{ error }}</div>
+                {% endfor %}
+            </div>
+            {% if can_pin %}
+            <div class="form-check mb-3">
+                {{ form.pinned(class="form-check-input", id='pinned') }}
+                {{ form.pinned.label(class="form-check-label", for='pinned') }}
+            </div>
+            {% endif %}
+            {{ form.submit(class="btn btn-primary") }}
+            <a class="btn btn-link" href="{{ url_for('notes.entity_notes', entity_type=entity_type, entity_id=entity_id) }}">Cancel</a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/app/templates/notes/entity_notes.html
+++ b/app/templates/notes/entity_notes.html
@@ -1,0 +1,75 @@
+{% extends 'base.html' %}
+{% block title %}{{ entity_label }} Notes{% endblock %}
+{% block content %}
+<div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4 gap-3">
+    <div>
+        <h1 class="h3 mb-1">{{ entity_label }} Notes</h1>
+        <p class="text-muted mb-0">{{ entity_name }}</p>
+    </div>
+    <div>
+        <a class="btn btn-outline-secondary" href="{{ back_url }}">Back to {{ back_label }}</a>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">Add Note</div>
+    <div class="card-body">
+        <form method="post">
+            {{ form.hidden_tag() }}
+            <div class="mb-3">
+                {{ form.content.label(class="form-label") }}
+                {{ form.content(class="form-control" + (' is-invalid' if form.content.errors else ''), rows=4) }}
+                {% for error in form.content.errors %}
+                    <div class="invalid-feedback d-block">{{ error }}</div>
+                {% endfor %}
+            </div>
+            {% if can_pin %}
+            <div class="form-check mb-3">
+                {{ form.pinned(class="form-check-input", id='pinned') }}
+                {{ form.pinned.label(class="form-check-label", for='pinned') }}
+            </div>
+            {% endif %}
+            {{ form.submit(class="btn btn-primary") }}
+        </form>
+    </div>
+</div>
+
+{% if notes %}
+    {% for note in notes %}
+        <div class="card mb-3{% if note.pinned %} border-warning{% endif %}">
+            <div class="card-header d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
+                <div>
+                    {% if note.pinned %}
+                        <span class="badge bg-warning text-dark me-2">Pinned</span>
+                    {% endif %}
+                    <strong>{{ note.user.email if note.user else 'Deleted user' }}</strong>
+                    <span class="text-muted ms-2">{{ note.created_at|format_datetime }}</span>
+                    {% if note.updated_at and note.updated_at != note.created_at %}
+                        <small class="text-muted ms-2">Updated {{ note.updated_at|format_datetime }}</small>
+                    {% endif %}
+                </div>
+                <div class="d-flex flex-wrap gap-2">
+                    <a class="btn btn-outline-secondary btn-sm" href="{{ url_for('notes.edit_note', entity_type=entity_type, entity_id=entity_id, note_id=note.id) }}">Edit</a>
+                    <form method="post" action="{{ url_for('notes.delete_note', entity_type=entity_type, entity_id=entity_id, note_id=note.id) }}" class="d-inline">
+                        {{ delete_form.hidden_tag() }}
+                        <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>
+                    </form>
+                    {% if can_pin %}
+                    <form method="post" action="{{ url_for('notes.toggle_pin', entity_type=entity_type, entity_id=entity_id, note_id=note.id) }}" class="d-inline">
+                        {{ pin_form.hidden_tag() }}
+                        <button type="submit" class="btn btn-outline-warning btn-sm">
+                            {% if note.pinned %}Unpin{% else %}Pin{% endif %}
+                        </button>
+                    </form>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="card-body">
+                <p class="mb-0" style="white-space: pre-wrap;">{{ note.content }}</p>
+            </div>
+        </div>
+    {% endfor %}
+{% else %}
+    <div class="alert alert-info">No notes yet. Add one above to start the conversation.</div>
+{% endif %}
+{% endblock %}

--- a/app/templates/products/_product_row.html
+++ b/app/templates/products/_product_row.html
@@ -47,6 +47,7 @@
     </td>
     <td class="col-product-actions">
         <a href="{{ url_for('product.edit_product', product_id=product.id) }}" class="btn btn-primary mr-2">Edit</a>
+        <a href="{{ url_for('notes.entity_notes', entity_type='product', entity_id=product.id) }}" class="btn btn-outline-secondary mr-2">Notes</a>
         <a href="{{ url_for('product.copy_product', product_id=product.id) }}" class="btn btn-secondary mr-2">Copy</a>
         <form action="{{ url_for('product.delete_product', product_id=product.id) }}" method="post" class="d-inline">
             {{ delete_form.hidden_tag() }}

--- a/app/templates/purchase_invoices/view_purchase_invoice.html
+++ b/app/templates/purchase_invoices/view_purchase_invoice.html
@@ -1,7 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="container mt-4">
-    <h2>Invoice {{ invoice.id }}</h2>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-2">
+        <h2 class="mb-0">Invoice {{ invoice.id }}</h2>
+        <a class="btn btn-outline-secondary" href="{{ url_for('notes.entity_notes', entity_type='purchase_invoice', entity_id=invoice.id) }}">View Notes</a>
+    </div>
     <p>Purchase Order: {{ invoice.purchase_order_id }}</p>
     <p>Vendor: {{ invoice.purchase_order.vendor.first_name }} {{ invoice.purchase_order.vendor.last_name }}</p>
     <p>Location: {{ invoice.location_name }}</p>

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -247,6 +247,7 @@
                 <td class="col-invoice-user" data-sort-value="{{ inv.user_id or '' }}">{{ inv.user_id or '—' }}</td>
                 <td class="col-invoice-actions">
                     <a href="{{ url_for('purchase.view_purchase_invoice', invoice_id=inv.id) }}" class="btn btn-sm btn-primary">View</a>
+                    <a href="{{ url_for('notes.entity_notes', entity_type='purchase_invoice', entity_id=inv.id) }}" class="btn btn-sm btn-outline-secondary">Notes</a>
                     <a href="{{ url_for('purchase.purchase_invoice_report', invoice_id=inv.id) }}" class="btn btn-sm btn-secondary">Report</a>
                     <a href="{{ url_for('purchase.reverse_purchase_invoice', invoice_id=inv.id) }}" class="btn btn-sm btn-danger">Reverse</a>
                 </td>

--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -206,6 +206,7 @@
                 <td class="col-po-user" data-sort-value="{{ order.user_id or '' }}">{{ order.user_id or '—' }}</td>
                 <td class="col-po-actions">
                     <a href="{{ url_for('purchase.edit_purchase_order', po_id=order.id) }}" class="btn btn-sm btn-primary">Edit</a>
+                    <a href="{{ url_for('notes.entity_notes', entity_type='purchase_order', entity_id=order.id) }}" class="btn btn-sm btn-outline-secondary">Notes</a>
                     <a href="{{ url_for('purchase.receive_invoice', po_id=order.id) }}" class="btn btn-sm btn-success">Receive</a>
                     <form action="{{ url_for('purchase.delete_purchase_order', po_id=order.id) }}" method="post" class="d-inline">
                         {{ delete_form.hidden_tag() }}

--- a/app/templates/transfers/view_transfer.html
+++ b/app/templates/transfers/view_transfer.html
@@ -2,7 +2,10 @@
 
 {% block content %}
 <div class="container mt-4">
-    <h2>Transfer Details</h2>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-2">
+        <h2 class="mb-0">Transfer Details</h2>
+        <a class="btn btn-outline-secondary" href="{{ url_for('notes.entity_notes', entity_type='transfer', entity_id=transfer.id) }}">View Notes</a>
+    </div>
     <br>
     <div class="row">
         <div class="col-md-6">

--- a/app/templates/vendors/_vendor_row.html
+++ b/app/templates/vendors/_vendor_row.html
@@ -4,6 +4,7 @@
     <td class="col-vendor-pst">{{ 'Yes' if vendor.pst_exempt else 'No' }}</td>
     <td class="col-vendor-actions">
         <a href="{{ url_for('vendor.edit_vendor', vendor_id=vendor.id) }}" class="btn btn-primary mr-2">Edit</a>
+        <a href="{{ url_for('notes.entity_notes', entity_type='vendor', entity_id=vendor.id) }}" class="btn btn-outline-secondary mr-2">Notes</a>
         <form action="{{ url_for('vendor.delete_vendor', vendor_id=vendor.id) }}" method="post" class="d-inline">
             {{ delete_form.hidden_tag() }}
             <button type="submit" class="btn btn-danger mr-2" data-confirm-message="Are you sure you want to delete this vendor?">Delete</button>

--- a/migrations/versions/a7c8e9f0b1a2_add_notes_table.py
+++ b/migrations/versions/a7c8e9f0b1a2_add_notes_table.py
@@ -1,0 +1,48 @@
+"""Add notes table for entity annotations."""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def _has_table(table_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    return inspector.has_table(table_name)
+
+
+# revision identifiers, used by Alembic.
+revision = "a7c8e9f0b1a2"
+down_revision = "f1c2d3e4a5b6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if _has_table("note", bind):
+        return
+
+    op.create_table(
+        "note",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("entity_type", sa.String(length=50), nullable=False),
+        sa.Column("entity_id", sa.String(length=64), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("pinned", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("pinned_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], name="fk_note_user_id"),
+    )
+    op.create_index("ix_note_entity", "note", ["entity_type", "entity_id"])
+    op.create_index("ix_note_pinned", "note", ["entity_type", "pinned"])
+
+
+def downgrade():
+    bind = op.get_bind()
+    if not _has_table("note", bind):
+        return
+
+    op.drop_index("ix_note_pinned", table_name="note")
+    op.drop_index("ix_note_entity", table_name="note")
+    op.drop_table("note")

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,138 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import ActivityLog, Location, Note, User
+from app.utils.activity import flush_activity_logs
+
+
+def _create_location_with_user(app):
+    with app.app_context():
+        admin = User.query.filter_by(email="admin@example.com").first()
+        if admin is None:
+            admin = User(
+                email="admin@example.com",
+                password=generate_password_hash("adminpass"),
+                active=True,
+                is_admin=True,
+            )
+            db.session.add(admin)
+        location = Location(name="Main Warehouse")
+        other_user = User(
+            email="user@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        db.session.add_all([location, other_user])
+        db.session.commit()
+        return location.id
+
+
+def test_admin_can_manage_notes(client, app):
+    location_id = _create_location_with_user(app)
+
+    with client:
+        with app.app_context():
+            admin = User.query.filter_by(email="admin@example.com").one()
+        with client.session_transaction() as session:
+            session["_user_id"] = str(admin.id)
+            session["_fresh"] = True
+        response = client.post(
+            f"/notes/location/{location_id}",
+            data={"content": "First note", "pinned": "y"},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+        with app.app_context():
+            note = Note.query.filter_by(
+                entity_type="location", entity_id=str(location_id)
+            ).one()
+            note_id = note.id
+            assert note.pinned is True
+            assert note.user.email == "admin@example.com"
+
+        update_response = client.post(
+            f"/notes/location/{location_id}/edit/{note_id}",
+            data={"content": "Updated note"},
+            follow_redirects=True,
+        )
+        assert update_response.status_code == 200
+
+        with app.app_context():
+            refreshed = db.session.get(Note, note_id)
+            assert refreshed.content == "Updated note"
+            assert refreshed.pinned is False
+
+        with app.app_context():
+            other_user = User.query.filter_by(email="user@example.com").one()
+        with client.session_transaction() as session:
+            session.clear()
+            session["_user_id"] = str(other_user.id)
+            session["_fresh"] = True
+
+        delete_resp = client.post(
+            f"/notes/location/{location_id}/delete/{note_id}",
+            data={},
+            follow_redirects=True,
+        )
+        assert delete_resp.status_code == 200
+        assert "Note deleted" in delete_resp.get_data(as_text=True)
+
+    with app.app_context():
+        flush_activity_logs()
+        assert Note.query.count() == 0
+        activities = [entry.activity for entry in ActivityLog.query.all()]
+        assert any("Added note to location" in activity for activity in activities)
+        assert any("Updated note on location" in activity for activity in activities)
+        assert any("Deleted note from location" in activity for activity in activities)
+
+
+def test_non_admin_cannot_pin_notes(client, app):
+    with app.app_context():
+        location = Location(name="Secondary")
+        user = User(
+            email="noteuser@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        db.session.add_all([location, user])
+        db.session.commit()
+        location_id = location.id
+
+    with client:
+        with app.app_context():
+            note_user = User.query.filter_by(email="noteuser@example.com").one()
+        with client.session_transaction() as session:
+            session["_user_id"] = str(note_user.id)
+            session["_fresh"] = True
+        add_resp = client.post(
+            f"/notes/location/{location_id}",
+            data={"content": "Hello", "pinned": "y"},
+            follow_redirects=True,
+        )
+        assert add_resp.status_code == 200
+
+        with app.app_context():
+            note = Note.query.filter_by(
+                entity_type="location", entity_id=str(location_id)
+            ).one()
+            note_id = note.id
+            assert note.pinned is False
+
+        toggle = client.post(
+            f"/notes/location/{location_id}/toggle-pin/{note_id}",
+            follow_redirects=False,
+        )
+        assert toggle.status_code == 403
+
+        update_resp = client.post(
+            f"/notes/location/{location_id}/edit/{note_id}",
+            data={"content": "Updated", "pinned": "y"},
+            follow_redirects=True,
+        )
+        assert update_resp.status_code == 200
+
+        with app.app_context():
+            refreshed = db.session.get(Note, note_id)
+            assert refreshed.content == "Updated"
+            assert refreshed.pinned is False


### PR DESCRIPTION
## Summary
- add a reusable Note model, forms, and migration to store user-authored notes across entities
- introduce a dedicated notes blueprint with listing, creation, editing, pinning, and deletion views
- expose "View Notes" entry points on key entity pages and add targeted tests for the workflow

## Testing
- pytest tests/test_notes.py

------
https://chatgpt.com/codex/tasks/task_e_68d98c31ef108324a8b80c6d4a01c757