### PR TITLE
Allow per-line receiving locations

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -774,6 +774,12 @@ class InvoiceItemReceiveForm(FlaskForm):
     quantity = DecimalField("Quantity", validators=[InputRequired()])
     cost = DecimalField("Cost", validators=[InputRequired()])
     position = HiddenField("Position")
+    location_id = SelectField(
+        "Location",
+        coerce=int,
+        validators=[Optional()],
+        validate_choice=False,
+    )
     gl_code = SelectField(
         "GL Code",
         coerce=int,
@@ -818,9 +824,15 @@ class ReceiveInvoiceForm(FlaskForm):
         items = load_item_choices()
         units = load_unit_choices()
         gl_codes = load_purchase_gl_code_choices()
+        location_choices = [(0, "Use Invoice Location")] + [
+            (loc_id, label) for loc_id, label in self.location_id.choices
+        ]
         for item_form in self.items:
             item_form.item.choices = items
             item_form.unit.choices = units
+            item_form.location_id.choices = location_choices
+            if item_form.location_id.data is None:
+                item_form.location_id.data = 0
             item_form.gl_code.choices = gl_codes
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -535,6 +535,12 @@ class PurchaseInvoiceItem(db.Model):
     prev_cost = db.Column(db.Float, nullable=False, default=0.0)
     item = relationship("Item")
     unit = relationship("ItemUnit")
+    location_id = db.Column(
+        db.Integer,
+        db.ForeignKey("location.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    location = relationship("Location")
     purchase_gl_code_id = db.Column(
         db.Integer,
         db.ForeignKey("gl_code.id"),
@@ -556,7 +562,7 @@ class PurchaseInvoiceItem(db.Model):
         if not self.item:
             return None
 
-        loc_id = location_id
+        loc_id = self.location_id if self.location_id is not None else location_id
         if loc_id is None and self.invoice is not None:
             loc_id = self.invoice.location_id
 

--- a/app/routes/report_routes.py
+++ b/app/routes/report_routes.py
@@ -265,7 +265,7 @@ def purchase_inventory_summary():
 
             for inv_item in invoice_items:
                 invoice = inv_item.invoice
-                location_id = invoice.location_id if invoice else None
+                location_id = inv_item.location_id or (invoice.location_id if invoice else None)
                 resolved_gl = inv_item.resolved_purchase_gl_code(location_id)
                 gl_id = resolved_gl.id if resolved_gl else None
 
@@ -364,7 +364,8 @@ def _invoice_gl_code_rows(invoice: PurchaseInvoice):
     buckets: Dict[str, Dict[str, Decimal]] = {}
 
     for item in invoice.items:
-        gl = item.resolved_purchase_gl_code(invoice.location_id)
+        line_location_id = item.location_id or invoice.location_id
+        gl = item.resolved_purchase_gl_code(line_location_id)
         if gl is not None:
             code_key = gl.code
             display_code = gl.code

--- a/app/templates/purchase_invoices/view_purchase_invoice.html
+++ b/app/templates/purchase_invoices/view_purchase_invoice.html
@@ -23,6 +23,7 @@
                 <th>Unit</th>
                 <th>Qty</th>
                 <th>Cost</th>
+                <th>Location</th>
                 <th>GL Code</th>
                 <th>Line Total</th>
             </tr>
@@ -37,7 +38,16 @@
                 <td>{{ it.quantity }}</td>
                 <td>{{ '%.2f'|format(it.cost) }}</td>
                 <td>
-                    {% set gl_obj = it.resolved_purchase_gl_code(invoice.location_id) %}
+                    {% if it.location %}
+                        {{ it.location.name }}
+                    {% elif it.location_id %}
+                        Deleted Location (#{{ it.location_id }})
+                    {% else %}
+                        {{ invoice.location_name }}
+                    {% endif %}
+                </td>
+                <td>
+                    {% set gl_obj = it.resolved_purchase_gl_code(it.location_id or invoice.location_id) %}
                     {% if gl_obj and gl_obj.code %}
                         {{ gl_obj.code }}{% if gl_obj.description %} - {{ gl_obj.description }}{% endif %}
                     {% else %}

--- a/app/templates/purchase_invoices/view_purchase_invoices.html
+++ b/app/templates/purchase_invoices/view_purchase_invoices.html
@@ -235,11 +235,12 @@
                         <ul class="mb-0 ps-3">
                             {% for item in inv.items %}
                                 <li>
+                                    {% set location_label = item.location.name if item.location else (inv.location_name if not item.location_id else 'Deleted Location (#' ~ item.location_id ~ ')') %}
                                     {{ item.item_name }} — {{ '%.4f'|format(item.quantity) }}
                                     {% if item.unit_name %}
                                         {{ item.unit_name }}
                                     {% endif %}
-                                    @ {{ '%.2f'|format(item.cost) }}
+                                    @ {{ '%.2f'|format(item.cost) }} — {{ location_label }}
                                 </li>
                             {% endfor %}
                         </ul>

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -28,6 +28,11 @@
             min-width: 180px;
         }
 
+        .item-row .location-col {
+            flex: 1 1 200px;
+            min-width: 180px;
+        }
+
         .item-row .line-total-col {
             flex: 0 0 110px;
             min-width: 100px;
@@ -42,6 +47,7 @@
             .item-row .unit-col,
             .item-row .quantity-col,
             .item-row .cost-col,
+            .item-row .location-col,
             .item-row .gl-code-col,
             .item-row .line-total-col {
                 flex: 0 0 100%;
@@ -98,6 +104,7 @@
             <div class="col-auto unit-col"><select name="items-{{ loop.index0 }}-unit" class="form-control unit-select" data-selected="{{ item.unit.data }}"></select></div>
             <div class="col quantity-col">{{ item.quantity(class="form-control quantity") }}</div>
             <div class="col cost-col">{{ item.cost(class="form-control cost") }}</div>
+            <div class="col location-col">{{ item.location_id(class="form-select location-select", **{"data-selected": item.location_id.data}) }}</div>
             <div class="col gl-code-col">{{ item.gl_code(class="form-control gl-code-select") }}</div>
             <div class="col line-total-col"><span class="line-total">0.00</span></div>
             <div class="col-auto">
@@ -125,6 +132,7 @@
 <script nonce="{{ csp_nonce }}">
     const itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     const glCodeOptions = `{% for val, label in form.items[0].gl_code.choices %}<option value="{{ val }}">{{ label|e }}</option>{% endfor %}`;
+    const locationOptions = `{% for val, label in form.items[0].location_id.choices %}<option value="{{ val }}">{{ label|e }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
 
     function createRow(index) {
@@ -138,6 +146,7 @@
             <div class="col-auto unit-col"><select name="items-${index}-unit" id="items-${index}-unit" class="form-control unit-select" data-selected=""></select></div>
             <div class="col quantity-col"><input type="number" step="any" name="items-${index}-quantity" id="items-${index}-quantity" class="form-control quantity"></div>
             <div class="col cost-col"><input type="number" step="any" name="items-${index}-cost" id="items-${index}-cost" class="form-control cost"></div>
+            <div class="col location-col"><select name="items-${index}-location_id" id="items-${index}-location_id" class="form-select location-select">${locationOptions}</select></div>
             <div class="col gl-code-col"><select name="items-${index}-gl_code" id="items-${index}-gl_code" class="form-control gl-code-select">${glCodeOptions}</select></div>
             <div class="col line-total-col"><span class="line-total">0.00</span></div>
             <div class="col-auto">
@@ -149,6 +158,22 @@
             <div class="col-auto"><button type="button" class="btn btn-danger remove-item">Remove</button></div>
         `;
         return row;
+    }
+
+    function getInvoiceLocationValue() {
+        const field = document.getElementById('location_id');
+        return field ? field.value : '';
+    }
+
+    function getRowLocationId(row) {
+        const select = row.querySelector('.location-select');
+        if (select) {
+            const value = select.value;
+            if (value && value !== '0') {
+                return value;
+            }
+        }
+        return getInvoiceLocationValue();
     }
 
     function updatePositions() {
@@ -184,17 +209,17 @@
 
     function fetchUnits(selectEl, selectedUnitId=null) {
         const itemId = selectEl.value;
-        const unitSelect = selectEl.closest('.item-row').querySelector('.unit-select');
         const row = selectEl.closest('.item-row');
+        const unitSelect = row.querySelector('.unit-select');
         if (!itemId) {
             unitSelect.innerHTML = '';
             applyDefaultGlCode(row, null);
             return;
         }
-        const locationField = document.getElementById('location_id');
         const params = new URLSearchParams();
-        if (locationField && locationField.value) {
-            params.append('location_id', locationField.value);
+        const effectiveLocation = getRowLocationId(row);
+        if (effectiveLocation) {
+            params.append('location_id', effectiveLocation);
         }
         const url = params.toString() ? `/items/${itemId}/units?${params.toString()}` : `/items/${itemId}/units`;
         fetch(url).then(r => r.json()).then(data => {
@@ -244,6 +269,10 @@
         if (glSelect) {
             glSelect.value = '0';
         }
+        const locationSelect = row.querySelector('.location-select');
+        if (locationSelect) {
+            locationSelect.value = '0';
+        }
         itemIndex++;
         updatePositions();
     });
@@ -279,6 +308,22 @@
         }
         if (e.target && e.target.classList.contains('gl-code-select')) {
             e.target.dataset.userSelected = '1';
+        }
+        if (e.target && e.target.classList.contains('location-select')) {
+            if (e.target.value === '0') {
+                delete e.target.dataset.userSelected;
+            } else {
+                e.target.dataset.userSelected = '1';
+            }
+            const row = e.target.closest('.item-row');
+            const itemSelect = row.querySelector('.item-select');
+            if (itemSelect && itemSelect.value) {
+                const unitSelect = row.querySelector('.unit-select');
+                const selectedUnit = unitSelect ? unitSelect.value : null;
+                fetchUnits(itemSelect, selectedUnit);
+            } else {
+                applyDefaultGlCode(row, null);
+            }
         }
         if (e.target && (e.target.classList.contains('quantity') || e.target.classList.contains('cost'))) {
             updateTotals();
@@ -334,6 +379,18 @@
     document.querySelectorAll('.item-select').forEach(sel => {
         const row = sel.closest('.item-row');
         const selectedUnit = row.querySelector('.unit-select').dataset.selected;
+        const locationSelect = row.querySelector('.location-select');
+        if (locationSelect) {
+            const selectedLocation = locationSelect.dataset.selected;
+            if (selectedLocation) {
+                locationSelect.value = selectedLocation;
+                if (selectedLocation !== '0') {
+                    locationSelect.dataset.userSelected = '1';
+                }
+            } else {
+                locationSelect.value = '0';
+            }
+        }
         fetchUnits(sel, selectedUnit);
         const glSelect = row.querySelector('.gl-code-select');
         if (glSelect && !glSelect.value) {

--- a/migrations/versions/202408200002_add_line_locations_to_purchase_invoice_items.py
+++ b/migrations/versions/202408200002_add_line_locations_to_purchase_invoice_items.py
@@ -1,0 +1,64 @@
+import sqlalchemy as sa
+from alembic import op
+
+
+def _has_column(table_name: str, column_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table_name):
+        return False
+    return column_name in {
+        column["name"] for column in inspector.get_columns(table_name)
+    }
+
+
+# revision identifiers, used by Alembic.
+revision = "202408200002"
+down_revision = "1f2e3d4c5b6a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if not bind:
+        return
+
+    with op.batch_alter_table("purchase_invoice_item", recreate="always") as batch_op:
+        if not _has_column("purchase_invoice_item", "location_id", bind):
+            batch_op.add_column(
+                sa.Column("location_id", sa.Integer(), nullable=True)
+            )
+            batch_op.create_foreign_key(
+                "fk_purchase_invoice_item_location_id",
+                "location",
+                ["location_id"],
+                ["id"],
+                ondelete="SET NULL",
+            )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE purchase_invoice_item AS pii
+            SET location_id = (
+                SELECT location_id
+                FROM purchase_invoice AS pi
+                WHERE pi.id = pii.invoice_id
+            )
+            WHERE location_id IS NULL
+            """
+        )
+    )
+
+
+def downgrade():
+    bind = op.get_bind()
+    if not bind:
+        return
+
+    with op.batch_alter_table("purchase_invoice_item", recreate="always") as batch_op:
+        if _has_column("purchase_invoice_item", "location_id", bind):
+            batch_op.drop_constraint(
+                "fk_purchase_invoice_item_location_id", type_="foreignkey"
+            )
+            batch_op.drop_column("location_id")


### PR DESCRIPTION
## Summary
- add a migration and model updates so purchase invoice items can store their own receiving location and resolve GL codes against that location
- extend the receive invoice form, template, and handlers to let each line pick a location while updating inventory adjustments, reversal checks, and invoice displays
- refresh reporting, forecasting, and purchase flow tests to exercise per-line locations and show them in invoice listings and detail views

## Testing
- `pytest tests/test_purchase_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd9b527a8083249869790d4a1f75fa