### PR TITLE
Fix terminal sales total updates

### DIFF
--- a/app/templates/events/add_terminal_sales.html
+++ b/app/templates/events/add_terminal_sales.html
@@ -1,19 +1,20 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Terminal Sales - {{ event_location.location.name }}</h2>
-<form method="post">
+<form method="post" id="terminal-sales-form">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <div class="table-responsive">
     <table class="table">
         <thead>
-            <tr><th>Product</th><th>Quantity</th></tr>
+            <tr><th>Product</th><th class="text-end">Price</th><th>Quantity</th></tr>
         </thead>
         <tbody>
         {% for product in event_location.location.products %}
-        <tr>
+        <tr data-price="{{ product.price | float }}">
             <td>{{ product.name }}</td>
+            <td class="text-end">${{ '{:,.2f}'.format(product.price) }}</td>
             <td>
-                <input type="number" step="any" name="qty_{{ product.id }}" class="form-control"
+                <input type="number" step="any" name="qty_{{ product.id }}" class="form-control terminal-sale-input"
                        value="{{ existing_sales.get(product.id, '') }}">
             </td>
         </tr>
@@ -21,6 +22,59 @@
         </tbody>
     </table>
     </div>
+    <div class="mt-3">
+        <strong>Grand Total:</strong>
+        <span id="terminal-sales-grand-total">$0.00</span>
+    </div>
     <button type="submit" class="btn btn-primary mt-2">Submit</button>
 </form>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const form = document.getElementById('terminal-sales-form');
+        const totalEl = document.getElementById('terminal-sales-grand-total');
+
+        if (!form || !totalEl) {
+            return;
+        }
+
+        const currencyFormatter = new Intl.NumberFormat(undefined, {
+            style: 'currency',
+            currency: 'USD',
+        });
+
+        const updateTotal = () => {
+            let total = 0;
+
+            document.querySelectorAll('tr[data-price]').forEach((row) => {
+                const price = Number(row.dataset.price);
+                if (!Number.isFinite(price)) {
+                    return;
+                }
+
+                const input = row.querySelector('.terminal-sale-input');
+                if (!input) {
+                    return;
+                }
+
+                const qty = Number(input.value || 0);
+                if (!Number.isNaN(qty)) {
+                    total += price * qty;
+                }
+            });
+
+            totalEl.textContent = currencyFormatter.format(total);
+        };
+
+        const handleInput = (event) => {
+            if (event.target.classList.contains('terminal-sale-input')) {
+                updateTotal();
+            }
+        };
+
+        form.addEventListener('input', handleInput);
+        form.addEventListener('change', handleInput);
+
+        updateTotal();
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure the terminal sales grand total updates automatically as quantities change
- tighten the template script to use delegated listeners and robust numeric parsing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2fb89d0a0832483153a7db3115b89