### PR TITLE
Add filter summary to purchase inventory report

### DIFF
--- a/app/routes/report_routes.py
+++ b/app/routes/report_routes.py
@@ -170,6 +170,8 @@ def purchase_inventory_summary():
     totals = None
     start = None
     end = None
+    selected_item_names = []
+    selected_gl_labels = []
 
     if form.validate_on_submit():
         start = form.start_date.data
@@ -271,6 +273,21 @@ def purchase_inventory_summary():
                 "spend": sum(row["total_spend"] for row in results),
             }
 
+            selected_item_ids = set(form.items.data or [])
+            if selected_item_ids:
+                selected_item_names = [
+                    label
+                    for value, label in form.items.choices
+                    if value in selected_item_ids
+                ]
+
+            if selected_gl_codes:
+                selected_gl_labels = [
+                    label
+                    for value, label in form.gl_codes.choices
+                    if value in selected_gl_codes
+                ]
+
     return render_template(
         "report_purchase_inventory_summary.html",
         form=form,
@@ -278,6 +295,8 @@ def purchase_inventory_summary():
         totals=totals,
         start=start,
         end=end,
+        selected_item_names=selected_item_names,
+        selected_gl_labels=selected_gl_labels,
     )
 
 

--- a/app/templates/report_purchase_inventory_summary.html
+++ b/app/templates/report_purchase_inventory_summary.html
@@ -56,6 +56,19 @@
         </div>
 
         {% if results %}
+        {% if selected_item_names or selected_gl_labels %}
+        <div class="alert alert-secondary" role="status">
+            <div class="fw-semibold">Filters Applied</div>
+            <ul class="mb-0 small">
+                {% if selected_item_names %}
+                <li><span class="fw-semibold">Items:</span> {{ selected_item_names | join(', ') }}</li>
+                {% endif %}
+                {% if selected_gl_labels %}
+                <li><span class="fw-semibold">GL Codes:</span> {{ selected_gl_labels | join(', ') }}</li>
+                {% endif %}
+            </ul>
+        </div>
+        {% endif %}
         <div class="table-responsive">
             <table class="table table-bordered table-striped align-middle">
                 <thead class="table-light">


### PR DESCRIPTION
## Summary
- surface the selected item and GL code filters on the purchase inventory summary page
- expose the filter labels from the report route so users can verify the applied criteria

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dac68eaa00832489798be5980df9b6