### PR TITLE
Allow purchase cost forecast to filter by purchase GL codes

### DIFF
--- a/app/templates/purchase_orders/view_purchase_orders.html
+++ b/app/templates/purchase_orders/view_purchase_orders.html
@@ -8,6 +8,9 @@
             <a class="btn btn-outline-primary mb-3 ms-2" href="{{ url_for('purchase.purchase_order_recommendations') }}">
                 View Recommendations
             </a>
+            <a class="btn btn-outline-secondary mb-3 ms-2" href="{{ url_for('report.purchase_cost_forecast') }}">
+                Forecast Purchase Costs
+            </a>
         </div>
         <div class="col-auto text-end">
             <div class="dropdown d-inline-block mb-3 me-2" data-column-visibility data-table-id="purchase-orders-table" data-storage-key="purchaseOrderTableColumnVisibility">

--- a/app/templates/report_purchase_cost_forecast.html
+++ b/app/templates/report_purchase_cost_forecast.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="container mt-4">
+    <h2>Purchase Cost Forecast</h2>
+    <p class="text-muted">Estimate the cost of replenishing inventory over a chosen future period using recent consumption trends.</p>
+    <form method="POST" class="row gy-3 align-items-end">
+        {{ form.hidden_tag() }}
+        <div class="col-md-3">
+            <label class="form-label" for="forecastPeriod">{{ form.forecast_period.label.text }}</label>
+            {{ form.forecast_period(class="form-select", id="forecastPeriod") }}
+        </div>
+        <div class="col-md-3">
+            <label class="form-label" for="locationSelect">{{ form.location_id.label.text }}</label>
+            {{ form.location_id(class="form-select", id="locationSelect") }}
+        </div>
+        <div class="col-md-3">
+            <label class="form-label" for="purchaseGlSelect">{{ form.purchase_gl_code_ids.label.text }}</label>
+            {{ form.purchase_gl_code_ids(class="form-select", id="purchaseGlSelect") }}
+            <div class="form-text">Hold Ctrl (Windows) or Command (Mac) to select multiple codes.</div>
+        </div>
+        <div class="col-md-3">
+            <label class="form-label" for="itemSelect">{{ form.item_id.label.text }}</label>
+            {{ form.item_id(class="form-select", id="itemSelect") }}
+        </div>
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary">{{ form.submit.label.text }}</button>
+        </div>
+    </form>
+
+    {% if report_rows is not none %}
+    <hr class="my-4">
+    {% if report_rows %}
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3">
+        <div>
+            <h4 class="mb-1">Forecast Results</h4>
+            <p class="mb-0 text-muted">History window: {{ lookback_days }} days &bull; Forecast window: {{ forecast_days }} days</p>
+        </div>
+        <div class="mt-3 mt-md-0">
+            <span class="fw-bold me-3">Total Quantity: {{ '%.2f'|format(totals.quantity) }}</span>
+            <span class="fw-bold">Total Cost: ${{ '%.2f'|format(totals.cost) }}</span>
+        </div>
+    </div>
+    <div class="table-responsive">
+        <table class="table table-striped table-bordered align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>Item</th>
+                    <th>Location</th>
+                    <th>Daily Consumption</th>
+                    <th>Daily Incoming</th>
+                    <th>Forecast Demand</th>
+                    <th>Forecast Incoming</th>
+                    <th>Net Quantity</th>
+                    <th>Unit Cost</th>
+                    <th>Projected Cost</th>
+                    <th>Last Activity</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in report_rows %}
+                <tr>
+                    <td>{{ row.item.name }}</td>
+                    <td>{{ row.location.name }}</td>
+                    <td>{{ '%.2f'|format(row.consumption_per_day) }}</td>
+                    <td>{{ '%.2f'|format(row.incoming_per_day) }}</td>
+                    <td>{{ '%.2f'|format(row.forecast_consumption) }}</td>
+                    <td>{{ '%.2f'|format(row.forecast_incoming) }}</td>
+                    <td>{{ '%.2f'|format(row.net_quantity) }}</td>
+                    <td>${{ '%.2f'|format(row.unit_cost) }}</td>
+                    <td>${{ '%.2f'|format(row.projected_cost) }}</td>
+                    <td>{{ row.last_activity.strftime('%Y-%m-%d') if row.last_activity else '—' }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    <div class="alert alert-info" role="alert">
+        No forecast data was available for the selected criteria. Try expanding the history window or choosing a different location or item.
+    </div>
+    {% endif %}
+    {% endif %}
+</div>
+{% endblock %}

--- a/app/utils/forecasting.py
+++ b/app/utils/forecasting.py
@@ -188,6 +188,7 @@ class DemandForecastingHelper:
         attendance_multiplier: float = 1.0,
         weather_multiplier: float = 1.0,
         promo_multiplier: float = 1.0,
+        purchase_gl_code_ids: Optional[Sequence[int]] = None,
     ) -> List[ForecastRecommendation]:
         """Return forecast recommendations for the supplied filters."""
 
@@ -278,6 +279,14 @@ class DemandForecastingHelper:
             location = locations.get(location_id)
             if item is None or location is None:
                 continue
+
+            if purchase_gl_code_ids:
+                effective_code = item.purchase_gl_code_for_location(location.id)
+                if (
+                    effective_code is None
+                    or effective_code.id not in purchase_gl_code_ids
+                ):
+                    continue
 
             base_consumption = history["sales_qty"] + history["transfer_out_qty"]
             adjusted_demand = base_consumption * multiplier


### PR DESCRIPTION
## Summary
- add a multi-select purchase GL code filter to the purchase cost forecast form and view
- plumb the selected GL codes through the reporting route and forecasting helper to limit recommendations
- cover the new filter path in the purchase cost forecast route test

## Testing
- pytest tests/test_report_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68da23114d6083249350bde5b4b76431