### PR TITLE
Add estimated sales tracking to events

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -681,6 +681,9 @@ class EventForm(FlaskForm):
     event_type = SelectField(
         "Event Type", choices=EVENT_TYPES, validators=[DataRequired()]
     )
+    estimated_sales = DecimalField(
+        "Estimated Sales", validators=[Optional(), NumberRange(min=0)], places=2
+    )
     submit = SubmitField("Submit")
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -633,6 +633,7 @@ class Event(db.Model):
     event_type = db.Column(
         db.String(20), nullable=False, default="other", server_default="other"
     )
+    estimated_sales = db.Column(db.Numeric(12, 2), nullable=True)
 
     locations = relationship(
         "EventLocation", back_populates="event", cascade="all, delete-orphan"

--- a/app/templates/events/_event_row.html
+++ b/app/templates/events/_event_row.html
@@ -3,6 +3,13 @@
     <td class="col-event-type">{{ type_labels.get(e.event_type, e.event_type) }}</td>
     <td class="col-event-start">{{ e.start_date }}</td>
     <td class="col-event-end">{{ e.end_date }}</td>
+    <td class="col-event-estimated-sales">
+        {% if e.estimated_sales is not none %}
+            ${{ '{:,.2f}'.format(e.estimated_sales) }}
+        {% else %}
+            —
+        {% endif %}
+    </td>
     <td class="col-event-closed">{{ 'Yes' if e.closed else 'No' }}</td>
     <td class="col-event-actions">
         <a href="{{ url_for('event.view_event', event_id=e.id) }}">View</a>

--- a/app/templates/events/bulk_count_sheets.html
+++ b/app/templates/events/bulk_count_sheets.html
@@ -10,7 +10,12 @@
 </style>
 <h2 class="no-print">Inventory Count Sheets - {{ event.name }}</h2>
 {% for block in data %}
-    <h4 class="mt-4">{{ block.location.name }}</h4>
+    <h4 class="mt-4">
+        {{ block.location.name }}
+        {% if block.page_count > 1 %}
+            <small class="text-muted">Page {{ block.page_number }} of {{ block.page_count }}</small>
+        {% endif %}
+    </h4>
     <div class="table-responsive">
     <table class="table table-bordered">
         <thead>

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -119,7 +119,12 @@
     <div class="generated">Generated {{ generated_at_local }}</div>
   </div>
   <div class="meta">
-    <div>Location: {{ entry.location.name }}</div>
+    <div>
+      Location: {{ entry.location.name }}
+      {% if entry.page_count > 1 %}
+        <span class="text-muted">(Page {{ entry.page_number }} of {{ entry.page_count }})</span>
+      {% endif %}
+    </div>
     <div>Event: {{ event.name }}</div>
     <div>Event Date/Time: {{ event.start_date|format_datetime('%-m/%-d/%Y %-I:%M %p') }}</div>
   </div>

--- a/app/templates/events/create_event.html
+++ b/app/templates/events/create_event.html
@@ -7,6 +7,7 @@
     {{ form.start_date.label }} {{ form.start_date(class='form-control') }}
     {{ form.end_date.label }} {{ form.end_date(class='form-control') }}
     {{ form.event_type.label }} {{ form.event_type(class='form-control') }}
+    {{ form.estimated_sales.label }} {{ form.estimated_sales(class='form-control', placeholder='Optional') }}
     {{ form.submit(class='btn btn-primary mt-2') }}
 </form>
 {% endblock %}

--- a/app/templates/events/edit_event.html
+++ b/app/templates/events/edit_event.html
@@ -7,6 +7,7 @@
     {{ form.start_date.label }} {{ form.start_date(class='form-control') }}
     {{ form.end_date.label }} {{ form.end_date(class='form-control') }}
     {{ form.event_type.label }} {{ form.event_type(class='form-control') }}
+    {{ form.estimated_sales.label }} {{ form.estimated_sales(class='form-control', placeholder='Optional') }}
     {{ form.submit(class='btn btn-primary mt-2', value='Update Event') }}
 </form>
 {% endblock %}

--- a/app/templates/events/view_event.html
+++ b/app/templates/events/view_event.html
@@ -7,6 +7,14 @@
             <h2 class="mb-1">{{ event.name }}</h2>
             <p class="mb-0">Start: {{ event.start_date }} | End: {{ event.end_date }}</p>
             <p class="mb-0">Type: {{ event_type_label }}</p>
+            <p class="mb-0">
+                Estimated Sales:
+                {% if event.estimated_sales is not none %}
+                    ${{ '{:,.2f}'.format(event.estimated_sales) }}
+                {% else %}
+                    Not set
+                {% endif %}
+            </p>
         </div>
         <div class="text-md-end">
             <a class="btn btn-secondary" href="{{ url_for('event.edit_event', event_id=event.id) }}">Edit Event</a>

--- a/app/templates/events/view_events.html
+++ b/app/templates/events/view_events.html
@@ -16,6 +16,7 @@
                 {'id': 'toggle-event-type', 'target': 'col-event-type', 'label': 'Type', 'checked': True},
                 {'id': 'toggle-event-start', 'target': 'col-event-start', 'label': 'Start', 'checked': True},
                 {'id': 'toggle-event-end', 'target': 'col-event-end', 'label': 'End', 'checked': True},
+                {'id': 'toggle-event-estimated-sales', 'target': 'col-event-estimated-sales', 'label': 'Estimated Sales', 'checked': True},
                 {'id': 'toggle-event-closed', 'target': 'col-event-closed', 'label': 'Closed', 'checked': True},
                 {'id': 'toggle-event-actions', 'target': 'col-event-actions', 'label': 'Actions', 'checked': True},
             ]
