### PR TITLE
Add recipe cost calculator accessible from items list

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -402,6 +402,14 @@ class RecipeItemForm(FlaskForm):
 
 
 class ProductRecipeForm(FlaskForm):
+    recipe_yield_quantity = DecimalField(
+        "Recipe Yield Quantity",
+        validators=[Optional(), NumberRange(min=0.0001)],
+        default=1,
+    )
+    recipe_yield_unit = StringField(
+        "Recipe Yield Unit", validators=[Optional(), Length(max=50)]
+    )
     items = FieldList(FormField(RecipeItemForm), min_entries=1)
     submit = SubmitField("Submit")
 
@@ -417,6 +425,14 @@ class ProductRecipeForm(FlaskForm):
 class ProductWithRecipeForm(ProductForm):
     """Form used on product create/edit pages to also manage recipe items."""
 
+    recipe_yield_quantity = DecimalField(
+        "Recipe Yield Quantity",
+        validators=[Optional(), NumberRange(min=0.0001)],
+        default=1,
+    )
+    recipe_yield_unit = StringField(
+        "Recipe Yield Unit", validators=[Optional(), Length(max=50)]
+    )
     items = FieldList(FormField(RecipeItemForm), min_entries=0)
 
     def __init__(self, *args, **kwargs):

--- a/app/models.py
+++ b/app/models.py
@@ -301,6 +301,10 @@ class Product(db.Model):
     quantity = db.Column(
         db.Float, nullable=False, default=0.0, server_default="0.0"
     )
+    recipe_yield_quantity = db.Column(
+        db.Float, nullable=False, default=1.0, server_default="1.0"
+    )
+    recipe_yield_unit = db.Column(db.String(50), nullable=True)
     sales_gl_code_id = db.Column(
         db.Integer, db.ForeignKey("gl_code.id"), nullable=True
     )

