### PR TITLE
Stop chunking bulk stand sheets

### DIFF
--- a/app/routes/event_routes.py
+++ b/app/routes/event_routes.py
@@ -1242,17 +1242,12 @@ def bulk_stand_sheets(event_id):
     data = []
     for el in ev.locations:
         loc, items = _get_stand_items(el.location_id, event_id)
-        chunks = _chunk_stand_sheet_items(items)
-        page_count = len(chunks)
-        for page_number, chunk in enumerate(chunks, start=1):
-            data.append(
-                {
-                    "location": loc,
-                    "stand_items": chunk,
-                    "page_number": page_number,
-                    "page_count": page_count,
-                }
-            )
+        data.append(
+            {
+                "location": loc,
+                "stand_items": items,
+            }
+        )
     dt = datetime.now()
     generated_at_local = (
         f"{dt.month}/{dt.day}/{dt.year} {dt.strftime('%I:%M %p').lstrip('0')}"

--- a/app/templates/events/bulk_stand_sheets.html
+++ b/app/templates/events/bulk_stand_sheets.html
@@ -121,9 +121,6 @@
   <div class="meta">
     <div>
       Location: {{ entry.location.name }}
-      {% if entry.page_count > 1 %}
-        <span class="text-muted">(Page {{ entry.page_number }} of {{ entry.page_count }})</span>
-      {% endif %}
     </div>
     <div>Event: {{ event.name }}</div>
     <div>Event Date/Time: {{ event.start_date|format_datetime('%-m/%-d/%Y %-I:%M %p') }}</div>


### PR DESCRIPTION
## Summary
- stop chunking event stand sheet data so each location renders as a single table with one signature block
- remove the template logic that displayed per-chunk page numbers to align with the new single-section output

## Testing
- pytest tests/test_event_flow.py::test_bulk_stand_sheet -q

------
https://chatgpt.com/codex/tasks/task_e_68e0554c138c8324a385ab319ee791d5