### PR TITLE
Fix recipe cost calculator inline script CSP violation

### DIFF
--- a/app/templates/items/recipe_calculator.html
+++ b/app/templates/items/recipe_calculator.html
@@ -56,7 +56,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="{{ csp_nonce }}">
 (function () {
     const ITEMS = {{ items|tojson }};
     const HAS_ITEMS = Array.isArray(ITEMS) && ITEMS.length > 0;


### PR DESCRIPTION
## Summary
- allow the recipe cost calculator inline script to run under the CSP by including the generated nonce

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da1f30904483249e3e80834b406367