### PR TITLE
Fix Alembic revision references

### DIFF
--- a/migrations/versions/202407171234_add_purchase_gl_code_to_location_stand_item.py
+++ b/migrations/versions/202407171234_add_purchase_gl_code_to_location_stand_item.py
@@ -29,7 +29,7 @@ def _has_fk(table_name: str, fk_name: str, bind) -> bool:
 
 
 # revision identifiers, used by Alembic.
-revision = "add_purchase_gl_code_to_location_stand_item"
+revision = "202407171234"
 down_revision = None
 branch_labels = None
 depends_on = None

--- a/migrations/versions/bbdaf2ebdf4c_add_indexes.py
+++ b/migrations/versions/bbdaf2ebdf4c_add_indexes.py
@@ -1,7 +1,7 @@
 """add indexes
 
 Revision ID: bbdaf2ebdf4c
-Revises: add_purchase_gl_code_to_location_stand_item
+Revises: 202407171234
 Create Date: 2025-09-06 05:37:39.070861
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "bbdaf2ebdf4c"
-down_revision = "add_purchase_gl_code_to_location_stand_item"
+down_revision = "202407171234"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- set the proper timestamp revision identifier for the purchase GL code migration
- update the add indexes migration to reference the corrected revision id

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da1caed21c83249ba183f62fea690f