### PR TITLE
Enable editing event details from event pages

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -156,7 +156,12 @@ def view_event(event_id):
     ev = db.session.get(Event, event_id)
     if ev is None:
         abort(404)
-    return render_template("events/view_event.html", event=ev)
+    type_labels = dict(EVENT_TYPES)
+    return render_template(
+        "events/view_event.html",
+        event=ev,
+        event_type_label=type_labels.get(ev.event_type, ev.event_type),
+    )
 
 
 @event.route("/events/<int:event_id>/add_location", methods=["GET", "POST"])

--- a/app/templates/events/_event_row.html
+++ b/app/templates/events/_event_row.html
@@ -4,5 +4,9 @@
     <td class="col-event-start">{{ e.start_date }}</td>
     <td class="col-event-end">{{ e.end_date }}</td>
     <td class="col-event-closed">{{ 'Yes' if e.closed else 'No' }}</td>
-    <td class="col-event-actions"><a href="{{ url_for('event.view_event', event_id=e.id) }}">View</a></td>
+    <td class="col-event-actions">
+        <a href="{{ url_for('event.view_event', event_id=e.id) }}">View</a>
+        |
+        <a href="{{ url_for('event.edit_event', event_id=e.id) }}">Edit</a>
+    </td>
 </tr>

--- a/app/templates/events/edit_event.html
+++ b/app/templates/events/edit_event.html
@@ -1,12 +1,12 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Create Event</h2>
+<h2>Edit Event</h2>
 <form method="post">
     {{ form.csrf_token }}
     {{ form.name.label }} {{ form.name(class='form-control') }}
     {{ form.start_date.label }} {{ form.start_date(class='form-control') }}
     {{ form.end_date.label }} {{ form.end_date(class='form-control') }}
     {{ form.event_type.label }} {{ form.event_type(class='form-control') }}
-    {{ form.submit(class='btn btn-primary mt-2') }}
+    {{ form.submit(class='btn btn-primary mt-2', value='Update Event') }}
 </form>
 {% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -2,8 +2,17 @@
 {% block content %}
 {% set unconfirmed_count = event.locations | selectattr('confirmed', 'equalto', False) | list | length %}
 <div class="container mt-4">
-    <h2>{{ event.name }}</h2>
-    <p>Start: {{ event.start_date }} End: {{ event.end_date }}</p>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
+        <div>
+            <h2 class="mb-1">{{ event.name }}</h2>
+            <p class="mb-0">Start: {{ event.start_date }} | End: {{ event.end_date }}</p>
+            <p class="mb-0">Type: {{ event_type_label }}</p>
+        </div>
+        <div class="text-md-end">
+            <a class="btn btn-secondary" href="{{ url_for('event.edit_event', event_id=event.id) }}">Edit Event</a>
+        </div>
+    </div>
+    <hr>
     <div class="mb-3">
         {% if not event.closed %}
         <a class="btn btn-primary me-2" href="{{ url_for('event.add_location', event_id=event.id) }}">Add Location</a>


### PR DESCRIPTION
## Summary
- add an Edit action to the events list so users can reach the update form
- show event type details with an Edit button on the event page for quick access
- retitle the edit form and adjust the submit button to reflect updating an event

## Testing
- pytest tests/events -q

------
https://chatgpt.com/codex/tasks/task_e_68da2406800c8324907b78c65f1fd5b1