### PR TITLE
Fix CSRF token for terminal sales mapping form

### DIFF
--- a/app/templates/events/upload_terminal_sales.html
+++ b/app/templates/events/upload_terminal_sales.html
@@ -42,6 +42,7 @@
     </div>
 
     <form method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
         <input type="hidden" name="step" value="map">
         <input type="hidden" name="payload" value="{{ mapping_payload }}">
         {% if open_locations %}


### PR DESCRIPTION
## Summary
- add a CSRF hidden field to the terminal sales mapping form so submissions succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2ee1425448324a73766ecc5618fb1