### PR TITLE
Convert stand sheet reporting units and persist base counts

### DIFF
--- a/app/routes/item_routes.py
+++ b/app/routes/item_routes.py
@@ -38,6 +38,7 @@ from app.models import (
 )
 from app.utils.activity import log_activity
 from app.utils.pagination import build_pagination_args, get_per_page
+from app.utils.units import BASE_UNITS
 
 item = Blueprint("item", __name__)
 
@@ -676,7 +677,7 @@ def quick_add_item():
                 "transfer_default": transfer_default,
             }
         )
-    valid_units = {"ounce", "gram", "each", "millilitre"}
+    valid_units = set(BASE_UNITS)
     if (
         not name
         or base_unit not in valid_units

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -31,6 +31,33 @@
             {{ form.max_backups.label }}
             {{ form.max_backups(class='form-control') }}
         </div>
+        <div class="mt-4">
+            <h3>Reporting Units</h3>
+            <p class="text-muted">Choose how base units should appear in reports.</p>
+            <div class="table-responsive">
+                <table class="table table-sm align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col">Base Unit</th>
+                            <th scope="col">Report As</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for key, label, field in form.iter_base_unit_conversions() %}
+                        <tr>
+                            <th scope="row" class="w-50">{{ label }}</th>
+                            <td>
+                                {{ field(class='form-select') }}
+                                {% if field.errors %}
+                                    <div class="text-danger small">{{ field.errors[0] }}</div>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
         {{ form.submit(class='btn btn-primary') }}
     </form>
 </div>

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -145,7 +145,7 @@
       </colgroup>
       <thead>
         <tr>
-          <th rowspan="2">Stock Item (Base Unit)</th>
+          <th rowspan="2">Stock Item (Report Unit)</th>
           <th rowspan="2">Expected Opening Count</th>
           <th rowspan="2">Opening Count</th>
           <th colspan="2" class="border-right">Event Transfers</th>
@@ -174,16 +174,22 @@
           {% endif %}
         {% endfor %}
         {% set expected_open = s.expected %}
-        {% set variance = (s.sheet.closing_count if s.sheet else 0) - expected_open %}
+        {% set opening_count = s.sheet_values.opening_count if s.sheet_values else None %}
+        {% set transferred_in = s.sheet_values.transferred_in if s.sheet_values else None %}
+        {% set transferred_out = s.sheet_values.transferred_out if s.sheet_values else None %}
+        {% set eaten_val = s.sheet_values.eaten if s.sheet_values else None %}
+        {% set spoiled_val = s.sheet_values.spoiled if s.sheet_values else None %}
+        {% set closing_count = s.sheet_values.closing_count if s.sheet_values else None %}
+        {% set variance = (closing_count or 0) - (expected_open or 0) %}
         <tr>
-          <td>{{ s.item.name }} ({{ s.item.base_unit }})</td>
-          <td>{{ expected_open }}</td>
-          <td>{{ s.sheet.opening_count if s.sheet else '' }}</td>
-          <td class="border-right">{{ s.sheet.transferred_in if s.sheet else '' }}</td>
-          <td>{{ s.sheet.transferred_out if s.sheet else '' }}</td>
-          <td>{{ s.sheet.eaten if s.sheet else '' }}</td>
-          <td class="border-right">{{ s.sheet.spoiled if s.sheet else '' }}</td>
-          <td>{{ s.sheet.closing_count if s.sheet else '' }}</td>
+          <td>{{ s.item.name }}{% if s.report_unit_label %} ({{ s.report_unit_label }}){% endif %}</td>
+          <td>{% if expected_open is not none %}{{ '%.2f'|format(expected_open) }}{% endif %}</td>
+          <td>{% if opening_count is not none %}{{ '%.2f'|format(opening_count) }}{% endif %}</td>
+          <td class="border-right">{% if transferred_in is not none %}{{ '%.2f'|format(transferred_in) }}{% endif %}</td>
+          <td>{% if transferred_out is not none %}{{ '%.2f'|format(transferred_out) }}{% endif %}</td>
+          <td>{% if eaten_val is not none %}{{ '%.2f'|format(eaten_val) }}{% endif %}</td>
+          <td class="border-right">{% if spoiled_val is not none %}{{ '%.2f'|format(spoiled_val) }}{% endif %}</td>
+          <td>{% if closing_count is not none %}{{ '%.2f'|format(closing_count) }}{% endif %}</td>
           <td></td>
           <td>{% if price.value is not none %}${{ '%.2f'|format(price.value) }}{% endif %}</td>
           <td>{% if s.sheet %}{{ '%.2f'|format(variance) }}{% endif %}</td>