--- a/app/templates/items/recipe_calculator.html
+++ b/app/templates/items/recipe_calculator.html
@@ -1,0 +1,277 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="container mt-4">
+    <div class="d-flex flex-wrap justify-content-between align-items-center mb-4">
+        <div>
+            <h2 class="mb-1">Recipe Cost Calculator</h2>
+            <p class="text-muted mb-0">Build a recipe to estimate the cost per finished product.</p>
+        </div>
+        <a href="{{ url_for('item.view_items') }}" class="btn btn-outline-secondary mt-2 mt-sm-0">Back to Items</a>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            {% if not items %}
+            <div class="alert alert-info" role="alert">
+                Add items to your inventory to start building recipe costs.
+            </div>
+            {% endif %}
+
+            <div id="recipe-items" class="mb-3"></div>
+            <button type="button" class="btn btn-secondary mb-4" id="add-ingredient" {% if not items %}disabled{% endif %}>
+                Add Item
+            </button>
+
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="yield-quantity" class="form-label">Recipe Yield Quantity</label>
+                    <input type="number" min="0" step="0.0001" class="form-control" id="yield-quantity" value="1">
+                    <div class="form-text">How many products this recipe batch makes.</div>
+                </div>
+                <div class="col-md-6">
+                    <label for="yield-unit" class="form-label">Recipe Yield Unit (optional)</label>
+                    <input type="text" class="form-control" id="yield-unit" placeholder="e.g. cups, servings">
+                </div>
+            </div>
+
+            <hr class="my-4">
+
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <div class="border rounded p-3 bg-light h-100">
+                        <div class="text-uppercase text-muted small mb-1">Batch Cost</div>
+                        <div class="fs-4 fw-semibold" id="batch-cost">$0.00</div>
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <div class="border rounded p-3 bg-light h-100">
+                        <div class="text-uppercase text-muted small mb-1">Base Cost per Product</div>
+                        <div class="fs-4 fw-semibold" id="unit-cost">$0.00</div>
+                        <div class="text-muted small" id="unit-cost-hint">Enter a yield above zero to see the per-product cost.</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+(function () {
+    const ITEMS = {{ items|tojson }};
+    const HAS_ITEMS = Array.isArray(ITEMS) && ITEMS.length > 0;
+    const itemLookup = new Map((ITEMS || []).map((item) => [String(item.id), item]));
+    const recipeContainer = document.getElementById('recipe-items');
+    const addButton = document.getElementById('add-ingredient');
+    const yieldInput = document.getElementById('yield-quantity');
+    const unitCostElement = document.getElementById('unit-cost');
+    const unitCostHint = document.getElementById('unit-cost-hint');
+    const batchCostElement = document.getElementById('batch-cost');
+
+    const ITEM_OPTIONS_HTML = ['<option value="">Select an item</option>']
+        .concat((ITEMS || []).map((item) => `<option value="${item.id}">${item.name}</option>`))
+        .join('');
+
+    function formatCurrency(value) {
+        if (typeof value !== 'number' || !isFinite(value)) {
+            return '$0.00';
+        }
+        return `$${value.toFixed(2)}`;
+    }
+
+    function updateTotals() {
+        let total = 0;
+        document.querySelectorAll('.recipe-row').forEach((row) => {
+            const lineCost = parseFloat(row.dataset.lineCost || '0');
+            if (!Number.isNaN(lineCost)) {
+                total += lineCost;
+            }
+        });
+        batchCostElement.textContent = formatCurrency(total);
+
+        const yieldQuantity = parseFloat(yieldInput.value);
+        if (!Number.isNaN(yieldQuantity) && yieldQuantity > 0) {
+            const perProduct = total / yieldQuantity;
+            unitCostElement.textContent = formatCurrency(perProduct);
+            unitCostElement.classList.remove('text-muted');
+            unitCostHint.classList.add('d-none');
+        } else {
+            unitCostElement.textContent = '$0.00';
+            unitCostElement.classList.add('text-muted');
+            unitCostHint.classList.remove('d-none');
+        }
+    }
+
+    function updateUnitCost(row) {
+        const unitSelect = row.querySelector('.unit-select');
+        const unitCostLabel = row.querySelector('.unit-cost');
+        const baseCost = parseFloat(row.dataset.baseCost || '0');
+        const selected = unitSelect.options[unitSelect.selectedIndex];
+        if (!selected || Number.isNaN(baseCost)) {
+            unitCostLabel.textContent = '$0.00';
+            row.dataset.unitFactor = '0';
+            return;
+        }
+        const factor = parseFloat(selected.dataset.factor || '1');
+        const cost = baseCost * factor;
+        unitCostLabel.textContent = formatCurrency(cost);
+        row.dataset.unitFactor = String(factor);
+    }
+
+    function updateRowCost(row) {
+        const quantityInput = row.querySelector('.quantity-input');
+        const lineCostLabel = row.querySelector('.line-cost');
+        const quantity = parseFloat(quantityInput.value);
+        const baseCost = parseFloat(row.dataset.baseCost || '0');
+        const factor = parseFloat(row.dataset.unitFactor || '0');
+
+        if (Number.isNaN(quantity) || Number.isNaN(baseCost) || Number.isNaN(factor) || baseCost <= 0 || factor <= 0) {
+            lineCostLabel.textContent = '$0.00';
+            row.dataset.lineCost = '0';
+        } else {
+            const lineCost = quantity * baseCost * factor;
+            row.dataset.lineCost = String(lineCost);
+            lineCostLabel.textContent = formatCurrency(lineCost);
+        }
+        updateTotals();
+    }
+
+    function resetRow(row) {
+        row.dataset.baseCost = '0';
+        row.dataset.unitFactor = '0';
+        row.dataset.lineCost = '0';
+        row.querySelector('.unit-select').innerHTML = '<option value="">Select a unit</option>';
+        row.querySelector('.unit-select').disabled = true;
+        row.querySelector('.unit-cost').textContent = '$0.00';
+        row.querySelector('.line-cost').textContent = '$0.00';
+        updateTotals();
+    }
+
+    function populateUnits(row, item) {
+        const unitSelect = row.querySelector('.unit-select');
+        const units = Array.isArray(item.units) ? item.units : [];
+        unitSelect.innerHTML = '';
+
+        const placeholder = document.createElement('option');
+        placeholder.value = '';
+        placeholder.textContent = 'Select a unit';
+        unitSelect.appendChild(placeholder);
+
+        units.forEach((unit, index) => {
+            const option = document.createElement('option');
+            const factor = typeof unit.factor === 'number' ? unit.factor : 1;
+            option.value = unit.id !== null ? String(unit.id) : `base-${item.id}`;
+            option.dataset.factor = String(factor);
+            option.dataset.isBase = unit.is_base ? '1' : '0';
+            option.textContent = unit.is_base
+                ? `${unit.name} (base unit)`
+                : `${unit.name} (×${factor} ${item.base_unit})`;
+            unitSelect.appendChild(option);
+            if (unit.is_base && index === 0) {
+                option.selected = true;
+            }
+        });
+
+        unitSelect.disabled = units.length === 0;
+        if (units.length > 0) {
+            const firstSelectable = unitSelect.querySelector('option[data-factor]');
+            if (firstSelectable) {
+                firstSelectable.selected = true;
+            }
+            row.dataset.baseCost = String(item.cost || 0);
+            updateUnitCost(row);
+            updateRowCost(row);
+        } else {
+            resetRow(row);
+        }
+    }
+
+    function createRow() {
+        const row = document.createElement('div');
+        row.className = 'recipe-row row g-3 align-items-end mb-3';
+        row.innerHTML = `
+            <div class="col-md-4">
+                <label class="form-label">Item</label>
+                <select class="form-select item-select">${ITEM_OPTIONS_HTML}</select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Unit of Measure</label>
+                <select class="form-select unit-select" disabled><option value="">Select a unit</option></select>
+                <div class="form-text">Unit Cost: <span class="unit-cost">$0.00</span></div>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Quantity</label>
+                <input type="number" min="0" step="0.0001" value="1" class="form-control quantity-input">
+            </div>
+            <div class="col-md-2">
+                <div class="form-label">Line Cost</div>
+                <div class="fw-semibold line-cost">$0.00</div>
+            </div>
+            <div class="col-md-1 text-md-end">
+                <button type="button" class="btn btn-outline-danger btn-sm remove-row">Remove</button>
+            </div>
+        `;
+
+        const itemSelect = row.querySelector('.item-select');
+        const unitSelect = row.querySelector('.unit-select');
+        const quantityInput = row.querySelector('.quantity-input');
+        const removeButton = row.querySelector('.remove-row');
+
+        itemSelect.addEventListener('change', () => {
+            const selectedItem = itemLookup.get(itemSelect.value);
+            if (!selectedItem) {
+                resetRow(row);
+                return;
+            }
+            populateUnits(row, selectedItem);
+        });
+
+        unitSelect.addEventListener('change', () => {
+            updateUnitCost(row);
+            updateRowCost(row);
+        });
+
+        quantityInput.addEventListener('input', () => updateRowCost(row));
+
+        removeButton.addEventListener('click', () => {
+            row.remove();
+            if (!document.querySelector('.recipe-row') && HAS_ITEMS) {
+                addRow();
+            } else {
+                updateTotals();
+            }
+        });
+
+        recipeContainer.appendChild(row);
+        updateTotals();
+        return row;
+    }
+
+    function addRow() {
+        const row = createRow();
+        const firstItem = ITEMS[0];
+        if (firstItem) {
+            row.querySelector('.item-select').value = String(firstItem.id);
+            populateUnits(row, firstItem);
+        }
+    }
+
+    if (HAS_ITEMS) {
+        addRow();
+    }
+
+    if (addButton) {
+        addButton.addEventListener('click', () => {
+            if (!HAS_ITEMS) {
+                return;
+            }
+            createRow();
+        });
+    }
+
+    if (yieldInput) {
+        yieldInput.addEventListener('input', updateTotals);
+    }
+})();
+</script>
+{% endblock %}

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -4,8 +4,9 @@
 <div class="container mt-5">
     <h2>Items List</h2>
     <div class="row justify-content-between">
