### PR TITLE
Add optional department to received purchase invoices

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -579,6 +579,19 @@ class ReceiveInvoiceForm(FlaskForm):
     location_id = SelectField(
         "Location", coerce=int, validators=[DataRequired()]
     )
+    department = SelectField(
+        "Department",
+        choices=[
+            ("", "—"),
+            ("Kitchen", "Kitchen"),
+            ("Concessions", "Concessions"),
+            ("Banquets", "Banquets"),
+            ("Beverages", "Beverages"),
+            ("Office", "Office"),
+            ("Other", "Other"),
+        ],
+        validators=[Optional()],
+    )
     gst = DecimalField("GST Amount", validators=[Optional()], default=0)
     pst = DecimalField("PST Amount", validators=[Optional()], default=0)
     delivery_charge = DecimalField(

--- a/app/models.py
+++ b/app/models.py
@@ -484,6 +484,7 @@ class PurchaseInvoice(db.Model):
     )
     received_date = db.Column(db.Date, nullable=False)
     invoice_number = db.Column(db.String(50), nullable=True)
+    department = db.Column(db.String(50), nullable=True)
     gst = db.Column(db.Float, nullable=False, default=0.0)
     pst = db.Column(db.Float, nullable=False, default=0.0)
     delivery_charge = db.Column(db.Float, nullable=False, default=0.0)

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -632,6 +632,7 @@ def receive_invoice(po_id):
             location_name=db.session.get(Location, form.location_id.data).name,
             received_date=form.received_date.data,
             invoice_number=form.invoice_number.data,
+            department=form.department.data or None,
             gst=form.gst.data or 0.0,
             pst=form.pst.data or 0.0,
             delivery_charge=form.delivery_charge.data or 0.0,

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -72,6 +72,10 @@
             {{ form.location_id(class="form-control narrow-field") }}
         </div>
         <div class="form-group">
+            {{ form.department.label(class="form-label") }}
+            {{ form.department(class="form-select narrow-field") }}
+        </div>
+        <div class="form-group">
             {{ form.pst.label(class="form-label") }}
             {{ form.pst(class="form-control narrow-field") }}
         </div>

--- a/app/templates/report_received_invoices_results.html
+++ b/app/templates/report_received_invoices_results.html
@@ -18,6 +18,7 @@
                 <th scope="col">Received By</th>
                 <th scope="col">Received Date</th>
                 <th scope="col">Vendor</th>
+                <th scope="col">Department</th>
                 <th scope="col" class="text-end">Invoice Total</th>
                 <th scope="col">Invoice Number</th>
             </tr>
@@ -31,6 +32,7 @@
                     <td>{{ row.received_by }}</td>
                     <td>{{ row.invoice.received_date|format_datetime('%Y-%m-%d') }}</td>
                     <td>{{ row.invoice.vendor_name }}</td>
+                    <td>{{ row.invoice.department or '—' }}</td>
                     <td class="text-end">${{ '%.2f'|format(row.invoice.total) }}</td>
                     <td>{{ row.invoice.invoice_number or '' }}</td>
                 </tr>
@@ -38,7 +40,7 @@
         </tbody>
         <tfoot>
             <tr>
-                <th colspan="4" class="text-end">Total for {{ results|length }} invoice{% if results|length != 1 %}s{% endif %}:</th>
+                <th colspan="5" class="text-end">Total for {{ results|length }} invoice{% if results|length != 1 %}s{% endif %}:</th>
                 <th class="text-end">${{ '%.2f'|format(totals.amount) }}</th>
                 <th></th>
             </tr>

--- a/migrations/versions/c4d5e6f7a8b9_add_department_to_purchase_invoice.py
+++ b/migrations/versions/c4d5e6f7a8b9_add_department_to_purchase_invoice.py
@@ -1,0 +1,54 @@
+"""add department column to purchase_invoice
+
+Revision ID: c4d5e6f7a8b9
+Revises: a7c8e9f0b1a2
+Create Date: 2025-10-01 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def _has_table(table_name: str, bind) -> bool:
+    """Return True if the database has the given table."""
+    inspector = sa.inspect(bind)
+    return inspector.has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str, bind) -> bool:
+    """Return True if the given table already has the specified column."""
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table_name):
+        return False
+    columns = [c["name"] for c in inspector.get_columns(table_name)]
+    return column_name in columns
+
+
+# revision identifiers, used by Alembic.
+revision = "c4d5e6f7a8b9"
+down_revision = "a7c8e9f0b1a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    table = "purchase_invoice"
+
+    if not _has_table(table, bind) or _has_column(table, "department", bind):
+        return
+
+    with op.batch_alter_table(table, recreate="always") as batch_op:
+        batch_op.add_column(sa.Column("department", sa.String(length=50), nullable=True))
+
+
+def downgrade():
+    bind = op.get_bind()
+    table = "purchase_invoice"
+
+    if not _has_table(table, bind) or not _has_column(table, "department", bind):
+        return
+
+    with op.batch_alter_table(table, recreate="always") as batch_op:
+        batch_op.drop_column("department")


### PR DESCRIPTION
## Summary
- allow users to choose an optional department when receiving a purchase order invoice
- persist the selected department on purchase invoices via a new database column and migration
- display the recorded department in the received invoice report output

## Testing
- pytest *(fails: tests/test_event_flow.py::test_bulk_stand_sheets_render_multiple_pages)*

------
https://chatgpt.com/codex/tasks/task_e_68d99f40deb88324ae936584d0ec6d75