@@ -30,6 +31,7 @@
             <th scope="col" class="col-event-type">Type</th>
             <th scope="col" class="col-event-start">Start</th>
             <th scope="col" class="col-event-end">End</th>
+            <th scope="col" class="col-event-estimated-sales">Estimated Sales</th>
             <th scope="col" class="col-event-closed">Closed</th>
             <th scope="col" class="col-event-actions">Actions</th>
         </tr>
@@ -81,6 +83,7 @@
           {{ create_form.start_date.label }} {{ create_form.start_date(class='form-control') }}
           {{ create_form.end_date.label }} {{ create_form.end_date(class='form-control') }}
           {{ create_form.event_type.label }} {{ create_form.event_type(class='form-control') }}
+          {{ create_form.estimated_sales.label }} {{ create_form.estimated_sales(class='form-control', placeholder='Optional') }}
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-primary">Create</button>

--- a/migrations/versions/1f2e3d4c5b6a_add_estimated_sales_to_event.py
+++ b/migrations/versions/1f2e3d4c5b6a_add_estimated_sales_to_event.py
@@ -1,0 +1,52 @@
+"""add estimated sales to event
+
+Revision ID: 1f2e3d4c5b6a
+Revises: c4d5e6f7a8b9
+Create Date: 2025-10-15 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def _has_column(table_name: str, column_name: str, bind) -> bool:
+    """Return True if the given table already has the specified column."""
+
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table_name):
+        return False
+    return column_name in {
+        column["name"] for column in inspector.get_columns(table_name)
+    }
+
+
+# revision identifiers, used by Alembic.
+revision = "1f2e3d4c5b6a"
+down_revision = "c4d5e6f7a8b9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    table = "event"
+    column = "estimated_sales"
+
+    if _has_column(table, column, bind):
+        return
+
+    with op.batch_alter_table(table, recreate="always") as batch_op:
+        batch_op.add_column(sa.Column(column, sa.Numeric(12, 2), nullable=True))
+
+
+def downgrade():
+    bind = op.get_bind()
+    table = "event"
+    column = "estimated_sales"
+
+    if not _has_column(table, column, bind):
+        return
+
+    with op.batch_alter_table(table, recreate="always") as batch_op:
+        batch_op.drop_column(column)


### PR DESCRIPTION
## Summary
- add an optional estimated sales value to events with database migration, form support, and create/edit views
- surface estimated sales in event listings and detail pages
- paginate stand/count sheet exports so long item lists render across multiple pages while displaying page indicators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da250dfe54832494c930b5850d9403