### PR TITLE
Add menu product copy feature and searchable product selector

### DIFF
--- a/app/static/js/menu_form.js
+++ b/app/static/js/menu_form.js
@@ -1,0 +1,137 @@
+(function () {
+    "use strict";
+
+    function ready(fn) {
+        if (document.readyState !== "loading") {
+            fn();
+        } else {
+            document.addEventListener("DOMContentLoaded", fn);
+        }
+    }
+
+    function toggleStatus(statusEl, message, isError) {
+        if (!statusEl) {
+            return;
+        }
+        statusEl.textContent = message;
+        statusEl.classList.remove("d-none", "text-danger", "text-success");
+        statusEl.classList.add(isError ? "text-danger" : "text-success");
+    }
+
+    function clearStatus(statusEl) {
+        if (!statusEl) {
+            return;
+        }
+        statusEl.textContent = "";
+        statusEl.classList.add("d-none");
+        statusEl.classList.remove("text-danger", "text-success");
+    }
+
+    ready(function () {
+        var productSelect = document.getElementById("product_ids");
+        if (!productSelect) {
+            return;
+        }
+
+        var menuForm = document.getElementById("menu-form");
+        var endpoint = null;
+        if (menuForm && menuForm.dataset.productsEndpoint) {
+            endpoint = menuForm.dataset.productsEndpoint;
+        }
+
+        var searchInput = document.getElementById("product-search");
+        var clearSearchButton = document.getElementById("product-search-clear");
+
+        function applyProductFilter() {
+            if (!searchInput) {
+                return;
+            }
+            var term = searchInput.value.trim().toLowerCase();
+            Array.prototype.forEach.call(productSelect.options, function (option) {
+                if (!term) {
+                    option.hidden = false;
+                    return;
+                }
+                var matches = option.text.toLowerCase().indexOf(term) !== -1;
+                option.hidden = !matches;
+            });
+        }
+
+        if (searchInput) {
+            searchInput.addEventListener("input", applyProductFilter);
+        }
+
+        if (clearSearchButton) {
+            clearSearchButton.addEventListener("click", function () {
+                if (!searchInput) {
+                    return;
+                }
+                searchInput.value = "";
+                applyProductFilter();
+                searchInput.focus();
+            });
+        }
+
+        var copySelect = document.getElementById("copy-menu-select");
+        var copyButton = document.getElementById("copy-menu-button");
+        var statusEl = document.getElementById("copy-menu-status");
+
+        if (!endpoint && copySelect && copySelect.dataset.productsEndpoint) {
+            endpoint = copySelect.dataset.productsEndpoint;
+        }
+
+        function setSelectedProducts(productIds) {
+            var idSet = new Set(productIds.map(function (id) {
+                return String(id);
+            }));
+            Array.prototype.forEach.call(productSelect.options, function (option) {
+                option.selected = idSet.has(option.value);
+            });
+            applyProductFilter();
+        }
+
+        if (copySelect && copyButton && endpoint) {
+            copyButton.addEventListener("click", function () {
+                clearStatus(statusEl);
+                var selectedMenuId = copySelect.value;
+                if (!selectedMenuId) {
+                    toggleStatus(statusEl, "Please choose a menu to copy from.", true);
+                    return;
+                }
+
+                copyButton.disabled = true;
+                var originalText = copyButton.textContent;
+                copyButton.textContent = "Copying…";
+
+                var url = endpoint + (endpoint.indexOf("?") === -1 ? "?" : "&") + "menu_id=" + encodeURIComponent(selectedMenuId);
+
+                fetch(url, {
+                    headers: {
+                        Accept: "application/json"
+                    }
+                })
+                    .then(function (response) {
+                        if (!response.ok) {
+                            throw new Error("Unable to load menu products");
+                        }
+                        return response.json();
+                    })
+                    .then(function (data) {
+                        if (!data || !Array.isArray(data.product_ids)) {
+                            throw new Error("Unexpected response from server");
+                        }
+                        setSelectedProducts(data.product_ids);
+                        toggleStatus(statusEl, "Copied products from " + (data.name || "selected menu") + ".", false);
+                    })
+                    .catch(function (error) {
+                        console.error(error);
+                        toggleStatus(statusEl, error.message || "Unable to copy products.", true);
+                    })
+                    .finally(function () {
+                        copyButton.disabled = false;
+                        copyButton.textContent = originalText;
+                    });
+            });
+        }
+    });
+})();

--- a/app/templates/menus/edit_menu.html
+++ b/app/templates/menus/edit_menu.html
@@ -2,7 +2,7 @@
 {% block content %}
 <div class="container my-4">
     <h1 class="h3 mb-3">{{ 'Edit Menu' if menu else 'Create Menu' }}</h1>
-    <form method="post">
+    <form method="post" id="menu-form" data-products-endpoint="{{ url_for('menu.get_menu_products') }}">
         {{ form.hidden_tag() }}
         <div class="mb-3">
             {{ form.name.label(class="form-label") }}
@@ -18,10 +18,28 @@
             <div class="text-danger small">{{ error }}</div>
             {% endfor %}
         </div>
+        <div class="mb-4">
+            <label for="copy-menu-select" class="form-label">Copy products from another menu</label>
+            <div class="input-group">
+                <select id="copy-menu-select" class="form-select" data-products-endpoint="{{ url_for('menu.get_menu_products') }}">
+                    <option value="">Select a menu…</option>
+                    {% for other_menu in copy_menus %}
+                    <option value="{{ other_menu.id }}">{{ other_menu.name }}</option>
+                    {% endfor %}
+                </select>
+                <button type="button" class="btn btn-outline-secondary" id="copy-menu-button">Copy Products</button>
+            </div>
+            <div id="copy-menu-status" class="form-text d-none"></div>
+        </div>
         <div class="mb-3">
             {{ form.product_ids.label(class="form-label") }}
-            {{ form.product_ids(class="form-select", multiple=True, size=10) }}
-            <div class="form-text">Hold Ctrl (Windows) or Command (Mac) to select multiple products.</div>
+            <div class="input-group mb-2">
+                <span class="input-group-text" id="product-search-label">Search</span>
+                <input type="text" class="form-control" id="product-search" placeholder="Search products" aria-describedby="product-search-label">
+                <button class="btn btn-outline-secondary" type="button" id="product-search-clear">Clear</button>
+            </div>
+            {{ form.product_ids(class="form-select", multiple=True, size=12) }}
+            <div class="form-text">Use the search box to quickly find products, then hold Ctrl (Windows) or Command (Mac) to select multiple items.</div>
             {% for error in form.product_ids.errors %}
             <div class="text-danger small">{{ error }}</div>
             {% endfor %}
@@ -30,4 +48,5 @@
         <a href="{{ url_for('menu.view_menus') }}" class="btn btn-secondary ms-2">Cancel</a>
     </form>
 </div>
+<script src="{{ url_for('static', filename='js/menu_form.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a JSON endpoint that returns the products attached to a menu for reuse in the UI
- expose copy-from-menu controls and a searchable product selector on the menu create/edit page
- add client-side logic to filter products and copy selections from another menu

## Testing
- pytest tests/test_menu_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68e0510d60b48324b616b225eeb1dfd1