### PR TITLE
Add link to forecasted stock item sales report from items page

### DIFF
--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -7,6 +7,7 @@
         <div class="col-auto d-flex flex-wrap gap-2">
             <a href="{{ url_for('item.add_item') }}" class="btn btn-primary mb-3" id="createItemBtn">Add New Item</a>
             <a href="{{ url_for('item.recipe_cost_calculator') }}" class="btn btn-outline-primary mb-3" id="recipeCostCalculatorBtn">Recipe Cost Calculator</a>
+            <a href="{{ url_for('report.purchase_cost_forecast') }}" class="btn btn-outline-primary mb-3" id="forecastedStockItemSalesBtn">Forecasted Stock Item Sales</a>
         </div>
         <div class="col-auto">
             <div class="dropdown d-inline-block mb-3 me-2" data-column-visibility data-table-id="itemsTable" data-storage-key="itemsTableColumnVisibility">

--- a/tests/test_items_forecast_link.py
+++ b/tests/test_items_forecast_link.py
@@ -1,0 +1,31 @@
+from werkzeug.security import generate_password_hash
+
+from app import db
+from app.models import Item, User
+from tests.utils import login
+
+
+def _prepare_items(app):
+    with app.app_context():
+        user = User(
+            email="forecast-link@example.com",
+            password=generate_password_hash("pass"),
+            active=True,
+        )
+        db.session.add(user)
+        db.session.add(Item(name="Widget", base_unit="each"))
+        db.session.commit()
+        return user.email
+
+
+def test_items_page_includes_forecast_report_link(client, app):
+    email = _prepare_items(app)
+
+    with client:
+        login(client, email, "pass")
+
+        resp = client.get("/items")
+
+        assert resp.status_code == 200
+        assert b"/reports/purchase-cost-forecast" in resp.data
+        assert b"Forecasted Stock Item Sales" in resp.data


### PR DESCRIPTION
## Summary
- add a button on the items list for the forecasted stock item sales report
- add a regression test to verify the link is rendered for authenticated users

## Testing
- pytest tests/test_items_forecast_link.py

------
https://chatgpt.com/codex/tasks/task_e_68da2e9f62548324a08ec251893714fa