### PR TITLE
Enhance transfer workflow item selection interface

### DIFF
--- a/app/static/js/transfer_workflow.js
+++ b/app/static/js/transfer_workflow.js
@@ -1,0 +1,251 @@
+(function (window) {
+  'use strict';
+
+  function formatNumber(value) {
+    if (!Number.isFinite(value)) {
+      return '';
+    }
+    const fixed = parseFloat(value.toFixed(4));
+    return Number.isInteger(fixed) ? String(fixed) : String(fixed);
+  }
+
+  function formatRatio(unitName, factor, baseUnit) {
+    const formattedFactor = formatNumber(factor);
+    return `${unitName} - ${formattedFactor} ${baseUnit}`;
+  }
+
+  function ensureUnits(data) {
+    const baseUnit = data.base_unit;
+    const units = Array.isArray(data.units) ? data.units.slice() : [];
+    const hasDefault = units.some(function (unit) {
+      return unit.transfer_default;
+    });
+    units.unshift({
+      id: 0,
+      name: baseUnit,
+      factor: 1,
+      transfer_default: !hasDefault,
+    });
+    return units;
+  }
+
+  function createTransferRow(options) {
+    const {
+      prefix,
+      index,
+      itemId,
+      itemName,
+      unitsData,
+      existingBaseQuantity,
+    } = options;
+
+    const units = ensureUnits(unitsData);
+    const baseUnit = unitsData.base_unit;
+    const defaultUnit = units.find(function (unit) {
+      return unit.transfer_default;
+    }) || units[0];
+
+    const listItem = document.createElement('div');
+    listItem.className = 'transfer-item card mb-3';
+    listItem.dataset.itemId = itemId;
+
+    const cardBody = document.createElement('div');
+    cardBody.className = 'card-body';
+    listItem.appendChild(cardBody);
+
+    const header = document.createElement('div');
+    header.className = 'd-flex justify-content-between align-items-start flex-wrap gap-2';
+    cardBody.appendChild(header);
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'fw-bold flex-grow-1';
+    nameEl.textContent = itemName;
+    header.appendChild(nameEl);
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
+    deleteBtn.className = 'btn btn-outline-danger btn-sm transfer-delete-item';
+    deleteBtn.textContent = 'Remove';
+    deleteBtn.addEventListener('click', function () {
+      listItem.remove();
+    });
+    header.appendChild(deleteBtn);
+
+    const hiddenInput = document.createElement('input');
+    hiddenInput.type = 'hidden';
+    hiddenInput.name = `${prefix}-${index}-item`;
+    hiddenInput.value = itemId;
+    cardBody.appendChild(hiddenInput);
+
+    const row = document.createElement('div');
+    row.className = 'row g-3 align-items-end mt-1';
+    cardBody.appendChild(row);
+
+    const unitCol = document.createElement('div');
+    unitCol.className = 'col-md-4 col-sm-6';
+    row.appendChild(unitCol);
+
+    const unitLabel = document.createElement('label');
+    unitLabel.className = 'form-label mb-1';
+    unitLabel.htmlFor = `${prefix}-${index}-unit`;
+    unitLabel.textContent = 'Unit of Measure';
+    unitCol.appendChild(unitLabel);
+
+    const unitSelect = document.createElement('select');
+    unitSelect.className = 'form-select transfer-unit-select';
+    unitSelect.name = `${prefix}-${index}-unit`;
+    unitSelect.id = `${prefix}-${index}-unit`;
+    unitCol.appendChild(unitSelect);
+
+    units.forEach(function (unit) {
+      const option = document.createElement('option');
+      option.value = unit.id || 0;
+      option.dataset.factor = unit.factor;
+      option.dataset.unitName = unit.id === 0 ? baseUnit : unit.name;
+      option.selected = unit.id === defaultUnit.id;
+      option.textContent = unit.id === 0 ? baseUnit : unit.name;
+      unitSelect.appendChild(option);
+    });
+
+    const ratioDisplay = document.createElement('div');
+    ratioDisplay.className = 'form-text text-muted ratio-display mt-1';
+    unitCol.appendChild(ratioDisplay);
+
+    const unitQtyCol = document.createElement('div');
+    unitQtyCol.className = 'col-md-4 col-sm-6';
+    row.appendChild(unitQtyCol);
+
+    const unitQtyLabel = document.createElement('label');
+    unitQtyLabel.className = 'form-label mb-1 unit-quantity-label';
+    unitQtyLabel.htmlFor = `${prefix}-${index}-quantity`;
+    unitQtyCol.appendChild(unitQtyLabel);
+
+    const unitQtyInput = document.createElement('input');
+    unitQtyInput.type = 'number';
+    unitQtyInput.step = 'any';
+    unitQtyInput.min = '0';
+    unitQtyInput.className = 'form-control unit-quantity';
+    unitQtyInput.name = `${prefix}-${index}-quantity`;
+    unitQtyInput.id = `${prefix}-${index}-quantity`;
+    unitQtyInput.placeholder = 'Transfer Qty';
+    unitQtyInput.dataset.baseQty = '';
+    unitQtyCol.appendChild(unitQtyInput);
+
+    const baseQtyCol = document.createElement('div');
+    baseQtyCol.className = 'col-md-4 col-sm-6';
+    row.appendChild(baseQtyCol);
+
+    const baseQtyLabel = document.createElement('label');
+    baseQtyLabel.className = 'form-label mb-1';
+    baseQtyLabel.htmlFor = `${prefix}-${index}-base_quantity`;
+    baseQtyLabel.textContent = `${baseUnit} Quantity`;
+    baseQtyCol.appendChild(baseQtyLabel);
+
+    const baseInputGroup = document.createElement('div');
+    baseInputGroup.className = 'input-group';
+    baseQtyCol.appendChild(baseInputGroup);
+
+    const baseQtyInput = document.createElement('input');
+    baseQtyInput.type = 'number';
+    baseQtyInput.step = 'any';
+    baseQtyInput.min = '0';
+    baseQtyInput.className = 'form-control base-quantity';
+    baseQtyInput.name = `${prefix}-${index}-base_quantity`;
+    baseQtyInput.id = `${prefix}-${index}-base_quantity`;
+    baseQtyInput.placeholder = 'Base Qty';
+    baseInputGroup.appendChild(baseQtyInput);
+
+    const baseUnitTag = document.createElement('span');
+    baseUnitTag.className = 'input-group-text';
+    baseUnitTag.textContent = baseUnit;
+    baseInputGroup.appendChild(baseUnitTag);
+
+    function updateLabels() {
+      const selected = unitSelect.selectedOptions[0];
+      const unitName = selected.dataset.unitName || selected.textContent || baseUnit;
+      const factor = parseFloat(selected.dataset.factor) || 1;
+      ratioDisplay.textContent = formatRatio(unitName, factor, baseUnit);
+      unitQtyLabel.textContent = `${unitName} Quantity`;
+    }
+
+    function updateUnitFromBase(baseValue) {
+      const selected = unitSelect.selectedOptions[0];
+      const factor = parseFloat(selected.dataset.factor) || 1;
+      if (Number.isFinite(baseValue)) {
+        unitQtyInput.value = formatNumber(baseValue / factor);
+        unitQtyInput.dataset.baseQty = String(baseValue);
+      } else {
+        unitQtyInput.value = '';
+        unitQtyInput.dataset.baseQty = '';
+      }
+    }
+
+    function updateBaseFromUnit(unitValue) {
+      const selected = unitSelect.selectedOptions[0];
+      const factor = parseFloat(selected.dataset.factor) || 1;
+      if (Number.isFinite(unitValue)) {
+        const baseValue = unitValue * factor;
+        baseQtyInput.value = formatNumber(baseValue);
+        unitQtyInput.dataset.baseQty = String(baseValue);
+      } else {
+        baseQtyInput.value = '';
+        unitQtyInput.dataset.baseQty = '';
+      }
+    }
+
+    const initialBaseQuantity = Number.isFinite(existingBaseQuantity)
+      ? existingBaseQuantity
+      : Number.isFinite(parseFloat(existingBaseQuantity))
+      ? parseFloat(existingBaseQuantity)
+      : NaN;
+
+    if (Number.isFinite(initialBaseQuantity)) {
+      baseQtyInput.value = formatNumber(initialBaseQuantity);
+      updateUnitFromBase(initialBaseQuantity);
+    } else {
+      unitQtyInput.value = '';
+      baseQtyInput.value = '';
+      unitQtyInput.dataset.baseQty = '';
+    }
+
+    updateLabels();
+
+    unitSelect.addEventListener('change', function () {
+      const baseQty = parseFloat(unitQtyInput.dataset.baseQty);
+      if (Number.isFinite(baseQty)) {
+        updateUnitFromBase(baseQty);
+      } else {
+        unitQtyInput.value = '';
+      }
+      updateLabels();
+    });
+
+    unitQtyInput.addEventListener('input', function () {
+      const unitValue = parseFloat(unitQtyInput.value);
+      if (Number.isFinite(unitValue)) {
+        updateBaseFromUnit(unitValue);
+      } else {
+        unitQtyInput.dataset.baseQty = '';
+        baseQtyInput.value = '';
+      }
+    });
+
+    baseQtyInput.addEventListener('input', function () {
+      const baseValue = parseFloat(baseQtyInput.value);
+      if (Number.isFinite(baseValue)) {
+        updateUnitFromBase(baseValue);
+      } else {
+        unitQtyInput.value = '';
+        unitQtyInput.dataset.baseQty = '';
+      }
+    });
+
+    return listItem;
+  }
+
+  window.TransferWorkflow = {
+    createRow: createTransferRow,
+    formatNumber: formatNumber,
+    formatRatio: formatRatio,
+  };
+})(window);

