### PR TITLE
Add purchase inventory summary link to invoice page

### DIFF
--- a/app/routes/report_routes.py
+++ b/app/routes/report_routes.py
@@ -170,6 +170,8 @@ def purchase_inventory_summary():
     totals = None
     start = None
     end = None
+    selected_item_names = []
+    selected_gl_labels = []
 
     if form.validate_on_submit():
         start = form.start_date.data
@@ -271,6 +273,21 @@ def purchase_inventory_summary():
                 "spend": sum(row["total_spend"] for row in results),
             }
 
+            selected_item_ids = set(form.items.data or [])
+            if selected_item_ids:
+                selected_item_names = [
+                    label
+                    for value, label in form.items.choices
+                    if value in selected_item_ids
+                ]
+
+            if selected_gl_codes:
+                selected_gl_labels = [
+                    label
+                    for value, label in form.gl_codes.choices
+                    if value in selected_gl_codes
+                ]
+
     return render_template(
         "report_purchase_inventory_summary.html",
         form=form,
@@ -278,6 +295,8 @@ def purchase_inventory_summary():
         totals=totals,
         start=start,
         end=end,
+        selected_item_names=selected_item_names,
+        selected_gl_labels=selected_gl_labels,
     )
 
 

--- a/app/templates/purchase_invoices/view_purchase_invoice.html
+++ b/app/templates/purchase_invoices/view_purchase_invoice.html
@@ -3,7 +3,12 @@
 <div class="container mt-4">
     <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3 gap-2">
         <h2 class="mb-0">Invoice {{ invoice.id }}</h2>
-        <a class="btn btn-outline-secondary" href="{{ url_for('notes.entity_notes', entity_type='purchase_invoice', entity_id=invoice.id) }}">View Notes</a>
+        <div class="d-flex flex-column flex-sm-row gap-2">
+            <a class="btn btn-secondary" href="{{ url_for('report.purchase_inventory_summary') }}">
+                Purchase Inventory Summary Report
+            </a>
+            <a class="btn btn-outline-secondary" href="{{ url_for('notes.entity_notes', entity_type='purchase_invoice', entity_id=invoice.id) }}">View Notes</a>
+        </div>
     </div>
     <p>Purchase Order: {{ invoice.purchase_order_id }}</p>
     <p>Vendor: {{ invoice.purchase_order.vendor.first_name }} {{ invoice.purchase_order.vendor.last_name }}</p>

--- a/app/templates/report_purchase_inventory_summary.html
+++ b/app/templates/report_purchase_inventory_summary.html
@@ -56,6 +56,19 @@
         </div>
 
         {% if results %}
+        {% if selected_item_names or selected_gl_labels %}
+        <div class="alert alert-secondary" role="status">
+            <div class="fw-semibold">Filters Applied</div>
+            <ul class="mb-0 small">
+                {% if selected_item_names %}
+                <li><span class="fw-semibold">Items:</span> {{ selected_item_names | join(', ') }}</li>
+                {% endif %}
+                {% if selected_gl_labels %}
+                <li><span class="fw-semibold">GL Codes:</span> {{ selected_gl_labels | join(', ') }}</li>
+                {% endif %}
+            </ul>
+        </div>
+        {% endif %}
         <div class="table-responsive">
             <table class="table table-bordered table-striped align-middle">
                 <thead class="table-light">


### PR DESCRIPTION
## Summary
- add a purchase inventory summary report button to the purchase invoice detail header

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dac68eaa00832489798be5980df9b6