### PR TITLE
Restore edit link on items list

### DIFF
--- a/app/templates/items/_item_row.html
+++ b/app/templates/items/_item_row.html
@@ -39,7 +39,7 @@
     <td class="col-archived" data-sort-value="{{ '1' if item.archived else '0' }}">{{ 'Yes' if item.archived else 'No' }}</td>
     <td class="col-actions">
         <a href="{{ url_for('item.view_item', item_id=item.id) }}" class="btn btn-primary">View</a>
-        <button type="button" class="btn btn-secondary edit-item-btn ms-1" data-item-id="{{ item.id }}">Edit</button>
+        <a href="{{ url_for('item.edit_item', item_id=item.id) }}" class="btn btn-secondary edit-item-btn ms-1" data-item-id="{{ item.id }}">Edit</a>
         <button type="button" class="btn btn-secondary copy-item-btn ms-1" data-item-id="{{ item.id }}">Copy</button>
         <a href="{{ url_for('item.item_locations', item_id=item.id) }}" class="btn btn-info ms-1">Locations</a>
     </td>

--- a/app/templates/items/view_items.html
+++ b/app/templates/items/view_items.html
@@ -404,8 +404,10 @@ if (createItemBtn) {
 const itemsTableEl = document.querySelector('#itemsTable');
 if (itemsTableEl) {
     itemsTableEl.addEventListener('click', function(e) {
-        if (e.target.classList.contains('edit-item-btn')) {
-            const itemId = e.target.getAttribute('data-item-id');
+        const editButton = e.target.closest('.edit-item-btn');
+        if (editButton) {
+            e.preventDefault();
+            const itemId = editButton.getAttribute('data-item-id');
             const url = '{{ url_for('item.edit_item', item_id=0) }}'.replace('0', itemId);
             fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
                 .then(r => r.text())
@@ -418,8 +420,11 @@ if (itemsTableEl) {
                     modal.show();
                     bindItemForm(url);
                 });
-        } else if (e.target.classList.contains('copy-item-btn')) {
-            const itemId = e.target.getAttribute('data-item-id');
+        }
+
+        const copyButton = e.target.closest('.copy-item-btn');
+        if (copyButton) {
+            const itemId = copyButton.getAttribute('data-item-id');
             const url = '{{ url_for('item.copy_item', item_id=0) }}'.replace('0', itemId);
             const actionUrl = '{{ url_for('item.add_item') }}';
             fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })


### PR DESCRIPTION
## Summary
- restore a direct Edit link on each items table row so users can open the edit page without JavaScript
- update the list click handler to work with nested targets and prevent navigation when handling modal edits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de1fb48068832485456ea02a2dfe63