--- a/app/templates/transfers/add_transfer.html
+++ b/app/templates/transfers/add_transfer.html
@@ -35,23 +35,25 @@
         {{ form.submit(class="btn btn-success") }}
     </form>
 </div>
+<script src="{{ url_for('static', filename='js/transfer_workflow.js') }}" nonce="{{ csp_nonce }}"></script>
 <script nonce="{{ csp_nonce }}">
+    let itemIndex = 0;
+
     document.getElementById('item-name').addEventListener('input', function() {
-        var input = this.value;
-        if (input === ''){
+        const input = this.value.trim();
+        if (input === '') {
             document.getElementById('suggestions').innerHTML = '';
             return;
         }
-        // Make AJAX request to fetch item suggestions based on input
-        fetch('/items/search?term=' + input)
+        fetch('/items/search?term=' + encodeURIComponent(input))
             .then(response => response.json())
             .then(data => {
-                var suggestionsDiv = document.getElementById('suggestions');
+                const suggestionsDiv = document.getElementById('suggestions');
                 suggestionsDiv.innerHTML = '';
                 data.forEach(function(item) {
-                    var suggestion = document.createElement('div');
-                    suggestion.textContent = item.name; // Display the item name
-                    suggestion.dataset.id = item.id; // Store the item ID in a data attribute
+                    const suggestion = document.createElement('div');
+                    suggestion.textContent = item.name;
+                    suggestion.dataset.id = item.id;
                     suggestion.classList.add('suggestion');
                     suggestionsDiv.appendChild(suggestion);
                 });
@@ -61,102 +63,34 @@
             });
     });
 
-    let itemIndex = 0;
-
     document.addEventListener('click', function(event) {
         if (event.target && event.target.classList.contains('suggestion')) {
-            var itemName = event.target.textContent; // Get the item name from textContent
-            var itemId = event.target.dataset.id; // Get the item ID from data attribute
-            addItemToList({id: itemId, name: itemName}); // Pass an object with both id and name
+            const itemName = event.target.textContent;
+            const itemId = event.target.dataset.id;
+            addItemToList({ id: itemId, name: itemName });
         }
     });
 
     function addItemToList(item) {
-        fetch(`/items/${item.id}/units`).then(r => r.json()).then(data => {
-            const base = data.base_unit;
-            const units = data.units || [];
-            const hasDefault = units.some(u => u.transfer_default);
-            units.unshift({id:0, name: base, factor:1, transfer_default: !hasDefault});
-            var options = '';
-            units.forEach(u => {
-                const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
-                options += `<option value="${u.id}" data-factor="${u.factor}" ${u.transfer_default ? 'selected' : ''}>${label}</option>`;
+        fetch(`/items/${item.id}/units`)
+            .then(r => r.json())
+            .then(data => {
+                const listItem = TransferWorkflow.createRow({
+                    prefix: 'items',
+                    index: itemIndex,
+                    itemId: item.id,
+                    itemName: item.name,
+                    unitsData: data,
+                    existingBaseQuantity: NaN,
+                });
+                document.getElementById('item-list').appendChild(listItem);
+                document.getElementById('suggestions').innerHTML = '';
+                document.getElementById('item-name').value = '';
+                itemIndex++;
+            })
+            .catch(error => {
+                console.error('Error loading item units:', error);
             });
-            var listItem = document.createElement('div');
-            listItem.classList.add('item-container', 'd-flex', 'justify-content-between', 'align-items-center', 'mb-2');
-
-            // Left column: item name
-            var nameDiv = document.createElement('div');
-            nameDiv.style.paddingLeft = '15px';
-            nameDiv.style.fontWeight = 'bold';
-            nameDiv.textContent = item.name;
-
-            // Right column: controls
-            var controlsDiv = document.createElement('div');
-            controlsDiv.className = 'd-flex align-items-center';
-
-            var inputHidden = document.createElement('input');
-            inputHidden.type = 'hidden';
-            inputHidden.name = `items-${itemIndex}-item`;
-            inputHidden.value = item.id;
-
-            var selectUnit = document.createElement('select');
-            selectUnit.name = `items-${itemIndex}-unit`;
-            selectUnit.className = 'form-control me-2';
-            selectUnit.style.maxWidth = '160px';
-            units.forEach(u => {
-                const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
-                var opt = document.createElement('option');
-                opt.value = u.id;
-                opt.setAttribute('data-factor', u.factor);
-                if (u.transfer_default) opt.selected = true;
-                opt.textContent = label;
-                selectUnit.appendChild(opt);
-            });
-
-            var inputQty = document.createElement('input');
-            inputQty.type = 'number';
-            inputQty.step = 'any';
-            inputQty.className = 'form-control quantity';
-            inputQty.name = `items-${itemIndex}-quantity`;
-            inputQty.placeholder = 'Qty';
-            inputQty.style.maxWidth = '120px';
-            inputQty.dataset.baseQty = "0";
-
-            var btnDelete = document.createElement('button');
-            btnDelete.type = 'button';
-            btnDelete.className = 'btn btn-danger delete-item ml-2';
-            btnDelete.textContent = 'Delete';
-
-            controlsDiv.appendChild(inputHidden);
-            controlsDiv.appendChild(selectUnit);
-            controlsDiv.appendChild(inputQty);
-            controlsDiv.appendChild(btnDelete);
-
-            listItem.appendChild(nameDiv);
-            listItem.appendChild(controlsDiv);
-
-            inputQty.addEventListener('input', function(){
-                const factor = parseFloat(selectUnit.selectedOptions[0].dataset.factor);
-                this.dataset.baseQty = (parseFloat(this.value) || 0) * factor;
-            });
-            selectUnit.addEventListener('change', function(){
-                const factor = parseFloat(this.selectedOptions[0].dataset.factor);
-                inputQty.value = (parseFloat(inputQty.dataset.baseQty) || 0) / factor;
-            });
-            document.getElementById('item-list').appendChild(listItem);
-            document.getElementById('suggestions').innerHTML = '';
-            document.getElementById('item-name').value = '';
-            itemIndex++;
-        });
     }
-
-
-
-        document.getElementById('item-list').addEventListener('click', function(event) {
-            if (event.target && event.target.classList.contains('delete-item')) {
-                event.target.closest('.item-container').remove();
-            }
-        });
 </script>
 {% endblock %}

--- a/app/templates/transfers/edit_transfer.html
+++ b/app/templates/transfers/edit_transfer.html
@@ -35,127 +35,68 @@
         {{ form.submit(class="btn btn-success") }}
     </form>
 </div>
+<script src="{{ url_for('static', filename='js/transfer_workflow.js') }}" nonce="{{ csp_nonce }}"></script>
 <script nonce="{{ csp_nonce }}">
     let itemIndex = 0;
-    window.addEventListener('DOMContentLoaded', (event) => {
-    const existingItems = {{ items | tojson | safe }};
-    existingItems.forEach((item, index) => {
-        addItemToList(item, index);
+
+    window.addEventListener('DOMContentLoaded', function() {
+        const existingItems = {{ items | tojson | safe }};
+        existingItems.forEach(function(item, index) {
+            addItemToList(item, index);
+        });
+        itemIndex = existingItems.length;
     });
-    itemIndex = existingItems.length;
-});
 
-
-document.getElementById('item-name').addEventListener('input', function() {
-    var input = this.value;
-    if (input === ''){
-        document.getElementById('suggestions').innerHTML = '';
-        return;
-    }
-    // Make AJAX request to fetch item suggestions based on input
-    fetch('/items/search?term=' + input)
-        .then(response => response.json())
-        .then(data => {
-            var suggestionsDiv = document.getElementById('suggestions');
-            suggestionsDiv.innerHTML = '';
-            data.forEach(function(item) {
-                var suggestion = document.createElement('div');
-                suggestion.textContent = item.name; // Display the item name
-                suggestion.dataset.id = item.id; // Store the item ID in a data attribute
-                suggestion.classList.add('suggestion');
-                suggestionsDiv.appendChild(suggestion);
+    document.getElementById('item-name').addEventListener('input', function() {
+        const input = this.value.trim();
+        if (input === '') {
+            document.getElementById('suggestions').innerHTML = '';
+            return;
+        }
+        fetch('/items/search?term=' + encodeURIComponent(input))
+            .then(response => response.json())
+            .then(data => {
+                const suggestionsDiv = document.getElementById('suggestions');
+                suggestionsDiv.innerHTML = '';
+                data.forEach(function(item) {
+                    const suggestion = document.createElement('div');
+                    suggestion.textContent = item.name;
+                    suggestion.dataset.id = item.id;
+                    suggestion.classList.add('suggestion');
+                    suggestionsDiv.appendChild(suggestion);
+                });
+            })
+            .catch(error => {
+                console.error('Error fetching item suggestions:', error);
             });
-        })
-        .catch(error => {
-            console.error('Error fetching item suggestions:', error);
-        });
-});
-
-document.addEventListener('click', function(event) {
-    if (event.target && event.target.classList.contains('suggestion')) {
-        var itemName = event.target.textContent; // Get the item name from textContent
-        var itemId = event.target.dataset.id; // Get the item ID from data attribute
-        addItemToList({id: itemId, name: itemName}, itemIndex);
-        itemIndex++;
-    }
-});
-
-function addItemToList(item, index) {
-    fetch(`/items/${item.id}/units`).then(r => r.json()).then(data => {
-        const base = data.base_unit;
-        const units = data.units || [];
-        const hasDefault = units.some(u => u.transfer_default);
-        units.unshift({id:0, name: base, factor:1, transfer_default: !hasDefault});
-        let defaultUnit = units.find(u => u.transfer_default) || units[0];
-        var options = '';
-        units.forEach(u => {
-            const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
-            const selected = u.id === defaultUnit.id ? 'selected' : '';
-            options += `<option value="${u.id}" data-factor="${u.factor}" ${selected}>${label}</option>`;
-        });
-        var listItem = document.createElement('div');
-        listItem.classList.add('item-container', 'd-flex', 'justify-content-between', 'align-items-center', 'mb-2');
-        const displayQty = item.quantity ? item.quantity / defaultUnit.factor : 0;
-        // Use DOM API to safely inject item.name.
-        // Create left (name) section
-        const nameDiv = document.createElement('div');
-        nameDiv.style.paddingLeft = '15px';
-        nameDiv.style.fontWeight = 'bold';
-        nameDiv.textContent = item.name;
-        // Create right (form section) div
-        const rightDiv = document.createElement('div');
-        rightDiv.className = 'd-flex align-items-center';
-        // Hidden input for item id
-        const hiddenInput = document.createElement('input');
-        hiddenInput.type = 'hidden';
-        hiddenInput.name = `items-${index}-item`;
-        hiddenInput.value = item.id;
-        // Select (units options)
-        const select = document.createElement('select');
-        select.name = `items-${index}-unit`;
-        select.className = 'form-control me-2';
-        select.style.maxWidth = '160px';
-        select.innerHTML = options;
-        // Quantity input
-        const qtyInputEl = document.createElement('input');
-        qtyInputEl.type = 'number';
-        qtyInputEl.step = 'any';
-        qtyInputEl.className = 'form-control quantity';
-        qtyInputEl.name = `items-${index}-quantity`;
-        qtyInputEl.value = displayQty;
-        qtyInputEl.placeholder = 'Qty';
-        qtyInputEl.style.maxWidth = '120px';
-        qtyInputEl.dataset.baseQty = item.quantity;
-        // Delete button
-        const delBtn = document.createElement('button');
-        delBtn.type = 'button';
-        delBtn.className = 'btn btn-danger delete-item mx-2';
-        delBtn.textContent = 'Delete';
-        // Append controls to rightDiv
-        rightDiv.appendChild(hiddenInput);
-        rightDiv.appendChild(select);
-        rightDiv.appendChild(qtyInputEl);
-        rightDiv.appendChild(delBtn);
-        // Now build final listItem
-        listItem.appendChild(nameDiv);
-        listItem.appendChild(rightDiv);
-        qtyInputEl.addEventListener('input', function(){
-            const factor = parseFloat(select.selectedOptions[0].dataset.factor);
-            this.dataset.baseQty = (parseFloat(this.value) || 0) * factor;
-        });
-        select.addEventListener('change', function(){
-            const factor = parseFloat(this.selectedOptions[0].dataset.factor);
-            const qty = qtyInputEl;
-            qty.value = (parseFloat(qty.dataset.baseQty) || 0) / factor;
-        });
-        document.getElementById('item-list').appendChild(listItem);
     });
-}
 
-    document.getElementById('item-list').addEventListener('click', function(event) {
-        if (event.target && event.target.classList.contains('delete-item')) {
-            event.target.closest('.item-container').remove();
+    document.addEventListener('click', function(event) {
+        if (event.target && event.target.classList.contains('suggestion')) {
+            const itemName = event.target.textContent;
+            const itemId = event.target.dataset.id;
+            addItemToList({ id: itemId, name: itemName }, itemIndex);
+            itemIndex++;
         }
     });
+
+    function addItemToList(item, index) {
+        fetch(`/items/${item.id}/units`)
+            .then(r => r.json())
+            .then(data => {
+                const listItem = TransferWorkflow.createRow({
+                    prefix: 'items',
+                    index: index,
+                    itemId: item.id,
+                    itemName: item.name,
+                    unitsData: data,
+                    existingBaseQuantity: item.quantity,
+                });
+                document.getElementById('item-list').appendChild(listItem);
+            })
+            .catch(error => {
+                console.error('Error loading item units:', error);
+            });
+    }
 </script>
 {% endblock %}

--- a/app/templates/transfers/view_transfers.html
+++ b/app/templates/transfers/view_transfers.html
@@ -184,6 +184,7 @@
   </div>
 </div>
 
+<script src="{{ url_for('static', filename='js/transfer_workflow.js') }}" nonce="{{ csp_nonce }}"></script>
 <script nonce="{{ csp_nonce }}">
     var protocol = window.location.protocol;
     var socket = io.connect(protocol + '//' + document.domain + ':' + location.port);
@@ -198,18 +199,18 @@
 
     let addItemIndex = 0;
     document.getElementById('add-item-name').addEventListener('input', function() {
-        var input = this.value;
-        if (input === ''){
+        const input = this.value.trim();
+        if (input === '') {
             document.getElementById('add-suggestions').innerHTML = '';
             return;
         }
-        fetch('/items/search?term=' + input)
+        fetch('/items/search?term=' + encodeURIComponent(input))
             .then(response => response.json())
             .then(data => {
-                var suggestionsDiv = document.getElementById('add-suggestions');
+                const suggestionsDiv = document.getElementById('add-suggestions');
                 suggestionsDiv.innerHTML = '';
                 data.forEach(function(item) {
-                    var suggestion = document.createElement('div');
+                    const suggestion = document.createElement('div');
                     suggestion.textContent = item.name;
                     suggestion.dataset.id = item.id;
                     suggestion.classList.add('suggestion');
@@ -220,66 +221,30 @@
 
     document.addEventListener('click', function(event) {
         if (event.target && event.target.classList.contains('suggestion') && event.target.parentElement.id === 'add-suggestions') {
-            var itemName = event.target.textContent;
-            var itemId = event.target.dataset.id;
+            const itemName = event.target.textContent;
+            const itemId = event.target.dataset.id;
             addItemToList(itemId, itemName);
         }
     });
 
-    // Escape HTML special characters to prevent XSS
-    function escapeHtml(str) {
-        return String(str)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    }
-
     function addItemToList(id, name) {
         fetch(`/items/${id}/units`).then(r => r.json()).then(data => {
-            const base = data.base_unit;
-            const units = data.units || [];
-            const hasDefault = units.some(u => u.transfer_default);
-            units.unshift({id:0, name: base, factor:1, transfer_default: !hasDefault});
-            var options = '';
-            units.forEach(u => {
-                const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
-                options += `<option value="${u.id}" data-factor="${u.factor}" ${u.transfer_default ? 'selected' : ''}>${label}</option>`;
-            });
-            var listItem = document.createElement('div');
-            listItem.classList.add('item-container','d-flex','justify-content-between','align-items-center','mb-2');
-            listItem.innerHTML = `
-                <div style="padding-left: 15px; font-weight: bold;">${escapeHtml(name)}</div>
-                <div class="d-flex align-items-center">
-                    <input type="hidden" name="add-items-${addItemIndex}-item" value="${id}">
-                    <select name="add-items-${addItemIndex}-unit" class="form-control me-2" style="max-width: 160px;">${options}</select>
-                    <input type="number" step="any" class="form-control quantity" name="add-items-${addItemIndex}-quantity" placeholder="Qty" style="max-width: 120px;" data-base-qty="0">
-                    <button type="button" class="btn btn-danger delete-item ms-2">Delete</button>
-                </div>`;
-            const qtyInput = listItem.querySelector('.quantity');
-            const unitSelect = listItem.querySelector('select');
-            qtyInput.addEventListener('input', function(){
-                const factor = parseFloat(unitSelect.selectedOptions[0].dataset.factor);
-                this.dataset.baseQty = (parseFloat(this.value) || 0) * factor;
-            });
-            unitSelect.addEventListener('change', function(){
-                const factor = parseFloat(this.selectedOptions[0].dataset.factor);
-                const qty = listItem.querySelector('.quantity');
-                qty.value = (parseFloat(qty.dataset.baseQty) || 0) / factor;
+            const listItem = TransferWorkflow.createRow({
+                prefix: 'add-items',
+                index: addItemIndex,
+                itemId: id,
+                itemName: name,
+                unitsData: data,
+                existingBaseQuantity: NaN,
             });
             document.getElementById('add-item-list').appendChild(listItem);
             document.getElementById('add-suggestions').innerHTML = '';
             document.getElementById('add-item-name').value = '';
             addItemIndex++;
+        }).catch(error => {
+            console.error('Error loading item units:', error);
         });
     }
-
-    document.getElementById('add-item-list').addEventListener('click', function(event) {
-        if (event.target && event.target.classList.contains('delete-item')) {
-            event.target.closest('.item-container').remove();
-        }
-    });
 
     document.getElementById('add-transfer-form').addEventListener('submit', function(e){
         e.preventDefault();
@@ -304,18 +269,18 @@
     // Edit form functionality
     let editItemIndex = 0;
     document.getElementById('edit-item-name').addEventListener('input', function() {
-        var input = this.value;
-        if (input === ''){
+        const input = this.value.trim();
+        if (input === '') {
             document.getElementById('edit-suggestions').innerHTML = '';
             return;
         }
-        fetch('/items/search?term=' + input)
+        fetch('/items/search?term=' + encodeURIComponent(input))
             .then(response => response.json())
             .then(data => {
-                var suggestionsDiv = document.getElementById('edit-suggestions');
+                const suggestionsDiv = document.getElementById('edit-suggestions');
                 suggestionsDiv.innerHTML = '';
                 data.forEach(function(item) {
-                    var suggestion = document.createElement('div');
+                    const suggestion = document.createElement('div');
                     suggestion.textContent = item.name;
                     suggestion.dataset.id = item.id;
                     suggestion.classList.add('suggestion');
@@ -326,66 +291,28 @@
 
     document.addEventListener('click', function(event) {
         if (event.target && event.target.classList.contains('suggestion') && event.target.parentElement.id === 'edit-suggestions') {
-            var itemName = event.target.textContent;
-            var itemId = event.target.dataset.id;
-            addEditItem({id: itemId, name: itemName, quantity: 0});
+            const itemName = event.target.textContent;
+            const itemId = event.target.dataset.id;
+            addEditItem({id: itemId, name: itemName, quantity: NaN});
             editItemIndex++;
         }
     });
 
-    function escapeHtml(str) {
-        return String(str)
-            .replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#39;");
-    }
-
     function addEditItem(item){
         fetch(`/items/${item.id}/units`).then(r => r.json()).then(data => {
-            const base = data.base_unit;
-            const units = data.units || [];
-            const hasDefault = units.some(u => u.transfer_default);
-            units.unshift({id:0, name: base, factor:1, transfer_default: !hasDefault});
-            let defaultUnit = units.find(u => u.transfer_default) || units[0];
-            var options = '';
-            units.forEach(u => {
-                const label = u.id === 0 ? base : `${u.name} of ${u.factor} ${base}${u.factor != 1 ? 's' : ''}`;
-                const selected = u.id === defaultUnit.id ? 'selected' : '';
-                options += `<option value="${u.id}" data-factor="${u.factor}" ${selected}>${label}</option>`;
-            });
-            var listItem = document.createElement('div');
-            listItem.classList.add('item-container','d-flex','justify-content-between','align-items-center','mb-2');
-            const displayQty = item.quantity ? item.quantity / defaultUnit.factor : 0;
-            listItem.innerHTML = `
-                <div style="padding-left: 15px; font-weight: bold;">${escapeHtml(item.name)}</div>
-                <div class="d-flex align-items-center">
-                    <input type="hidden" name="items-${editItemIndex}-item" value="${item.id}">
-                    <select name="items-${editItemIndex}-unit" class="form-control me-2" style="max-width: 160px;">${options}</select>
-                    <input type="number" step="any" class="form-control quantity" name="items-${editItemIndex}-quantity" value="${displayQty}" placeholder="Qty" style="max-width: 120px;" data-base-qty="${item.quantity}">
-                    <button type="button" class="btn btn-danger delete-item ms-2">Delete</button>
-                </div>`;
-            const qtyInput = listItem.querySelector('.quantity');
-            const unitSelect = listItem.querySelector('select');
-            qtyInput.addEventListener('input', function(){
-                const factor = parseFloat(unitSelect.selectedOptions[0].dataset.factor);
-                this.dataset.baseQty = (parseFloat(this.value) || 0) * factor;
-            });
-            unitSelect.addEventListener('change', function(){
-                const factor = parseFloat(this.selectedOptions[0].dataset.factor);
-                const qty = listItem.querySelector('.quantity');
-                qty.value = (parseFloat(qty.dataset.baseQty) || 0) / factor;
+            const listItem = TransferWorkflow.createRow({
+                prefix: 'items',
+                index: editItemIndex,
+                itemId: item.id,
+                itemName: item.name,
+                unitsData: data,
+                existingBaseQuantity: item.quantity,
             });
             document.getElementById('edit-item-list').appendChild(listItem);
+        }).catch(error => {
+            console.error('Error loading item units:', error);
         });
     }
-
-    document.getElementById('edit-item-list').addEventListener('click', function(event) {
-        if (event.target && event.target.classList.contains('delete-item')) {
-            event.target.closest('.item-container').remove();
-        }
-    });
 
     function loadEditTransfer(id){
         fetch(`/transfers/${id}/json`).then(r => r.json()).then(data => {


### PR DESCRIPTION
## Summary
- add a shared transfer_workflow.js helper that renders transfer items with unit defaults, ratio text, and base quantity support
- update add/edit transfer templates and the dashboard modal workflow to use the new UI and sanitised search handling

## Testing
- pytest tests/test_item_transfer_invoice.py

------
https://chatgpt.com/codex/tasks/task_e_68e5ff2246c083248e5d0ee329aba981