### PR TITLE
Fix migration chain by updating indexes revision

### DIFF
--- a/migrations/versions/bbdaf2ebdf4c_add_indexes.py
+++ b/migrations/versions/bbdaf2ebdf4c_add_indexes.py
@@ -1,7 +1,7 @@
 """add indexes
 
 Revision ID: bbdaf2ebdf4c
-Revises: 202407171234
+Revises: 202408010001
 Create Date: 2025-09-06 05:37:39.070861
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "bbdaf2ebdf4c"
-down_revision = "202407171234"
+down_revision = "202408010001"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
- update the `bbdaf2ebdf4c_add_indexes` migration to depend on the preceding recipe yield migration
- ensure the Alembic history forms a single linear chain to avoid multiple heads

## Testing
- `alembic -c migrations/alembic.ini heads` *(fails: No 'script_location' key found in configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68da1dc8b1f88324a11b21bcbfba63a1