### PR TITLE
Ensure invoice GL code selects include choices for new items

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -833,7 +833,9 @@ class ReceiveInvoiceForm(FlaskForm):
             item_form.location_id.choices = location_choices
             if item_form.location_id.data is None:
                 item_form.location_id.data = 0
-            item_form.gl_code.choices = gl_codes
+            item_form.gl_code.choices = [
+                (value, label) for value, label in gl_codes
+            ]
 
 
 class DeleteForm(FlaskForm):

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -592,6 +592,7 @@ def receive_invoice(po_id):
     if po is None:
         abort(404)
     form = ReceiveInvoiceForm()
+    gl_code_choices = load_purchase_gl_code_choices()
     if request.method == "GET":
         form.delivery_charge.data = po.delivery_charge
         form.items.min_entries = max(1, len(po.items))
@@ -605,7 +606,9 @@ def receive_invoice(po_id):
             item_form.unit.choices = [
                 (u.id, u.name) for u in ItemUnit.query.all()
             ]
-            item_form.gl_code.choices = load_purchase_gl_code_choices()
+            item_form.gl_code.choices = [
+                (value, label) for value, label in gl_code_choices
+            ]
         for i, poi in enumerate(po.items):
             form.items[i].item.data = poi.item_id
             form.items[i].unit.data = poi.unit_id
@@ -778,7 +781,10 @@ def receive_invoice(po_id):
         return redirect(url_for("purchase.view_purchase_invoices"))
 
     return render_template(
-        "purchase_orders/receive_invoice.html", form=form, po=po
+        "purchase_orders/receive_invoice.html",
+        form=form,
+        po=po,
+        gl_code_choices=gl_code_choices,
     )
 
 

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -131,7 +131,7 @@
 </div>
 <script nonce="{{ csp_nonce }}">
     const itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
-    const glCodeOptions = `{% for val, label in form.items[0].gl_code.choices %}<option value="{{ val }}">{{ label|e }}</option>{% endfor %}`;
+    const glCodeOptions = `{% for val, label in gl_code_choices %}<option value="{{ val }}">{{ label|e }}</option>{% endfor %}`;
     const locationOptions = `{% for val, label in form.items[0].location_id.choices %}<option value="{{ val }}">{{ label|e }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
 


### PR DESCRIPTION
## Summary
- copy purchase GL code choices per invoice line so each select retains its options
- preload purchase GL code choices for the receive invoice view and reuse them in the template
- update the template to build GL code option markup from the shared choice list

## Testing
- pytest tests/test_quick_item_creation.py

------
https://chatgpt.com/codex/tasks/task_e_68debd9a92a4832490d984ebf87b534b