### PR TITLE
Add filters and column visibility controls to menus listing

### DIFF
--- a/app/templates/menus/view_menus.html
+++ b/app/templates/menus/view_menus.html
@@ -1,30 +1,61 @@
 {% extends "base.html" %}
+{% from 'macros/column_visibility.html' import column_visibility_dropdown %}
 {% block content %}
 <div class="container my-4">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h1 class="h3 mb-0">Menus</h1>
-        <a href="{{ url_for('menu.add_menu') }}" class="btn btn-primary">Create Menu</a>
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-3">
+        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-3">
+            <h1 class="h3 mb-0">Menus</h1>
+            <a href="{{ url_for('menu.add_menu') }}" class="btn btn-primary">Create Menu</a>
+        </div>
+        <div class="text-md-end">
+            {{ column_visibility_dropdown(
+                table_id='menus-table',
+                storage_key='menusTableColumnVisibility',
+                columns=[
+                    {'id': 'toggle-menu-name', 'target': 'col-menu-name', 'label': 'Name', 'checked': True},
+                    {'id': 'toggle-menu-description', 'target': 'col-menu-description', 'label': 'Description', 'checked': True},
+                    {'id': 'toggle-menu-products', 'target': 'col-menu-products', 'label': 'Products', 'checked': True},
+                    {'id': 'toggle-menu-locations', 'target': 'col-menu-locations', 'label': 'Active Locations', 'checked': True},
+                    {'id': 'toggle-menu-last-used', 'target': 'col-menu-last-used', 'label': 'Last Used', 'checked': True},
+                    {'id': 'toggle-menu-actions', 'target': 'col-menu-actions', 'label': 'Actions', 'checked': True},
+                ]
+            ) }}
+            <button type="button" class="btn btn-secondary mb-3" data-bs-toggle="modal" data-bs-target="#menuFilterModal">
+                Filters
+            </button>
+        </div>
     </div>
+
+    {% if name_query %}
+    <div class="mb-2"><strong>Filtering by Name ({{ match_mode.replace('_', ' ')|title }}):</strong> {{ name_query }}</div>
+    {% endif %}
+    {% if assigned_status != 'all' %}
+    <div class="mb-2"><strong>Assigned Status:</strong> {{ 'Assigned to locations' if assigned_status == 'assigned' else 'Not assigned to any location' }}</div>
+    {% endif %}
+    {% if product_status != 'all' %}
+    <div class="mb-3"><strong>Product Status:</strong> {{ 'Has products' if product_status == 'with' else 'No products' }}</div>
+    {% endif %}
+
     {% if menus %}
     <div class="table-responsive">
-        <table class="table table-striped align-middle">
+        <table class="table table-striped align-middle" id="menus-table">
             <thead>
                 <tr>
-                    <th scope="col">Name</th>
-                    <th scope="col">Description</th>
-                    <th scope="col">Products</th>
-                    <th scope="col">Active Locations</th>
-                    <th scope="col">Last Used</th>
-                    <th scope="col" class="text-end">Actions</th>
+                    <th scope="col" class="col-menu-name">Name</th>
+                    <th scope="col" class="col-menu-description">Description</th>
+                    <th scope="col" class="col-menu-products">Products</th>
+                    <th scope="col" class="col-menu-locations">Active Locations</th>
+                    <th scope="col" class="col-menu-last-used">Last Used</th>
+                    <th scope="col" class="col-menu-actions text-end">Actions</th>
                 </tr>
             </thead>
             <tbody>
                 {% for menu in menus %}
                 {% set active_assignments = menu.assignments | selectattr('unassigned_at', 'equalto', None) | list %}
                 <tr>
-                    <td class="fw-semibold">{{ menu.name }}</td>
-                    <td class="text-wrap">{{ menu.description or '—' }}</td>
-                    <td>
+                    <td class="col-menu-name fw-semibold">{{ menu.name }}</td>
+                    <td class="col-menu-description text-wrap">{{ menu.description or '—' }}</td>
+                    <td class="col-menu-products">
                         {% if menu.products %}
                         <ul class="mb-0 ps-3 small">
                             {% for product in menu.products %}
@@ -35,7 +66,7 @@
                         <span class="text-muted">No products</span>
                         {% endif %}
                     </td>
-                    <td>
+                    <td class="col-menu-locations">
                         {% if active_assignments %}
                         <ul class="mb-0 ps-3 small">
                             {% for assignment in active_assignments %}
@@ -46,14 +77,14 @@
                         <span class="text-muted">Not assigned</span>
                         {% endif %}
                     </td>
-                    <td>
+                    <td class="col-menu-last-used">
                         {% if menu.last_used_at %}
                         {{ menu.last_used_at.strftime('%Y-%m-%d %H:%M') }}
                         {% else %}
                         <span class="text-muted">—</span>
                         {% endif %}
                     </td>
-                    <td class="text-end">
+                    <td class="col-menu-actions text-end">
                         <div class="btn-group" role="group">
                             <a href="{{ url_for('menu.edit_menu', menu_id=menu.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
                             <a href="{{ url_for('menu.assign_menu', menu_id=menu.id) }}" class="btn btn-sm btn-outline-primary">Assign</a>
@@ -71,5 +102,54 @@
     {% else %}
     <div class="alert alert-info">No menus have been created yet.</div>
     {% endif %}
+</div>
+
+<div class="modal fade" id="menuFilterModal" tabindex="-1" aria-labelledby="menuFilterModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="menuFilterModalLabel">Filters</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="menu-filter-form" method="get">
+                    <div class="mb-3">
+                        <label for="name_query" class="form-label">Name</label>
+                        <input type="text" id="name_query" name="name_query" class="form-control" value="{{ name_query }}" placeholder="Search name">
+                    </div>
+                    <div class="mb-3">
+                        <label for="match_mode" class="form-label">Match Mode</label>
+                        <select id="match_mode" name="match_mode" class="form-select">
+                            <option value="exact" {% if match_mode == 'exact' %}selected{% endif %}>Exact</option>
+                            <option value="startswith" {% if match_mode == 'startswith' %}selected{% endif %}>Starts with</option>
+                            <option value="contains" {% if match_mode == 'contains' %}selected{% endif %}>Contains</option>
+                            <option value="not_contains" {% if match_mode == 'not_contains' %}selected{% endif %}>Does not contain</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="assigned_status" class="form-label">Assigned Status</label>
+                        <select id="assigned_status" name="assigned_status" class="form-select">
+                            <option value="all" {% if assigned_status == 'all' %}selected{% endif %}>All</option>
+                            <option value="assigned" {% if assigned_status == 'assigned' %}selected{% endif %}>Assigned to locations</option>
+                            <option value="unassigned" {% if assigned_status == 'unassigned' %}selected{% endif %}>Not assigned</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="product_status" class="form-label">Product Status</label>
+                        <select id="product_status" name="product_status" class="form-select">
+                            <option value="all" {% if product_status == 'all' %}selected{% endif %}>All</option>
+                            <option value="with" {% if product_status == 'with' %}selected{% endif %}>Has products</option>
+                            <option value="without" {% if product_status == 'without' %}selected{% endif %}>No products</option>
+                        </select>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <a href="{{ url_for('menu.view_menus') }}" class="btn btn-outline-secondary">Reset</a>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="submit" form="menu-filter-form" class="btn btn-primary">Apply</button>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add server-side filtering for menus by name, assignment status, and product presence
- refresh the menus table template with a reusable column visibility dropdown and matching filter modal styling

## Testing
- pytest tests/test_menu_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68e054a129048324bcaadb49c5079e65