--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -13,7 +13,7 @@
     <table class="table table-bordered">
         <thead>
             <tr>
-                <th>Item</th>
+                <th>Item (Report Unit)</th>
                 <th>Prior Event Close</th>
                 <th>Pre-Event Count</th>
                 <th>Transferred In</th>
@@ -27,17 +27,45 @@
         </thead>
         <tbody>
             {% for entry in stand_items %}
+            {% set opening_val = entry.sheet_values.opening_count or 0 %}
+            {% set in_val = entry.sheet_values.transferred_in or 0 %}
+            {% set out_val = entry.sheet_values.transferred_out or 0 %}
+            {% set eaten_val = entry.sheet_values.eaten or 0 %}
+            {% set spoiled_val = entry.sheet_values.spoiled or 0 %}
+            {% set close_val = entry.sheet_values.closing_count or 0 %}
+            {% set variance = opening_val + in_val - out_val - entry.sales - eaten_val - spoiled_val - close_val %}
             <tr>
-                <td>{{ entry.item.name }}</td>
-                <td>{{ entry.expected }}</td>
-                <td><input type="number" class="form-control" name="open_{{ entry.item.id }}" value="{{ entry.sheet.opening_count if entry.sheet else '' }}"></td>
-                <td><input type="number" class="form-control" name="in_{{ entry.item.id }}" value="{{ entry.sheet.transferred_in if entry.sheet else '' }}"></td>
-                <td><input type="number" class="form-control" name="out_{{ entry.item.id }}" value="{{ entry.sheet.transferred_out if entry.sheet else '' }}"></td>
-                <td class="sales" data-sales="{{ entry.sales }}">{{ entry.sales }}</td>
-                <td><input type="number" step="0.01" class="form-control" name="eaten_{{ entry.item.id }}" value="{{ entry.sheet.eaten if entry.sheet else '' }}"></td>
-                <td><input type="number" step="0.01" class="form-control" name="spoiled_{{ entry.item.id }}" value="{{ entry.sheet.spoiled if entry.sheet else '' }}"></td>
-                <td><input type="number" class="form-control" name="close_{{ entry.item.id }}" value="{{ entry.sheet.closing_count if entry.sheet else '' }}"></td>
-                <td class="variance">0</td>
+                <td>
+                    {{ entry.item.name }}
+                    {% if entry.report_unit_label %}
+                        ({{ entry.report_unit_label }})
+                    {% endif %}
+                </td>
+                <td>
+                    {% if entry.expected is not none %}
+                        {{ '%.2f'|format(entry.expected) }}
+                    {% endif %}
+                </td>
+                <td>
+                    <input type="number" step="any" class="form-control" name="open_{{ entry.item.id }}" value="{% if entry.sheet_values.opening_count is not none %}{{ '%.4f'|format(entry.sheet_values.opening_count) }}{% endif %}">
+                </td>
+                <td>
+                    <input type="number" step="any" class="form-control" name="in_{{ entry.item.id }}" value="{% if entry.sheet_values.transferred_in is not none %}{{ '%.4f'|format(entry.sheet_values.transferred_in) }}{% endif %}">
+                </td>
+                <td>
+                    <input type="number" step="any" class="form-control" name="out_{{ entry.item.id }}" value="{% if entry.sheet_values.transferred_out is not none %}{{ '%.4f'|format(entry.sheet_values.transferred_out) }}{% endif %}">
+                </td>
+                <td class="sales" data-sales="{{ '%.4f'|format(entry.sales) }}">{{ '%.2f'|format(entry.sales) }}</td>
+                <td>
+                    <input type="number" step="any" class="form-control" name="eaten_{{ entry.item.id }}" value="{% if entry.sheet_values.eaten is not none %}{{ '%.4f'|format(entry.sheet_values.eaten) }}{% endif %}">
+                </td>
+                <td>
+                    <input type="number" step="any" class="form-control" name="spoiled_{{ entry.item.id }}" value="{% if entry.sheet_values.spoiled is not none %}{{ '%.4f'|format(entry.sheet_values.spoiled) }}{% endif %}">
+                </td>
+                <td>
+                    <input type="number" step="any" class="form-control" name="close_{{ entry.item.id }}" value="{% if entry.sheet_values.closing_count is not none %}{{ '%.4f'|format(entry.sheet_values.closing_count) }}{% endif %}">
+                </td>
+                <td class="variance">{% if entry.sheet %}{{ '%.2f'|format(variance) }}{% else %}0.00{% endif %}</td>
             </tr>
             {% endfor %}
         </tbody>

