### PR TITLE
Add defaults for receiving invoices

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,4 +1,5 @@
 import os
+from datetime import date
 from functools import lru_cache
 from zoneinfo import available_timezones
 
@@ -847,9 +848,11 @@ class InvoiceItemReceiveForm(FlaskForm):
 
 class ReceiveInvoiceForm(FlaskForm):
     invoice_number = StringField("Invoice Number", validators=[Optional()])
-    received_date = DateField("Received Date", validators=[DataRequired()])
+    received_date = DateField(
+        "Received Date", validators=[DataRequired()], default=date.today
+    )
     location_id = SelectField(
-        "Location", coerce=int, validators=[DataRequired()]
+        "Location", coerce=int, validators=[DataRequired()] 
     )
     department = SelectField(
         "Department",
@@ -870,6 +873,9 @@ class ReceiveInvoiceForm(FlaskForm):
         "Delivery Charge", validators=[Optional()], default=0
     )
     items = FieldList(FormField(InvoiceItemReceiveForm), min_entries=1)
+    remember_department_location = BooleanField(
+        "Set current location as default for this department"
+    )
     submit = SubmitField("Submit")
 
     def __init__(self, *args, **kwargs):

--- a/app/routes/purchase_routes.py
+++ b/app/routes/purchase_routes.py
@@ -597,8 +597,15 @@ def receive_invoice(po_id):
         abort(404)
     form = ReceiveInvoiceForm()
     gl_code_choices = load_purchase_gl_code_choices()
+    department_defaults = current_user.get_receive_location_defaults()
     if request.method == "GET":
         form.delivery_charge.data = po.delivery_charge
+        if not form.received_date.data:
+            form.received_date.data = datetime.date.today()
+        selected_department = form.department.data or ""
+        default_location_id = department_defaults.get(selected_department)
+        if default_location_id:
+            form.location_id.data = default_location_id
         form.items.min_entries = max(1, len(po.items))
         while len(form.items) < len(po.items):
             form.items.append_entry()
@@ -627,6 +634,17 @@ def receive_invoice(po_id):
             form.items[i].gl_code.data = 0
             form.items[i].location_id.data = 0
     if form.validate_on_submit():
+        if (
+            form.remember_department_location.data
+            and form.department.data
+            and form.location_id.data
+        ):
+            current_user.set_receive_location_default(
+                form.department.data, form.location_id.data
+            )
+            db.session.add(current_user)
+            department_defaults = current_user.get_receive_location_defaults()
+        location_obj = db.session.get(Location, form.location_id.data)
         if not PurchaseOrderItemArchive.query.filter_by(
             purchase_order_id=po.id
         ).first():
@@ -646,7 +664,7 @@ def receive_invoice(po_id):
             user_id=current_user.id,
             location_id=form.location_id.data,
             vendor_name=po.vendor_name,
-            location_name=db.session.get(Location, form.location_id.data).name,
+            location_name=location_obj.name if location_obj else "",
             received_date=form.received_date.data,
             invoice_number=form.invoice_number.data,
             department=form.department.data or None,
@@ -795,6 +813,7 @@ def receive_invoice(po_id):
         form=form,
         po=po,
         gl_code_choices=gl_code_choices,
+        department_defaults=department_defaults,
     )
 
 

--- a/app/templates/admin/settings.html
+++ b/app/templates/admin/settings.html
@@ -32,6 +32,21 @@
             {{ form.max_backups(class='form-control') }}
         </div>
         <div class="mt-4">
+            <h3>Purchase Receiving Defaults</h3>
+            <p class="text-muted">Select default locations for each department.</p>
+            <div class="row g-3">
+                {% for label, field in form.iter_receive_location_defaults() %}
+                <div class="col-md-6">
+                    <label class="form-label">{{ label }}</label>
+                    {{ field(class='form-select') }}
+                    {% if field.errors %}
+                        <div class="text-danger small">{{ field.errors[0] }}</div>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+        </div>
+        <div class="mt-4">
             <h3>Reporting Units</h3>
             <p class="text-muted">Choose how base units should appear in reports.</p>
             <div class="table-responsive">

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -81,10 +81,6 @@
             {{ form.department.label(class="form-label") }}
             {{ form.department(class="form-select narrow-field") }}
         </div>
-        <div class="form-check mb-3">
-            {{ form.remember_department_location(class="form-check-input") }}
-            {{ form.remember_department_location.label(class="form-check-label") }}
-        </div>
         <div class="form-group">
             {{ form.pst.label(class="form-label") }}
             {{ form.pst(class="form-control narrow-field") }}

--- a/app/templates/purchase_orders/receive_invoice.html
+++ b/app/templates/purchase_orders/receive_invoice.html
@@ -81,6 +81,10 @@
             {{ form.department.label(class="form-label") }}
             {{ form.department(class="form-select narrow-field") }}
         </div>
+        <div class="form-check mb-3">
+            {{ form.remember_department_location(class="form-check-input") }}
+            {{ form.remember_department_location.label(class="form-check-label") }}
+        </div>
         <div class="form-group">
             {{ form.pst.label(class="form-label") }}
             {{ form.pst(class="form-control narrow-field") }}