-        <div class="col-auto">
+        <div class="col-auto d-flex flex-wrap gap-2">
             <a href="{{ url_for('item.add_item') }}" class="btn btn-primary mb-3" id="createItemBtn">Add New Item</a>
+            <a href="{{ url_for('item.recipe_cost_calculator') }}" class="btn btn-outline-primary mb-3" id="recipeCostCalculatorBtn">Recipe Cost Calculator</a>
         </div>
         <div class="col-auto">
             <div class="dropdown d-inline-block mb-3 me-2" data-column-visibility data-table-id="itemsTable" data-storage-key="itemsTableColumnVisibility">

--- a/app/templates/products/_create_product_form.html
+++ b/app/templates/products/_create_product_form.html
@@ -20,6 +20,17 @@
             {{ form.gl_code_id(class="form-control") }}
         </div>
     </div>
+    <div class="row">
+        <div class="col-md-6 mb-3">
+            {{ form.recipe_yield_quantity.label(class="form-label") }}
+            {{ form.recipe_yield_quantity(class="form-control", id="recipe_yield_quantity") }}
+            <div class="form-text">Number of products produced by this recipe batch.</div>
+        </div>
+        <div class="col-md-6 mb-3">
+            {{ form.recipe_yield_unit.label(class="form-label") }}
+            {{ form.recipe_yield_unit(class="form-control", placeholder="e.g. cups") }}
+        </div>
+    </div>
     <div id="item-list">
         {% for item in form.items %}
         {% set selected_name = item.item.choices | selectattr('0', 'equalto', item.item.data) | map(attribute=1) | first %}
