### PR TITLE
Add dedicated purchased items report

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -614,6 +614,12 @@ class ProductSalesReportForm(FlaskForm):
     submit = SubmitField("Generate Report")
 
 
+class PurchasedItemsReportForm(FlaskForm):
+    start_date = DateField("Start Date", validators=[DataRequired()])
+    end_date = DateField("End Date", validators=[DataRequired()])
+    submit = SubmitField("Generate Report")
+
+
 class ProductRecipeReportForm(FlaskForm):
     products = SelectMultipleField(
         "Products",

--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -13,6 +13,7 @@
             <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createInvoiceModal">Create Invoice</button>
             <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#filterModal">Filter</button>
             <a href="{{ url_for('report.vendor_invoice_report') }}" class="btn btn-secondary mb-3">Vendor Report</a>
+            <a href="{{ url_for('report.purchased_items_report') }}" class="btn btn-secondary mb-3">Purchased Items Report</a>
             <a href="{{ url_for('report.product_sales_report') }}" class="btn btn-secondary mb-3">Revenue Report</a>
         </div>
         <div class="col-auto text-end">

--- a/app/templates/report_purchased_items.html
+++ b/app/templates/report_purchased_items.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container mt-5">
+    <h2>Purchased Items Report</h2>
+    <p class="text-muted">Review all items received on purchase invoices within a selected date range.</p>
+    <form method="POST" class="mb-4">
+        {{ form.hidden_tag() }}
+        <div class="row g-3">
+            <div class="col-md-6">
+                {{ form.start_date.label(class="form-label") }}
+                {{ form.start_date(class="form-control") }}
+                {% if form.start_date.errors %}
+                    <div class="text-danger small">{{ form.start_date.errors[0] }}</div>
+                {% endif %}
+            </div>
+            <div class="col-md-6">
+                {{ form.end_date.label(class="form-label") }}
+                {{ form.end_date(class="form-control") }}
+                {% if form.end_date.errors %}
+                    <div class="text-danger small">{{ form.end_date.errors[0] }}</div>
+                {% endif %}
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary mt-3">Generate Report</button>
+    </form>
+
+    {% if purchases is not none %}
+        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+            <h3 class="mb-0">Report Results</h3>
+            {% if start and end %}
+            <span class="text-muted">{{ start.strftime('%Y-%m-%d') }} to {{ end.strftime('%Y-%m-%d') }}</span>
+            {% endif %}
+        </div>
+
+        {% if purchases %}
+        <div class="table-responsive">
+            <table class="table table-bordered table-striped align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th scope="col">Item</th>
+                        <th scope="col" class="text-end">Total Quantity</th>
+                        <th scope="col" class="text-end">Amount Spent</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in purchases %}
+                    <tr>
+                        <td>{{ row.item_name }}</td>
+                        <td class="text-end">{{ '%.2f'|format(row.total_quantity) }}{% if row.unit_name %} {{ row.unit_name }}{% endif %}</td>
+                        <td class="text-end">${{ '%.2f'|format(row.total_spend) }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                <tfoot>
+                    <tr>
+                        <th class="text-end">Totals</th>
+                        <th class="text-end">{{ '%.2f'|format(totals.quantity) }}</th>
+                        <th class="text-end">${{ '%.2f'|format(totals.spend) }}</th>
+                    </tr>
+                </tfoot>
+            </table>
+        </div>
+        {% else %}
+        <div class="alert alert-info" role="alert">
+            No purchase invoice items were found for the selected date range.
+        </div>
+        {% endif %}
+    {% endif %}
+</div>
+{% endblock %}

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -244,8 +244,9 @@ that developers should keep in mind when working on or extending the routes.
 - **Blueprint name and prefix:** `report` (no additional prefix).
 - **Primary endpoints:**
   - `/reports/vendor-invoices`, `/reports/received-invoices`,
-    `/reports/product-sales`, `/reports/product-recipes`, and
-    `/reports/product-location-sales` each expose a GET/POST form for selecting
+    `/reports/purchased-items`, `/reports/product-sales`,
+    `/reports/product-recipes`, and `/reports/product-location-sales` each
+    expose a GET/POST form for selecting
     filters and redirect to result views when submitted.
   - Result routes (e.g. `/reports/vendor-invoices/results`) compute aggregates
     based on the selected criteria.


### PR DESCRIPTION
## Summary
- add a simple date range form dedicated to purchased items
- expose the new /reports/purchased-items route, template, and navigation link
- document the endpoint and cover it with a report routes test

## Testing
- pytest tests/test_report_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68dacdc652b08324a17c2ae6ef34e3fc