@@ -130,10 +134,42 @@
     </form>
 </div>
 <script nonce="{{ csp_nonce }}">
+    const departmentDefaults = {{ department_defaults|tojson }};
     const itemOptions = `<option value="">Select Item</option>{% for val, label in form.items[0].item.choices %}<option value="{{ val }}">{{ label }}</option>{% endfor %}`;
     const glCodeOptions = `{% for val, label in gl_code_choices %}<option value="{{ val }}">{{ label|e }}</option>{% endfor %}`;
     const locationOptions = `{% for val, label in form.items[0].location_id.choices %}<option value="{{ val }}">{{ label|e }}</option>{% endfor %}`;
     let itemIndex = {{ form.items|length }};
+    const departmentField = document.getElementById('department');
+    const invoiceLocationField = document.getElementById('location_id');
+
+    function applyDepartmentDefault(department, { skipIfSet = false } = {}) {
+        if (!invoiceLocationField) {
+            return;
+        }
+        const defaultLocation = departmentDefaults && departmentDefaults[department];
+        if (!defaultLocation) {
+            return;
+        }
+        if (skipIfSet && invoiceLocationField.value) {
+            return;
+        }
+        const targetValue = String(defaultLocation);
+        const hasOption = Array.from(invoiceLocationField.options).some(
+            (option) => option.value === targetValue
+        );
+        if (!hasOption) {
+            return;
+        }
+        invoiceLocationField.value = targetValue;
+        invoiceLocationField.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+
+    if (departmentField) {
+        applyDepartmentDefault(departmentField.value, { skipIfSet: true });
+        departmentField.addEventListener('change', () => {
+            applyDepartmentDefault(departmentField.value);
+        });
+    }
 
     function createRow(index) {
         const row = document.createElement('div');

--- a/migrations/versions/202409150001_add_receive_location_defaults_to_user.py
+++ b/migrations/versions/202409150001_add_receive_location_defaults_to_user.py
@@ -1,0 +1,61 @@
+"""add receive location defaults to user"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+def _has_table(table_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    return inspector.has_table(table_name)
+
+
+def _has_column(table_name: str, column_name: str, bind) -> bool:
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(table_name):
+        return False
+    return column_name in {
+        column["name"] for column in inspector.get_columns(table_name)
+    }
+
+
+# revision identifiers, used by Alembic.
+revision = "202409150001"
+down_revision = "202409010001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    if not bind or not _has_table("user", bind):
+        return
+
+    if _has_column("user", "receive_location_defaults", bind):
+        return
+
+    with op.batch_alter_table("user", recreate="always") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "receive_location_defaults",
+                sa.Text(),
+                nullable=False,
+                server_default="",
+            )
+        )
+
+    with op.batch_alter_table("user", recreate="always") as batch_op:
+        batch_op.alter_column(
+            "receive_location_defaults", server_default=None
+        )
+
+
+def downgrade():
+    bind = op.get_bind()
+    if not bind or not _has_table("user", bind):
+        return
+
+    if not _has_column("user", "receive_location_defaults", bind):
+        return
+
+    with op.batch_alter_table("user", recreate="always") as batch_op:
+        batch_op.drop_column("receive_location_defaults")

--- a/migrations/versions/202409150001_add_receive_location_defaults_to_user.py
+++ b/migrations/versions/202409150001_add_receive_location_defaults_to_user.py
@@ -1,4 +1,4 @@
-"""add receive location defaults to user"""
+"""remove user-specific receive location defaults column"
 
 import sqlalchemy as sa
 from alembic import op
@@ -30,6 +30,18 @@ def upgrade():
     if not bind or not _has_table("user", bind):
         return
 
+    if not _has_column("user", "receive_location_defaults", bind):
+        return
+
+    with op.batch_alter_table("user", recreate="always") as batch_op:
+        batch_op.drop_column("receive_location_defaults")
+
+
+def downgrade():
+    bind = op.get_bind()
+    if not bind or not _has_table("user", bind):
+        return
+
     if _has_column("user", "receive_location_defaults", bind):
         return
 
@@ -47,15 +59,3 @@ def upgrade():
         batch_op.alter_column(
             "receive_location_defaults", server_default=None
         )
-
-
-def downgrade():
-    bind = op.get_bind()
-    if not bind or not _has_table("user", bind):
-        return
-
-    if not _has_column("user", "receive_location_defaults", bind):
-        return
-
-    with op.batch_alter_table("user", recreate="always") as batch_op:
-        batch_op.drop_column("receive_location_defaults")


### PR DESCRIPTION
## Summary
- default the purchase invoice receive date to today and allow users to opt into department-specific default locations
- persist per-user department receive locations and surface a control on the receive invoice form
- update the receive form to auto-fill the location when the department changes and add a migration for the new user setting

## Testing
- pytest tests/test_purchase_flow.py::test_receive_form_prefills_delivery_charge -q

------
https://chatgpt.com/codex/tasks/task_e_68e2adaf03c8832483a863ea63515f8d