### PR TITLE
Fix Flask factory defaults and migration docstring

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -110,9 +110,13 @@ def create_admin_user():
         print("Admin user created.")
 
 
-def create_app(args: list):
+def create_app(args=None):
     """Application factory used by Flask."""
     global socketio, GST, DEFAULT_TIMEZONE, BASE_UNIT_CONVERSIONS
+    if args is None:
+        args = sys.argv[1:]
+    else:
+        args = list(args)
     app = Flask(__name__)
     app.config["SECRET_KEY"] = os.getenv("SECRET_KEY")
     default_secure_cookies = "--demo" not in args

--- a/migrations/versions/202409150001_add_receive_location_defaults_to_user.py
+++ b/migrations/versions/202409150001_add_receive_location_defaults_to_user.py
@@ -1,4 +1,4 @@
-"""remove user-specific receive location defaults column"
+"""remove user-specific receive location defaults column"""
 
 import sqlalchemy as sa
 from alembic import op


### PR DESCRIPTION
## Summary
- allow the Flask application factory to be invoked without explicit CLI arguments so `flask db upgrade` works during image builds
- repair the latest migration file's docstring so Alembic can import it

## Testing
- `flask db upgrade`
- `pytest` *(fails: tests/test_event_flow.py::test_bulk_stand_sheets_render_multiple_pages)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cde1f5e483249806be0b9123a32d