--- a/app/templates/locations/stand_sheet.html
+++ b/app/templates/locations/stand_sheet.html
@@ -92,7 +92,7 @@ body {
       </colgroup>
       <thead>
         <tr>
-          <th rowspan="2">Stock Item (Base Unit)</th>
+          <th rowspan="2">Stock Item (Report Unit)</th>
           <th rowspan="2">Expected Opening Count</th>
           <th rowspan="2">Opening Count</th>
           <th colspan="2" class="border-right">Event Transfers</th>
@@ -121,8 +121,8 @@ body {
           {% endif %}
         {% endfor %}
         <tr>
-          <td>{{ s.item.name }} ({{ s.item.base_unit }})</td>
-          <td>{{ s.expected }}</td>
+          <td>{{ s.item.name }}{% if s.report_unit_label %} ({{ s.report_unit_label }}){% endif %}</td>
+          <td>{% if s.expected is not none %}{{ '%.2f'|format(s.expected) }}{% endif %}</td>
           <td></td>
           <td class="border-right"></td>
           <td></td>

--- a/app/utils/units.py
+++ b/app/utils/units.py
@@ -1,0 +1,166 @@
+"""Utilities for working with the application's base units."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Iterator, List, Mapping, Tuple
+
+# Display labels for each base unit supported by the system. The keys are stored
+# in the database and should remain stable.
+BASE_UNIT_LABELS: Dict[str, str] = {
+    "ounce": "Ounce",
+    "gram": "Gram",
+    "each": "Each",
+    "millilitre": "Millilitre",
+}
+
+
+# Keep the units ordered for deterministic form rendering.
+BASE_UNITS: List[str] = list(BASE_UNIT_LABELS.keys())
+
+
+def _choice(unit: str) -> Tuple[str, str]:
+    return unit, BASE_UNIT_LABELS[unit]
+
+
+BASE_UNIT_CHOICES: List[Tuple[str, str]] = [_choice(unit) for unit in BASE_UNITS]
+
+
+# Default conversion map ensures each unit reports as itself.
+DEFAULT_BASE_UNIT_CONVERSIONS: Dict[str, str] = {
+    unit: unit for unit in BASE_UNITS
+}
+
+
+# Conversion factors used when translating between units. Each mapping is from
+# the source unit to the target unit and represents the multiplier applied to a
+# quantity expressed in the source unit in order to obtain the target unit.
+_UNIT_CONVERSION_FACTORS: Dict[str, Dict[str, float]] = {
+    "each": {"each": 1.0},
+    "ounce": {
+        "ounce": 1.0,
+        "gram": 28.349523125,
+        "millilitre": 29.5735295625,
+    },
+    "gram": {
+        "gram": 1.0,
+        "ounce": 1 / 28.349523125,
+    },
+    "millilitre": {
+        "millilitre": 1.0,
+        "ounce": 0.0338140227,
+    },
+}
+
+
+def get_allowed_target_units(base_unit: str) -> List[str]:
+    """Return the list of report units supported for a given base unit."""
+
+    return list(_UNIT_CONVERSION_FACTORS.get(base_unit, {}).keys())
+
+
+def get_conversion_factor(from_unit: str, to_unit: str) -> float | None:
+    """Return the multiplier to convert ``from_unit`` quantities to ``to_unit``."""
+
+    return _UNIT_CONVERSION_FACTORS.get(from_unit, {}).get(to_unit)
+
+
+def convert_quantity(value: float, from_unit: str, to_unit: str) -> float:
+    """Convert ``value`` from ``from_unit`` to ``to_unit`` for quantities."""
+
+    if from_unit == to_unit:
+        return value
+    factor = get_conversion_factor(from_unit, to_unit)
+    if factor is None:
+        raise ValueError(f"Unsupported conversion from {from_unit} to {to_unit}")
+    return value * factor
+
+
+def convert_unit_cost(value: float, from_unit: str, to_unit: str) -> float:
+    """Convert a per-unit cost from ``from_unit`` to ``to_unit``."""
+
+    if from_unit == to_unit:
+        return value
+    factor = get_conversion_factor(from_unit, to_unit)
+    if factor is None or factor == 0:
+        raise ValueError(f"Unsupported conversion from {from_unit} to {to_unit}")
+    return value / factor
+
+
+def get_unit_label(unit: str | None) -> str:
+    """Return the display label for ``unit``."""
+
+    if not unit:
+        return ""
+    return BASE_UNIT_LABELS.get(unit, unit)
+
+
+def parse_conversion_setting(value: str | None) -> Dict[str, str]:
+    """Parse the stored JSON conversion setting into a mapping."""
+
+    mapping = dict(DEFAULT_BASE_UNIT_CONVERSIONS)
+    if not value:
+        return mapping
+    try:
+        data = json.loads(value)
+    except (TypeError, ValueError):
+        return mapping
+
+    for unit in BASE_UNITS:
+        target = data.get(unit)
+        if target in get_allowed_target_units(unit):
+            mapping[unit] = target
+    return mapping
+
+
+def serialize_conversion_setting(mapping: Mapping[str, str]) -> str:
+    """Serialize a conversion mapping for storage in the database."""
+
+    normalized = {
+        unit: mapping.get(unit, unit)
+        if mapping.get(unit, unit) in get_allowed_target_units(unit)
+        else unit
+        for unit in BASE_UNITS
+    }
+    return json.dumps(normalized, sort_keys=True)
+
+
+def convert_quantity_for_reporting(
+    quantity: float, base_unit: str | None, conversions: Mapping[str, str]
+) -> Tuple[float, str | None]:
+    """Convert ``quantity`` into the reporting unit specified for ``base_unit``."""
+
+    if not base_unit:
+        return quantity, base_unit
+    target_unit = conversions.get(base_unit, base_unit)
+    if target_unit == base_unit:
+        return quantity, base_unit
+    factor = get_conversion_factor(base_unit, target_unit)
+    if factor is None:
+        return quantity, base_unit
+    return quantity * factor, target_unit
+
+
+def convert_cost_for_reporting(
+    unit_cost: float, base_unit: str | None, conversions: Mapping[str, str]
+) -> float:
+    """Convert a per-unit cost into the configured reporting unit."""
+
+    if not base_unit:
+        return unit_cost
+    target_unit = conversions.get(base_unit, base_unit)
+    if target_unit == base_unit:
+        return unit_cost
+    factor = get_conversion_factor(base_unit, target_unit)
+    if factor is None or factor == 0:
+        return unit_cost
+    return unit_cost / factor
+
+
+def iter_base_unit_fields(form) -> Iterator[Tuple[str, str, object]]:
+    """Yield form fields related to base unit conversions."""
+
+    for unit in BASE_UNITS:
+        field = getattr(form, f"convert_{unit}", None)
+        if field is not None:
+            yield unit, BASE_UNIT_LABELS[unit], field

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,10 @@ from flask_migrate import upgrade
 
 from app import create_app, create_admin_user, db
 from app.models import GLCode, Setting
+from app.utils.units import (
+    DEFAULT_BASE_UNIT_CONVERSIONS,
+    serialize_conversion_setting,
+)
 
 # Ensure the app package is importable when tests change directories
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -47,6 +51,15 @@ def app(tmp_path):
             db.session.add(Setting(name="GST", value=""))
         if Setting.query.filter_by(name="DEFAULT_TIMEZONE").count() == 0:
             db.session.add(Setting(name="DEFAULT_TIMEZONE", value="UTC"))
+        if Setting.query.filter_by(name="BASE_UNIT_CONVERSIONS").count() == 0:
+            db.session.add(
+                Setting(
+                    name="BASE_UNIT_CONVERSIONS",
+                    value=serialize_conversion_setting(
+                        DEFAULT_BASE_UNIT_CONVERSIONS
+                    ),
+                )
+            )
         db.session.commit()
 
         yield app


### PR DESCRIPTION
## Summary
- convert event stand sheet helpers to surface configured reporting units across interactive and printable views
- convert posted stand sheet quantities from reporting units back into base units and align location stand sheet output with those conversions
- extend event flow tests to exercise reporting-unit conversions for stand sheets

## Testing
- pytest tests/test_event_flow.py::test_bulk_stand_sheet tests/test_event_flow.py::test_save_stand_sheet tests/test_item_transfer_invoice.py::test_stand_sheet_shows_expected_counts

------
https://chatgpt.com/codex/tasks/task_e_68dffe95754c8324b9a4b1de7a00b825