### PR TITLE
Add product stock usage report

### DIFF
--- a/app/templates/invoices/view_invoices.html
+++ b/app/templates/invoices/view_invoices.html
@@ -15,6 +15,7 @@
             <a href="{{ url_for('report.vendor_invoice_report') }}" class="btn btn-secondary mb-3">Vendor Report</a>
             <a href="{{ url_for('report.purchase_inventory_summary') }}" class="btn btn-secondary mb-3">Purchase Inventory Summary</a>
             <a href="{{ url_for('report.product_sales_report') }}" class="btn btn-secondary mb-3">Revenue Report</a>
+            <a href="{{ url_for('report.product_stock_usage_report') }}" class="btn btn-secondary mb-3">Stock Usage Report</a>
         </div>
         <div class="col-auto text-end">
             {{ column_visibility_dropdown(

--- a/app/templates/products/view_products.html
+++ b/app/templates/products/view_products.html
@@ -10,6 +10,7 @@
             <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#createProductModal">Create Product</button>
             <a href="{{ url_for('report.product_recipe_report') }}" class="btn btn-secondary mb-3">Recipe Report</a>
             <a href="{{ url_for('report.product_sales_report') }}" class="btn btn-secondary mb-3">Revenue Report</a>
+            <a href="{{ url_for('report.product_stock_usage_report') }}" class="btn btn-secondary mb-3">Stock Usage Report</a>
             <button type="submit" class="btn btn-warning mb-3" form="bulk-cost-form">Set Cost From Recipe</button>
         </div>
         <div class="col-auto text-end">

--- a/app/templates/report_product_stock_usage.html
+++ b/app/templates/report_product_stock_usage.html
@@ -1,0 +1,121 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container mt-5">
+    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+        <h2 class="mb-0">Product Stock Usage Report</h2>
+        <a class="btn btn-outline-secondary" href="{{ url_for('invoice.view_invoices') }}">Back to Invoices</a>
+    </div>
+    <p class="text-muted">Review the inventory items that were consumed through product sales over the selected period. Use the filters to focus on specific products or sales GL codes.</p>
+
+    <form method="POST" class="mb-4">
+        {{ form.hidden_tag() }}
+        <div class="row g-3">
+            <div class="col-md-6">
+                {{ form.start_date.label(class="form-label") }}
+                {{ form.start_date(class="form-control") }}
+                {% if form.start_date.errors %}
+                    <div class="text-danger small">{{ form.start_date.errors[0] }}</div>
+                {% endif %}
+            </div>
+            <div class="col-md-6">
+                {{ form.end_date.label(class="form-label") }}
+                {{ form.end_date(class="form-control") }}
+                {% if form.end_date.errors %}
+                    <div class="text-danger small">{{ form.end_date.errors[0] }}</div>
+                {% endif %}
+            </div>
+        </div>
+        <div class="row g-3 mt-1">
+            <div class="col-md-6">
+                {{ form.products.label(class="form-label") }}
+                {{ form.products(class="form-select", multiple=true) }}
+                <div class="form-text">Leave blank to include sales of all products.</div>
+                {% if form.products.errors %}
+                    <div class="text-danger small">{{ form.products.errors[0] }}</div>
+                {% endif %}
+            </div>
+            <div class="col-md-6">
+                {{ form.gl_codes.label(class="form-label") }}
+                {{ form.gl_codes(class="form-select", multiple=true) }}
+                <div class="form-text">Hold Ctrl (Windows) or Command (Mac) to select multiple GL codes.</div>
+                {% if form.gl_codes.errors %}
+                    <div class="text-danger small">{{ form.gl_codes.errors[0] }}</div>
+                {% endif %}
+            </div>
+        </div>
+        {{ form.submit(class="btn btn-primary mt-3") }}
+    </form>
+
+    {% if report is not none %}
+        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+            <h3 class="mb-0">Report Results</h3>
+            <div class="d-flex align-items-center flex-wrap gap-2">
+                {% if start and end %}
+                <span class="text-muted">{{ start.strftime('%Y-%m-%d') }} to {{ end.strftime('%Y-%m-%d') }}</span>
+                {% endif %}
+                <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('report.product_stock_usage_report') }}">Reset Filters</a>
+            </div>
+        </div>
+
+        {% if selected_product_names or selected_gl_labels %}
+        <div class="alert alert-secondary" role="status">
+            <div class="fw-semibold">Filters Applied</div>
+            <ul class="mb-0 small">
+                {% if selected_product_names %}
+                <li><span class="fw-semibold">Products:</span> {{ selected_product_names | join(', ') }}</li>
+                {% endif %}
+                {% if selected_gl_labels %}
+                <li><span class="fw-semibold">Sales GL Codes:</span> {{ selected_gl_labels | join(', ') }}</li>
+                {% endif %}
+            </ul>
+            <div class="mt-2">
+                <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('report.product_stock_usage_report') }}">Clear Filters</a>
+            </div>
+        </div>
+        {% endif %}
+
+        {% if report %}
+        <div class="table-responsive">
+            <table class="table table-bordered table-striped align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th scope="col">Stock Item</th>
+                        <th scope="col">Unit</th>
+                        <th scope="col" class="text-end">Quantity Used</th>
+                        <th scope="col" class="text-end">Cost (each)</th>
+                        <th scope="col" class="text-end">Total Cost</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in report %}
+                    <tr>
+                        <td>{{ row.name }}</td>
+                        <td>{{ row.unit }}</td>
+                        <td class="text-end">{{ '%.2f'|format(row.quantity) }}</td>
+                        <td class="text-end">${{ '%.2f'|format(row.cost) }}</td>
+                        <td class="text-end">${{ '%.2f'|format(row.total_cost) }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+                {% if totals %}
+                <tfoot>
+                    <tr>
+                        <th scope="row" class="text-end">Totals</th>
+                        <td></td>
+                        <td class="text-end">{{ '%.2f'|format(totals.quantity) }}</td>
+                        <td></td>
+                        <td class="text-end">${{ '%.2f'|format(totals.cost) }}</td>
+                    </tr>
+                </tfoot>
+                {% endif %}
+            </table>
+        </div>
+        {% else %}
+            <div class="alert alert-info" role="alert">
+                No stock usage matched the selected filters.
+            </div>
+        {% endif %}
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a new report route that aggregates recipe item consumption from product sales
- create a dedicated template for the product stock usage report and expose navigation links from invoices and products views

## Testing
- pytest *(fails: tests/test_location_gl_override.py::test_location_specific_gl_override returns 404 for purchase invoice report)*

------
https://chatgpt.com/codex/tasks/task_e_68daf673a75483248a501965832cd406