### PR TITLE
Add total cost to product sales report

### DIFF
--- a/app/routes/report_routes.py
+++ b/app/routes/report_routes.py
@@ -363,16 +363,19 @@ def product_sales_report():
             total_quantity = 0.0
             total_revenue = 0.0
             total_profit = 0.0
+            total_cost = 0.0
 
             for product_row in products:
                 quantity = float(product_row.total_quantity or 0.0)
                 cost = float(product_row.cost or 0.0)
                 price = float(product_row.price or 0.0)
                 profit_each = price - cost
+                total_item_cost = quantity * cost
                 revenue = quantity * price
                 profit = quantity * profit_each
 
                 total_quantity += quantity
+                total_cost += total_item_cost
                 total_revenue += revenue
                 total_profit += profit
 
@@ -383,6 +386,7 @@ def product_sales_report():
                         "quantity": quantity,
                         "cost": cost,
                         "price": price,
+                        "total_cost": total_item_cost,
                         "profit_each": profit_each,
                         "revenue": revenue,
                         "profit": profit,
@@ -391,6 +395,7 @@ def product_sales_report():
 
             totals = {
                 "quantity": total_quantity,
+                "cost": total_cost,
                 "revenue": total_revenue,
                 "profit": total_profit,
             }

--- a/app/templates/report_product_sales.html
+++ b/app/templates/report_product_sales.html
@@ -84,6 +84,7 @@
                         <th scope="col" class="text-end">Quantity Sold</th>
                         <th scope="col" class="text-end">Cost (each)</th>
                         <th scope="col" class="text-end">Price (each)</th>
+                        <th scope="col" class="text-end">Total Cost</th>
                         <th scope="col" class="text-end">Profit per Item</th>
                         <th scope="col" class="text-end">Total Revenue</th>
                         <th scope="col" class="text-end">Total Profit</th>
@@ -96,6 +97,7 @@
                         <td class="text-end">{{ '%.2f'|format(row.quantity) }}</td>
                         <td class="text-end">${{ '%.2f'|format(row.cost) }}</td>
                         <td class="text-end">${{ '%.2f'|format(row.price) }}</td>
+                        <td class="text-end">${{ '%.2f'|format(row.total_cost) }}</td>
                         <td class="text-end">${{ '%.2f'|format(row.profit_each) }}</td>
                         <td class="text-end">${{ '%.2f'|format(row.revenue) }}</td>
                         <td class="text-end">${{ '%.2f'|format(row.profit) }}</td>
@@ -109,6 +111,7 @@
                         <td class="text-end">{{ '%.2f'|format(totals.quantity) }}</td>
                         <td></td>
                         <td></td>
+                        <td class="text-end">${{ '%.2f'|format(totals.cost) }}</td>
                         <td></td>
                         <td class="text-end">${{ '%.2f'|format(totals.revenue) }}</td>
                         <td class="text-end">${{ '%.2f'|format(totals.profit) }}</td>


### PR DESCRIPTION
## Summary
- calculate the total cost of items sold when building the product sales report
- expose the new total cost field in the HTML table and include it in the totals row

## Testing
- pytest tests/test_report_routes.py -q

------
https://chatgpt.com/codex/tasks/task_e_68daf05254a88324a7872d61e821ab3a