### PR TITLE
Add inline unit management to purchase orders

### DIFF
--- a/app/templates/purchase_orders/_manage_units_modal.html
+++ b/app/templates/purchase_orders/_manage_units_modal.html
@@ -1,0 +1,31 @@
+<div class="modal fade" id="manageUnitsModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Edit Units of Measure</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div id="manage-units-alert" class="alert alert-danger d-none" role="alert"></div>
+                <div class="mb-3">
+                    <label class="form-label">Item</label>
+                    <input type="text" id="manage-units-item-name" class="form-control" readonly>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Base Unit</label>
+                    <input type="text" id="manage-units-base-unit" class="form-control" readonly>
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Units of Measure</label>
+                    <div id="manage-units-rows" class="d-flex flex-column gap-2"></div>
+                    <button type="button" id="add-manage-unit" class="btn btn-outline-secondary btn-sm mt-2">Add Unit</button>
+                    <div class="form-text">Ratios are relative to the base unit. Choose the default units for receiving and transfers.</div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" id="save-manage-units" class="btn btn-primary">Save Units</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/templates/purchase_orders/create_purchase_order.html
+++ b/app/templates/purchase_orders/create_purchase_order.html
@@ -55,6 +55,7 @@
     </form>
 
     {% include 'purchase_orders/_create_item_modal.html' %}
+    {% include 'purchase_orders/_manage_units_modal.html' %}
 </div>
 
 <script src="{{ url_for('static', filename='js/purchase_order_form.js') }}"></script>

--- a/app/templates/purchase_orders/edit_purchase_order.html
+++ b/app/templates/purchase_orders/edit_purchase_order.html
@@ -55,6 +55,7 @@
     </form>
 
     {% include 'purchase_orders/_create_item_modal.html' %}
+    {% include 'purchase_orders/_manage_units_modal.html' %}
 </div>
 
 <script src="{{ url_for('static', filename='js/purchase_order_form.js') }}"></script>


### PR DESCRIPTION
## Summary
- add a modal to manage item units directly from the purchase order forms
- extend the purchase order form script to load, edit, and save units without leaving the page
- allow the item units endpoint to accept updates so unit changes persist

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e54c0a57b08324958085077f83fdb5