### PR TITLE
Improve recipe cost calculator layout

### DIFF
--- a/app/templates/items/recipe_calculator.html
+++ b/app/templates/items/recipe_calculator.html
@@ -79,6 +79,16 @@
         return `$${value.toFixed(2)}`;
     }
 
+    function refreshColumnHeaders() {
+        const rows = recipeContainer.querySelectorAll('.recipe-row');
+        rows.forEach((row, index) => {
+            const showHeaders = index === 0;
+            row.querySelectorAll('.column-label').forEach((label) => {
+                label.classList.toggle('visually-hidden', !showHeaders);
+            });
+        });
+    }
+
     function updateTotals() {
         let total = 0;
         document.querySelectorAll('.recipe-row').forEach((row) => {
@@ -190,24 +200,27 @@
         const row = document.createElement('div');
         row.className = 'recipe-row row g-3 align-items-end mb-3';
         row.innerHTML = `
-            <div class="col-md-4">
-                <label class="form-label">Item</label>
+            <div class="col-12 col-md-6 col-lg-4">
+                <label class="form-label column-label">Item</label>
                 <select class="form-select item-select">${ITEM_OPTIONS_HTML}</select>
             </div>
-            <div class="col-md-3">
-                <label class="form-label">Unit of Measure</label>
+            <div class="col-12 col-md-6 col-lg-3">
+                <label class="form-label column-label">Unit of Measure</label>
                 <select class="form-select unit-select" disabled><option value="">Select a unit</option></select>
-                <div class="form-text">Unit Cost: <span class="unit-cost">$0.00</span></div>
             </div>
-            <div class="col-md-2">
-                <label class="form-label">Quantity</label>
+            <div class="col-6 col-md-4 col-lg-2">
+                <label class="form-label column-label">Quantity</label>
                 <input type="number" min="0" step="0.0001" value="1" class="form-control quantity-input">
             </div>
-            <div class="col-md-2">
-                <div class="form-label">Line Cost</div>
+            <div class="col-6 col-md-4 col-lg-1">
+                <div class="form-label column-label">Unit Cost</div>
+                <div class="fw-semibold unit-cost">$0.00</div>
+            </div>
+            <div class="col-6 col-md-4 col-lg-1">
+                <div class="form-label column-label">Line Cost</div>
                 <div class="fw-semibold line-cost">$0.00</div>
             </div>
-            <div class="col-md-1 text-md-end">
+            <div class="col-6 col-md-12 col-lg-1 text-lg-end align-self-center">
                 <button type="button" class="btn btn-outline-danger btn-sm remove-row">Remove</button>
             </div>
         `;
@@ -239,10 +252,12 @@
                 addRow();
             } else {
                 updateTotals();
+                refreshColumnHeaders();
             }
         });
 
         recipeContainer.appendChild(row);
+        refreshColumnHeaders();
         updateTotals();
         return row;
     }


### PR DESCRIPTION
## Summary
- align the recipe calculator row layout so each field lines up and unit cost displays beside line cost
- limit column headers to the first row by toggling visibility when rows are added or removed
- keep totals accurate after row changes by updating headers and costs together

## Testing
- pytest *(fails: test_bulk_stand_sheets_render_multiple_pages expects two "Opening Standsheet" sections but only one is rendered in the test fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68da20f3781883248c57a02b13a4ce46