### PR TITLE
Add advanced filtering options to events list

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -44,22 +44,80 @@ from app.utils.activity import log_activity
 event = Blueprint("event", __name__)
 
 
+def _parse_date(value):
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def _get_event_filters(source):
+    return {
+        "type": (source.get("type") or "").strip(),
+        "name_contains": (source.get("name_contains") or "").strip(),
+        "name_not_contains": (source.get("name_not_contains") or "").strip(),
+        "start_date_from": (source.get("start_date_from") or "").strip(),
+        "start_date_to": (source.get("start_date_to") or "").strip(),
+        "end_date_from": (source.get("end_date_from") or "").strip(),
+        "end_date_to": (source.get("end_date_to") or "").strip(),
+        "closed_status": (source.get("closed_status") or "").strip(),
+    }
+
+
+def _apply_event_filters(query, filters):
+    event_type = filters.get("type")
+    if event_type:
+        query = query.filter_by(event_type=event_type)
+
+    name_contains = filters.get("name_contains")
+    if name_contains:
+        query = query.filter(Event.name.ilike(f"%{name_contains}%"))
+
+    name_not_contains = filters.get("name_not_contains")
+    if name_not_contains:
+        query = query.filter(~Event.name.ilike(f"%{name_not_contains}%"))
+
+    start_date_from = _parse_date(filters.get("start_date_from"))
+    if start_date_from:
+        query = query.filter(Event.start_date >= start_date_from)
+
+    start_date_to = _parse_date(filters.get("start_date_to"))
+    if start_date_to:
+        query = query.filter(Event.start_date <= start_date_to)
+
+    end_date_from = _parse_date(filters.get("end_date_from"))
+    if end_date_from:
+        query = query.filter(Event.end_date >= end_date_from)
+
+    end_date_to = _parse_date(filters.get("end_date_to"))
+    if end_date_to:
+        query = query.filter(Event.end_date <= end_date_to)
+
+    closed_status = filters.get("closed_status")
+    if closed_status == "open":
+        query = query.filter(Event.closed.is_(False))
+    elif closed_status == "closed":
+        query = query.filter(Event.closed.is_(True))
+
+    return query
+
+
 @event.route("/events")
 @login_required
 def view_events():
-    event_type = request.args.get("type")
-    query = Event.query
-    if event_type:
-        query = query.filter_by(event_type=event_type)
+    filters = _get_event_filters(request.args)
+    query = _apply_event_filters(Event.query, filters)
     events = query.all()
     create_form = EventForm()
     return render_template(
         "events/view_events.html",
         events=events,
-        event_type=event_type,
         event_types=EVENT_TYPES,
         type_labels=dict(EVENT_TYPES),
         create_form=create_form,
+        filter_values=filters,
     )
 
 
@@ -85,11 +143,8 @@ def create_event():
 @event.route("/events/filter", methods=["POST"])
 @login_required
 def filter_events_ajax():
-    event_type = request.form.get("type")
-    query = Event.query
-    if event_type:
-        query = query.filter_by(event_type=event_type)
-    events = query.all()
+    filters = _get_event_filters(request.form)
+    events = _apply_event_filters(Event.query, filters).all()
     return render_template(
         "events/_events_table.html",
         events=events,

--- a/app/templates/events/view_events.html
+++ b/app/templates/events/view_events.html
@@ -51,12 +51,51 @@
       <form id="filterForm">
         <div class="modal-body">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
-            <select name="type" class="form-control">
-                <option value="">All Types</option>
-                {% for val, label in event_types %}
-                    <option value="{{ val }}">{{ label }}</option>
-                {% endfor %}
-            </select>
+            <div class="mb-3">
+                <label for="filter-type" class="form-label">Event Type</label>
+                <select name="type" id="filter-type" class="form-control">
+                    <option value="">All Types</option>
+                    {% for val, label in event_types %}
+                        <option value="{{ val }}" {% if filter_values.type == val %}selected{% endif %}>{{ label }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="mb-3">
+                <label for="filter-name-contains" class="form-label">Name Contains</label>
+                <input type="text" name="name_contains" id="filter-name-contains" class="form-control" value="{{ filter_values.name_contains }}" placeholder="e.g. Summer" />
+            </div>
+            <div class="mb-3">
+                <label for="filter-name-not-contains" class="form-label">Name Does Not Contain</label>
+                <input type="text" name="name_not_contains" id="filter-name-not-contains" class="form-control" value="{{ filter_values.name_not_contains }}" placeholder="e.g. Test" />
+            </div>
+            <div class="row g-2 mb-3">
+                <div class="col-sm-6">
+                    <label for="filter-start-date-from" class="form-label">Start Date From</label>
+                    <input type="date" name="start_date_from" id="filter-start-date-from" class="form-control" value="{{ filter_values.start_date_from }}" />
+                </div>
+                <div class="col-sm-6">
+                    <label for="filter-start-date-to" class="form-label">Start Date To</label>
+                    <input type="date" name="start_date_to" id="filter-start-date-to" class="form-control" value="{{ filter_values.start_date_to }}" />
+                </div>
+            </div>
+            <div class="row g-2 mb-3">
+                <div class="col-sm-6">
+                    <label for="filter-end-date-from" class="form-label">End Date From</label>
+                    <input type="date" name="end_date_from" id="filter-end-date-from" class="form-control" value="{{ filter_values.end_date_from }}" />
+                </div>
+                <div class="col-sm-6">
+                    <label for="filter-end-date-to" class="form-label">End Date To</label>
+                    <input type="date" name="end_date_to" id="filter-end-date-to" class="form-control" value="{{ filter_values.end_date_to }}" />
+                </div>
+            </div>
+            <div class="mb-3">
+                <label for="filter-closed-status" class="form-label">Status</label>
+                <select name="closed_status" id="filter-closed-status" class="form-control">
+                    <option value="" {% if not filter_values.closed_status %}selected{% endif %}>All</option>
+                    <option value="open" {% if filter_values.closed_status == 'open' %}selected{% endif %}>Open</option>
+                    <option value="closed" {% if filter_values.closed_status == 'closed' %}selected{% endif %}>Closed</option>
+                </select>
+            </div>
         </div>
         <div class="modal-footer">
             <button type="submit" class="btn btn-primary">Apply</button>


### PR DESCRIPTION
## Summary
- add reusable helpers to apply advanced filtering to the events query
- extend the events filter modal with text, date range, and status inputs

## Testing
- pytest tests/events/test_sustainability_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68da27fe5ac8832492c4ccc73670ee1d