### PR TITLE
Prevent spaces in stand sheet numeric inputs

### DIFF
--- a/app/templates/events/stand_sheet.html
+++ b/app/templates/events/stand_sheet.html
@@ -99,7 +99,18 @@
                 }
                 columns[colIdx].push(inp);
                 inp.dataset.columnIndex = colIdx;
-                inp.addEventListener('input', function() { calcVariance(row); });
+                inp.addEventListener('keydown', function(e) {
+                    if (e.key === ' ') {
+                        e.preventDefault();
+                    }
+                });
+                inp.addEventListener('input', function() {
+                    const cleaned = inp.value.replace(/\s+/g, '');
+                    if (cleaned !== inp.value) {
+                        inp.value = cleaned;
+                    }
+                    calcVariance(row);
+                });
             });
             calcVariance(row);
         });


### PR DESCRIPTION
## Summary
- prevent spacebar input in stand sheet numeric fields
- strip whitespace from numeric field values before variance recalculation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5fba7934883249116d77a597b3e20