### PR TITLE
Add filtering controls to activity log view

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -489,6 +489,19 @@ class InvoiceFilterForm(FlaskForm):
     submit = SubmitField("Filter")
 
 
+class ActivityLogFilterForm(FlaskForm):
+    user_id = SelectField(
+        "User",
+        coerce=int,
+        validators=[Optional()],
+        validate_choice=False,
+    )
+    activity = StringField("Activity Contains", validators=[Optional()])
+    start_date = DateField("Start Date", validators=[Optional()])
+    end_date = DateField("End Date", validators=[Optional()])
+    submit = SubmitField("Filter")
+
+
 class CreateBackupForm(FlaskForm):
     submit = SubmitField("Create Backup")
 

--- a/app/templates/admin/activity_logs.html
+++ b/app/templates/admin/activity_logs.html
@@ -4,17 +4,46 @@
 {% block content %}
 <div class="container mt-4">
     <h2>Activity Logs</h2>
-    <div class="d-flex justify-content-end mb-3">
-        {{ column_visibility_dropdown(
-            table_id='activity-logs-table',
-            storage_key='activityLogsTableColumnVisibility',
-            align='end',
-            columns=[
-                {'id': 'toggle-log-timestamp', 'target': 'col-log-timestamp', 'label': 'Timestamp', 'checked': True},
-                {'id': 'toggle-log-user', 'target': 'col-log-user', 'label': 'User', 'checked': True},
-                {'id': 'toggle-log-activity', 'target': 'col-log-activity', 'label': 'Activity', 'checked': True},
-            ]
-        ) }}
+    <div class="row g-3 align-items-end mb-3">
+        <div class="col-12 col-xl">
+            <form method="get" class="row g-3 align-items-end">
+                {{ form.hidden_tag() }}
+                <div class="col-12 col-md-6 col-xl-3">
+                    {{ form.user_id.label(class="form-label") }}
+                    {{ form.user_id(class="form-select") }}
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                    {{ form.activity.label(class="form-label") }}
+                    {{ form.activity(class="form-control", placeholder="Contains text") }}
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                    {{ form.start_date.label(class="form-label") }}
+                    {{ form.start_date(class="form-control", type="date") }}
+                </div>
+                <div class="col-12 col-md-6 col-xl-3">
+                    {{ form.end_date.label(class="form-label") }}
+                    {{ form.end_date(class="form-control", type="date") }}
+                </div>
+                <div class="col-12 col-md-auto">
+                    <div class="d-flex gap-2">
+                        <button type="submit" class="btn btn-primary">Apply</button>
+                        <a href="{{ url_for('admin.activity_logs') }}" class="btn btn-secondary">Clear</a>
+                    </div>
+                </div>
+            </form>
+        </div>
+        <div class="col-12 col-xl-auto text-xl-end">
+            {{ column_visibility_dropdown(
+                table_id='activity-logs-table',
+                storage_key='activityLogsTableColumnVisibility',
+                align='end',
+                columns=[
+                    {'id': 'toggle-log-timestamp', 'target': 'col-log-timestamp', 'label': 'Timestamp', 'checked': True},
+                    {'id': 'toggle-log-user', 'target': 'col-log-user', 'label': 'User', 'checked': True},
+                    {'id': 'toggle-log-activity', 'target': 'col-log-activity', 'label': 'Activity', 'checked': True},
+                ]
+            ) }}
+        </div>
     </div>
     <div class="table-responsive">
     <table class="table" id="activity-logs-table">

--- a/tests/test_activity_logs.py
+++ b/tests/test_activity_logs.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta
 
 from flask import url_for
 from werkzeug.security import generate_password_hash
@@ -52,3 +53,78 @@ def test_non_admin_forbidden_from_activity_logs(client, app):
         login(client, "normal@example.com", "pass")
         resp = client.get("/controlpanel/activity")
         assert resp.status_code == 403
+
+
+def test_activity_log_filters(client, app):
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    admin_pass = os.getenv("ADMIN_PASS", "adminpass")
+
+    with app.app_context():
+        admin_user = User.query.filter_by(email=admin_email).first()
+        admin_id = admin_user.id
+        other_user = User(
+            email="other@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        db.session.add(other_user)
+        db.session.commit()
+
+        base_time = datetime(2024, 1, 1, 12, 0, 0)
+        db.session.add_all(
+            [
+                ActivityLog(
+                    user_id=admin_user.id,
+                    activity="Alpha admin action",
+                    timestamp=base_time,
+                ),
+                ActivityLog(
+                    user_id=other_user.id,
+                    activity="Beta user action",
+                    timestamp=base_time + timedelta(days=1),
+                ),
+                ActivityLog(
+                    user_id=None,
+                    activity="Gamma system event",
+                    timestamp=base_time + timedelta(days=2),
+                ),
+            ]
+        )
+        db.session.commit()
+
+        with app.test_request_context():
+            activity_url = url_for("admin.activity_logs")
+
+    with client:
+        login(client, admin_email, admin_pass)
+
+        # Filter by a specific user
+        resp = client.get(f"{activity_url}?user_id={admin_id}")
+        assert resp.status_code == 200
+        assert b"Alpha admin action" in resp.data
+        assert b"Beta user action" not in resp.data
+        assert b"Gamma system event" not in resp.data
+
+        # Filter for system-generated entries
+        resp = client.get(f"{activity_url}?user_id=-2")
+        assert resp.status_code == 200
+        assert b"Gamma system event" in resp.data
+        assert b"Alpha admin action" not in resp.data
+        assert b"Beta user action" not in resp.data
+
+        # Filter by partial activity text
+        resp = client.get(f"{activity_url}?activity=beta")
+        assert resp.status_code == 200
+        assert b"Beta user action" in resp.data
+        assert b"Alpha admin action" not in resp.data
+        assert b"Gamma system event" not in resp.data
+
+        # Filter by date range
+        filter_date = (base_time + timedelta(days=1)).date().isoformat()
+        resp = client.get(
+            f"{activity_url}?start_date={filter_date}&end_date={filter_date}"
+        )
+        assert resp.status_code == 200
+        assert b"Beta user action" in resp.data
+        assert b"Alpha admin action" not in resp.data
+        assert b"Gamma system event" not in resp.data


### PR DESCRIPTION
## Summary
- add an activity log filter form so admins can narrow results by user, text, or date
- update the activity log route and template to apply the new filters and expose UI controls
- extend the activity log tests to cover the new filtering behaviour

## Testing
- pytest tests/test_activity_logs.py

------
https://chatgpt.com/codex/tasks/task_e_68d9be3633148324baf355e69c3b4f23