### PR TITLE
Add SQLite migration drift test for pre-existing approval_metadata

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: Run migration-focused tests
+        run: pytest tests/migrations -q
       - name: Run tests
         run: pytest --cov --cov-branch --cov-report=xml
       - name: Verify Alembic has a single head

--- a/tests/migrations/test_pos_sales_import_drift_migration.py
+++ b/tests/migrations/test_pos_sales_import_drift_migration.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+import pytest
+import sqlalchemy as sa
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERSIONS_DIR = REPO_ROOT / "migrations" / "versions"
+ENV_TEMPLATE = """
+from __future__ import annotations
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+config = context.config
+
+target_metadata = None
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section) or {},
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+""".strip()
+
+
+@pytest.fixture(autouse=True)
+def gl_codes():
+    """Override root autouse fixture so this module stays migration-only."""
+    pass
+
+
+def _make_alembic_script_dir(tmp_path: Path) -> Path:
+    script_dir = tmp_path / "alembic_runtime"
+    versions_link = script_dir / "versions"
+    script_dir.mkdir()
+    (script_dir / "env.py").write_text(ENV_TEMPLATE)
+    versions_link.symlink_to(VERSIONS_DIR, target_is_directory=True)
+    return script_dir
+
+
+def _alembic_config(db_path: Path, script_dir: Path) -> Config:
+    config = Config()
+    config.set_main_option("script_location", str(script_dir))
+    config.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return config
+
+
+def _create_fk_target_tables(db_path: Path) -> None:
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as connection:
+        connection.execute(sa.text("CREATE TABLE IF NOT EXISTS user (id INTEGER PRIMARY KEY)"))
+        connection.execute(sa.text("CREATE TABLE IF NOT EXISTS location (id INTEGER PRIMARY KEY)"))
+        connection.execute(sa.text("CREATE TABLE IF NOT EXISTS product (id INTEGER PRIMARY KEY)"))
+
+
+def test_upgrade_handles_preexisting_approval_metadata_column(tmp_path):
+    db_path = tmp_path / "drifted_schema.db"
+    script_dir = _make_alembic_script_dir(tmp_path)
+    config = _alembic_config(db_path, script_dir)
+
+    # Avoid replaying unrelated historical revisions; start right before 202603260001.
+    command.stamp(config, "202603210002")
+    _create_fk_target_tables(db_path)
+    command.upgrade(config, "202603260002")
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as connection:
+        connection.execute(sa.text("ALTER TABLE pos_sales_import_row ADD COLUMN approval_metadata TEXT"))
+
+    command.upgrade(config, "head")
+
+    expected_head = ScriptDirectory.from_config(config).get_current_head()
+    with engine.connect() as connection:
+        current_revision = connection.execute(sa.text("SELECT version_num FROM alembic_version")).scalar_one()
+        assert current_revision == expected_head
+
+        columns = connection.execute(sa.text("PRAGMA table_info('pos_sales_import_row')")).mappings().all()
+
+    approval_metadata_columns = [column for column in columns if column["name"] == "approval_metadata"]
+    assert len(approval_metadata_columns) == 1


### PR DESCRIPTION
### Motivation

- Ensure Alembic migrations remain idempotent when a schema has drifted and `pos_sales_import_row.approval_metadata` already exists prior to revision `202603260003`.
- Prevent regressions in SQLite test environments and CI by validating the upgrade path handles preexisting columns without error.

### Description

- Add a migration-focused pytest module at `tests/migrations/test_pos_sales_import_drift_migration.py` that creates an isolated Alembic runtime and SQLite DB, stamps to the pre-POS staging revision, upgrades to `202603260002`, injects the `approval_metadata` column, then upgrades to `head` and verifies results.
- The test overrides the repo-level autouse fixture to run as a pure migration scenario and creates minimal FK target tables (`user`, `location`, `product`) to satisfy migrations that expect them.
- Assertions verify the Alembic `alembic_version` equals the repository head and that `approval_metadata` appears exactly once in `pos_sales_import_row` schema.
- Update CI workflow `.github/workflows/tests.yml` to run `pytest tests/migrations -q` as a dedicated migration-focused step before the full test run.

### Testing

- Ran `pytest tests/migrations/test_pos_sales_import_drift_migration.py -q` and it passed.
- Ran `pytest tests/migrations -q` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c4b68940f083229ff1c11ea9854301)