@@ -54,9 +65,22 @@ document.addEventListener('DOMContentLoaded', function() {
         const pid = btn.getAttribute('data-product-id');
         if (pid) {
             btn.addEventListener('click', function() {
-                fetch(`/products/${pid}/calculate_cost`).then(resp => resp.json()).then(data => {
+                const yieldInput = document.getElementById('recipe_yield_quantity');
+                let url = `/products/${pid}/calculate_cost`;
+                if (yieldInput) {
+                    const parsedYield = parseFloat(yieldInput.value);
+                    if (!Number.isNaN(parsedYield) && parsedYield > 0) {
+                        url += `?yield_quantity=${encodeURIComponent(parsedYield)}`;
+                    }
+                }
+                fetch(url).then(resp => resp.json()).then(data => {
                     const costInput = document.getElementById('cost');
-                    if (costInput) costInput.value = data.cost;
+                    if (costInput && typeof data.cost !== 'undefined') {
+                        costInput.value = data.cost;
+                    }
+                    if (yieldInput && typeof data.yield_quantity !== 'undefined') {
+                        yieldInput.value = data.yield_quantity;
+                    }
                 });
             });
         } else {

--- a/app/templates/products/_product_row.html
+++ b/app/templates/products/_product_row.html
@@ -26,6 +26,9 @@
     <td class="col-product-recipe-count" data-sort-value="{{ recipe_count }}">{{ recipe_count }}</td>
     <td class="col-product-recipe-details text-wrap">
         {% if product.recipe_items %}
+            {% if product.recipe_yield_quantity %}
+                <div><strong>Yield:</strong> {{ '{:g}'.format(product.recipe_yield_quantity) }}{% if product.recipe_yield_unit %} {{ product.recipe_yield_unit }}{% endif %}</div>
+            {% endif %}
             <ul class="mb-0 ps-3">
                 {% for recipe_item in product.recipe_items %}
                     <li>

--- a/app/templates/products/edit_product_recipe.html
+++ b/app/templates/products/edit_product_recipe.html
@@ -4,6 +4,17 @@
     <h2>Recipe for {{ product.name }}</h2>
     <form method="POST">
         {{ form.hidden_tag() }}
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                {{ form.recipe_yield_quantity.label(class="form-label") }}
+                {{ form.recipe_yield_quantity(class="form-control") }}
+                <div class="form-text">Number of products produced by this recipe batch.</div>
+            </div>
+            <div class="col-md-6 mb-3">
+                {{ form.recipe_yield_unit.label(class="form-label") }}
+                {{ form.recipe_yield_unit(class="form-control", placeholder="e.g. cups") }}
+            </div>
+        </div>
         <div id="item-list">
             {% for item in form.items %}
             <div class="row g-2 mb-2 align-items-center">

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -184,6 +184,9 @@ that developers should keep in mind when working on or extending the routes.
     `/products/<id>/edit`, and `/products/<id>/delete`.
   - Recipe management lives under `/products/<id>/recipe` and cost helpers
     (`/products/<id>/calculate_cost`, `/products/bulk_set_cost_from_recipe`).
+    The cost calculator divides the batch total by the recipe yield (override via
+    `?yield_quantity=`) and returns both batch and per-unit values so pricing can
+    be aligned with output volume.
   - `/search_products` powers autocomplete searches.
 - **Key dependencies:** Forms include `ProductWithRecipeForm`,
   `ProductRecipeForm`, `BulkProductCostForm`, and `DeleteForm`. Models span

--- a/migrations/versions/202408010001_add_recipe_yield_to_product.py
+++ b/migrations/versions/202408010001_add_recipe_yield_to_product.py
@@ -1,0 +1,53 @@
+"""Add recipe yield fields to product"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def _has_column(table_name: str, column_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table_name):
+        return False
+    return column_name in {
+        column["name"] for column in inspector.get_columns(table_name)
+    }
+
+
+# revision identifiers, used by Alembic.
+revision = "202408010001"
+down_revision = "202407171234"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if not bind:
+        return
+
+    with op.batch_alter_table("product", recreate="always") as batch_op:
+        if not _has_column("product", "recipe_yield_quantity", bind):
+            batch_op.add_column(
+                sa.Column(
+                    "recipe_yield_quantity",
+                    sa.Float(),
+                    nullable=False,
+                    server_default="1.0",
+                )
+            )
+        if not _has_column("product", "recipe_yield_unit", bind):
+            batch_op.add_column(
+                sa.Column("recipe_yield_unit", sa.String(length=50), nullable=True)
+            )
+
+
+def downgrade():
+    bind = op.get_bind()
+    if not bind:
+        return
+
+    with op.batch_alter_table("product", recreate="always") as batch_op:
+        if _has_column("product", "recipe_yield_unit", bind):
+            batch_op.drop_column("recipe_yield_unit")
+        if _has_column("product", "recipe_yield_quantity", bind):
+            batch_op.drop_column("recipe_yield_quantity")

--- a/tests/test_item_recipe_calculator.py
+++ b/tests/test_item_recipe_calculator.py
@@ -1,0 +1,56 @@
+import os
+
+from app import db
+from app.models import Item, ItemUnit
+from tests.utils import login
+
+
+def _ensure_sample_item():
+    item = Item.query.filter_by(name="Recipe Calculator Test Item").first()
+    if not item:
+        item = Item(name="Recipe Calculator Test Item", base_unit="each", cost=2.5)
+        db.session.add(item)
+        db.session.flush()
+    if not ItemUnit.query.filter_by(item_id=item.id, name=item.base_unit).first():
+        db.session.add(ItemUnit(item_id=item.id, name=item.base_unit, factor=1.0))
+    if not ItemUnit.query.filter_by(item_id=item.id, name="case").first():
+        db.session.add(ItemUnit(item_id=item.id, name="case", factor=12.0))
+    db.session.commit()
+    return item
+
+
+def test_recipe_calculator_page_renders(client, app):
+    with app.app_context():
+        _ensure_sample_item()
+
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    admin_pass = os.getenv("ADMIN_PASS", "adminpass")
+
+    client.environ_base["wsgi.url_scheme"] = "https"
+    with client:
+        login_response = login(client, admin_email, admin_pass)
+        assert login_response.status_code == 200
+        response = client.get("/items/recipe-cost-calculator", follow_redirects=True)
+        assert response.status_code == 200
+        page = response.get_data(as_text=True)
+        assert "Recipe Cost Calculator" in page
+        assert "Base Cost per Product" in page
+        assert "Recipe Calculator Test Item" in page
+
+
+def test_items_page_links_to_recipe_calculator(client, app):
+    with app.app_context():
+        _ensure_sample_item()
+
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@example.com")
+    admin_pass = os.getenv("ADMIN_PASS", "adminpass")
+
+    client.environ_base["wsgi.url_scheme"] = "https"
+    with client:
+        login_response = login(client, admin_email, admin_pass)
+        assert login_response.status_code == 200
+        response = client.get("/items", follow_redirects=True)
+        assert response.status_code == 200
+        page = response.get_data(as_text=True)
+        assert "/items/recipe-cost-calculator" in page
+        assert "Recipe Cost Calculator" in page


### PR DESCRIPTION
## Summary
- add a dedicated recipe cost calculator route that preloads item/unit data for the UI
- build a new items template with dynamic cost calculations and batch/yield summaries
- surface a shortcut button from the items list and cover the flow with request tests

## Testing
- pytest tests/test_item_recipe_calculator.py

------
https://chatgpt.com/codex/tasks/task_e_68da1189a9f4832494f958a12e5e8c06